### PR TITLE
Adding a timing for the scale animation in HelloWorld sample

### DIFF
--- a/samples/hello-world/src/App.tsx
+++ b/samples/hello-world/src/App.tsx
@@ -44,7 +44,7 @@ class App extends RX.Component<null, null> {
         this._animatedStyle = RX.Styles.createAnimatedTextStyle({
             transform: [
                 {
-                    translateY: this._translationValue,
+                    translateY: this._translationValue
                 },
                 {
                     scale: this._scaleValue

--- a/samples/hello-world/src/App.tsx
+++ b/samples/hello-world/src/App.tsx
@@ -45,6 +45,8 @@ class App extends RX.Component<null, null> {
             transform: [
                 {
                     translateY: this._translationValue,
+                },
+                {
                     scale: this._scaleValue
                 }
             ]
@@ -52,12 +54,18 @@ class App extends RX.Component<null, null> {
     }
 
     componentDidMount() {
-        let animation = RX.Animated.timing(this._translationValue, {
-              toValue: 0,
-              easing: RX.Animated.Easing.OutBack(),
-              duration: 500
-            }
-        );
+        let animation = RX.Animated.parallel([
+            RX.Animated.timing(this._translationValue, {
+                toValue: 0,
+                easing: RX.Animated.Easing.OutBack(),
+                duration: 500
+            }),
+            RX.Animated.timing(this._scaleValue, {
+                toValue: 1,
+                easing: RX.Animated.Easing.InOut(),
+                duration: 500
+            })
+        ]);
 
         animation.start();
     }


### PR DESCRIPTION
The animated value `_scaleValue` indicates that the size of the "Hello World" text should be animated, but there's no timing for it. Right now, the text just moves vertically, it doesn't scale as well.

This PR:
- Adds a timing for the `_scaleValue` animated value for Hello World text
- Combines the scale and transform timings in a composite parallel animation

Screen capture of the animation after this change: [https://1drv.ms/v/s!Al9jOUS7_zLMiLZRxgwVGtqEFZkDgA](https://1drv.ms/v/s!Al9jOUS7_zLMiLZRxgwVGtqEFZkDgA)