### PR TITLE
[BUGFIX] Typo in ReactXP.ts for Windows

### DIFF
--- a/src/windows/ReactXP.ts
+++ b/src/windows/ReactXP.ts
@@ -57,7 +57,7 @@ ViewBase.setDefaultViewStyle(_defaultViewStyle);
 // Initialize Windows implementation of platform accessibility helpers inside the singleton
 // instance of native-common AccessibilityUtil. This is to let native-common components access
 // platform specific APIs through native-common implementation itself. 
-import AccessibilityUtil from '../native-common/Accessibilityutil';
+import AccessibilityUtil from '../native-common/AccessibilityUtil';
 import AccessibilityPlatformUtil from './AccessibilityUtil';
 
 AccessibilityUtil.setAccessibilityPlatformUtil(AccessibilityPlatformUtil);


### PR DESCRIPTION
**Do**

When trying to build my application for Windows with ReactXP I face the following issue:

![err-reactxp](https://cloud.githubusercontent.com/assets/367236/25563097/a6e309c6-2d94-11e7-8a9d-9f85fa5127e5.png)


I found out that it happens because of the path. 

So here is a PR for helping. Now having my App up and running on the web, Android and Windows :D