### PR TITLE
Fixing package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "react-addons-perf": "^15.3.1-rc.2",
     "react-addons-test-utils": "^15.3.1-rc.2",
     "react-dom": "^15.3.1-rc.2",
+    "react-native": "^0.34.0",
+    "react-native-windows": "^0.33.0",
     "rebound": "^0.0.13",
     "synctasks": "^0.2.9"
   },
   "devDependencies": {
-    "react-native": "^0.34.0",
-    "react-native-windows": "^0.33.0",
     "typescript": "2.0.8"
   },
   "homepage": "https://microsoft.github.io/reactxp/",

--- a/samples/hello-world/package.json
+++ b/samples/hello-world/package.json
@@ -17,15 +17,6 @@
     "webpack": "2.2.1"
   },
   "dependencies": {
-    "assert": "^1.3.0",
-    "ifvisible.js": "^1.0.6",
-    "lodash": "^4.17.1",
-    "react": "^15.3.1-rc.2",
-    "react-addons-perf": "^15.3.1-rc.2",
-    "react-addons-test-utils": "^15.3.1-rc.2",
-    "react-dom": "^15.3.1-rc.2",
-    "reactxp": "^0.34.0",
-    "rebound": "^0.0.13",
-    "synctasks": "^0.2.9"
+    "reactxp": "^0.34.0"
   }
 }


### PR DESCRIPTION
react-native and react-native-windows were specified as devDependencies, but they are actually required at runtime not just to build reactxp. This was causing an issue also in the sample app, since `npm run start` wouldn't work because react-native wouldn't exist in node_modules. An alternative is to specify react-native and react-native-windows as peerDependencies, if we want users to be able to choose a range, and include them as dependencies in the sample app. But if we want to lock down what versions they use, having a direct dependency is probably fine.

Also the sample app had a bunch of packages in its dependencies section which didn't need to, since they're already direct dependencies of reactxp and so they're already pulled on `npm install`