### PR TITLE
Fixed ignore/blockPointerEvents in View implementation for RN

### DIFF
--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -62,10 +62,10 @@ export class View extends ViewBase<Types.ViewProps, {}> {
             this._internalProps.onLayout = this._onLayout;
         }
 
-        if (this.props.blockPointerEvents) {
+        if (props.blockPointerEvents) {
             this._internalProps.pointerEvents = 'none';
         } else {
-            if (this.props.ignorePointerEvents) {
+            if (props.ignorePointerEvents) {
                 this._internalProps.pointerEvents = 'box-none';
             }
         }


### PR DESCRIPTION
View._buildInternalProps() used this.props instead of passed props
to build internal state. Result was that we were using stale values
set in constructor.