### PR TITLE
Adding Display Name for the animated components.

### DIFF
--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -723,6 +723,9 @@ function createAnimatedComponent<PropsType extends Types.CommonProps>(Component:
                 </Component>
             );
         }
+
+        // Update the component's display name for easy debugging in react devtools extension
+        static displayName = `Animated.${Component.displayName || Component.name || "Component"}`;
     }
 
     return AnimatedComponentGenerated;


### PR DESCRIPTION
Currently ReactXP Animated components show up as "AnimatedComponentGenerated" in the React DevTools in chrome.

In this code change I added a dynamic display name to improve the debugging experience (eg. "Animated.Text").

![reactxp-devtools-displayname](https://cloud.githubusercontent.com/assets/176327/24890017/4f8eae2c-1e22-11e7-9e69-506b00b9bc71.png)

More Info:
[https://facebook.github.io/react/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging](https://facebook.github.io/react/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)
