### PR TITLE
Expose className property for text input (for web purpose)

### DIFF
--- a/docs/docs/components/textinput.md
+++ b/docs/docs/components/textinput.md
@@ -28,6 +28,9 @@ autoFocus: boolean = false;
 // Should focus be lost after submitting?
 blurOnSubmit: boolean = false;
 
+// If defined, value is set as a class attribute of text input element
+className: string = undefined; // web-specific
+
 // Initial value that will change when the user starts typing
 defaultValue: string = undefined;
 

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -782,6 +782,9 @@ export interface TextInputPropsShared extends CommonProps, CommonAccessibilityPr
     // iOS and Android only property for controlling the text input selection color
     selectionColor?: string;
 
+    // web prop for adding class attribute to the input element
+    className?: string;
+
     onKeyPress?: (e: KeyboardEvent) => void;
     onFocus?: (e: FocusEvent) => void;
     onBlur?: (e: FocusEvent) => void;

--- a/src/web/TextInput.tsx
+++ b/src/web/TextInput.tsx
@@ -95,6 +95,7 @@ export class TextInput extends RX.TextInput<TextInputState> {
                     onPaste={ this._onPaste }
                     onScroll={ this._onScroll }
                     aria-label={ this.props.accessibilityLabel }
+                    className={ this.props.className }
                 />
             );
         } else {
@@ -119,6 +120,7 @@ export class TextInput extends RX.TextInput<TextInputState> {
                     onPaste={ this._onPaste }
                     aria-label={ this.props.accessibilityLabel }
                     type={ this.props.secureTextEntry ? 'password' : 'text' }
+                    className={ this.props.className }
                 />
             );
         }


### PR DESCRIPTION
Expose className property for text input to improve element locating on the web that is needed in some cases 
(e. g. to style pseudo-elements like a placeholder, because placeholderTextColor property does not work on the web)