### PR TITLE
Correct _renderScene implementation in ExperementalNavigatorDelegate

### DIFF
--- a/src/native-common/NavigatorExperimentalDelegate.tsx
+++ b/src/native-common/NavigatorExperimentalDelegate.tsx
@@ -207,7 +207,7 @@ export class NavigatorExperimentalDelegate extends NavigatorDelegate {
     // Callback from Navigator.js to RX.Navigator
     private _renderScene = (props: NavigationSceneRendererProps, navigator?: RN.Navigator): JSX.Element => {
         let parentState: NavigationState = props.navigationState;
-        let sceneState: NavigationRouteState = parentState.routes[parentState.index] as NavigationRouteState;
+        let sceneState: NavigationRouteState = parentState.routes[props.scene.index] as NavigationRouteState;
         // route exists?
         if (sceneState.route) {
             // call the renderScene callback sent from SkypeXNavigator


### PR DESCRIPTION
We render the scene passed by the NavigationTransitioner instead of the latest stored scene.

This is a correct implementation of this function. The previous version has issues in case the inital state has more than one route.