### PR TITLE
Make popups accessible.

### DIFF
--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -134,6 +134,7 @@ export class FrontLayerViewManager {
                 <ModalContainer>
                     <RN.TouchableWithoutFeedback
                         onPressOut={ this._onBackgroundPressed }
+                        importantForAccessibility={ 'no' }
                     >
                         <RN.View style={ _styles.fullScreenView }>
                             <PopupContainerView

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -160,7 +160,7 @@ declare module 'react-native' {
         accessibilityComponentType?    : string; //enum ( 'none', 'button', 'radiobutton_checked', 'radiobutton_unchecked' )
         accessibilityTraits?: string | string[]; //enum( 'none', 'button', 'link', 'header', 'search', 'image', 'selected', 'plays', 'key', 'text', 'summary', 'disabled', 'frequentUpdates', 'startsMedia', 'adjustable', 'allowsDirectInteraction', 'pageTurn' )
         accessible?: boolean;
-        importantForAccessibility?     : string; //enum( 'auto', 'yes', 'no', 'no-hide-descendants' )
+        importantForAccessibility? : string; //enum( 'auto', 'yes', 'no', 'no-hide-descendants' )
         delayLongPress?: number;
         delayPressIn?: number;
         delayPressOut?: number;

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -160,6 +160,7 @@ declare module 'react-native' {
         accessibilityComponentType?    : string; //enum ( 'none', 'button', 'radiobutton_checked', 'radiobutton_unchecked' )
         accessibilityTraits?: string | string[]; //enum( 'none', 'button', 'link', 'header', 'search', 'image', 'selected', 'plays', 'key', 'text', 'summary', 'disabled', 'frequentUpdates', 'startsMedia', 'adjustable', 'allowsDirectInteraction', 'pageTurn' )
         accessible?: boolean;
+        importantForAccessibility?     : string; //enum( 'auto', 'yes', 'no', 'no-hide-descendants' )
         delayLongPress?: number;
         delayPressIn?: number;
         delayPressOut?: number;


### PR DESCRIPTION
This change exposes importantForAccessibility on touchableWithoutFeedbackProps to make popups accessible for native platforms. 