### PR TITLE
Add “display” to forbiddenProps

### DIFF
--- a/src/native-common/Styles.ts
+++ b/src/native-common/Styles.ts
@@ -17,7 +17,8 @@ import Types = require('../common/Types');
 const forbiddenProps: string[] = [
     'wordBreak',
     'appRegion',
-    'cursor'
+    'cursor',
+    'display'
 ];
 
 // React Native styles that ReactXP doesn't expose.


### PR DESCRIPTION
In order to center align everything inside a `<ScrollView />` (which has a default of `display: block;`) I need it to be `display: flex;`, this makes sure that we never expose `display` to RN clients (which makes it crash).