### PR TITLE
Fix docs/react_concepts layout bug

### DIFF
--- a/docs/docs/react_concepts.md
+++ b/docs/docs/react_concepts.md
@@ -30,6 +30,7 @@ Note that this component is emitting a "div" tag, which is valid only in browser
             return <RX.Text>Hello World</RX.Text>;
         }
     }
+
 Also note that `RX.Component` replaces `React.Component` in the above example. [ReactXP *re-exports* `React.Component`](https://github.com/Microsoft/reactxp/blob/master/src/web/ReactXP.ts#L131) as `RX.Component` so your imports remain tidy, you don't need to import `React` specifically.
 
 ## Props


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1331413/24941132/a7f9432a-1f7a-11e7-8a8d-6a1de5ffc006.png)

The missing line break leads into incorrect rendering of the manual page.