### PR TITLE
Displaying non-selectable texts as pseudo elements

### DIFF
--- a/docs/docs/using-reactxp.md
+++ b/docs/docs/using-reactxp.md
@@ -11,16 +11,6 @@ next: faq
 
 ReactXP assumes that your main web page will have a DOM element container called "app-container". The root view of the app will be rendered within this container. Typically, this DOM element will be a &lt;div&gt; that covers the entire page.
 
-React Native's layout engine assumes "border-box" box sizing rules, whereas browsers default to "content-box". To match layout behavior, override the default box-sizing value using CSS.
-
-```
-  <style>
-    *, *:before, *:after {
-      box-sizing: border-box;
-    }
-  </style>
-```
-
 ## Tips for Native
 
 The main module is assumed to be called "RXApp", and it must be registered as such by the native code. Refer to the sample app for how to register the module in Android and iOS.

--- a/samples/hello-world/index.html
+++ b/samples/hello-world/index.html
@@ -11,9 +11,6 @@
       margin: 0;
       font-family: proxima-nova, "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif
     }
-    *, *:before, *:after {
-        box-sizing: border-box;
-    }
     *:focus {
         outline: 0;
     }

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -89,6 +89,15 @@ const _styles = {
 
 const ESC_KEY_CODE = 27;
 
+// Setting the expected default box-sizing for everything.
+if (typeof document !== 'undefined') {
+    const defaultBoxSizing = '*, *:before, *:after { box-sizing: border-box; }';
+    const style = document.createElement('style');
+    style.type = 'text/css';
+    style.appendChild(document.createTextNode(defaultBoxSizing));
+    document.head.appendChild(style);
+}
+
 export class RootView extends React.Component<RootViewProps, RootViewState> {
     private _hidePopupTimer: number = null;
     private _respositionPopupTimer: number = null;

--- a/src/web/Text.tsx
+++ b/src/web/Text.tsx
@@ -15,6 +15,10 @@ import RX = require('../common/Interfaces');
 import Styles from './Styles';
 import Types = require('../common/Types');
 
+// Adding a CSS rule to display non-selectable texts. Those texts
+// will be displayed as pseudo elements to prevent them from being copied
+// to clipboard. It's not possible to style pseudo elements with inline
+// styles, so, we're dynamically creating a <style> tag with the rule.
 if (typeof document !== 'undefined') {
     const textAsPseudoElement = '[data-text-as-pseudo-element]::before { content: attr(data-text-as-pseudo-element); }';
     const style = document.createElement('style');


### PR DESCRIPTION
Displaying non-selectable texts as pseudo elements to avoid copying them to clipboard on web.