### PR TITLE
Pass “secureTextEntry” down to RN

### DIFF
--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -77,6 +77,7 @@ export class TextInput extends RX.TextInput<TextInputState> {
                 onBlur={ this._onBlur }
                 onScroll={ this._onScroll }
                 selection={{ start: this._selectionStart, end: this._selectionEnd}}
+                secureTextEntry={this.props.secureTextEntry}
 
                 textAlign={ this.props.textAlign }
                 keyboardAppearance={ this.props.keyboardAppearance }


### PR DESCRIPTION
`secureTextEntry` didn't work and then I looked at the code and it seem's like it's never passed down to RN, this fixes that.