### PR TITLE
[Accessibility] Expose the implementation for setting accessibility focus programmatically on iOS. Also, expose .focus() API for RX.Button.

### DIFF
--- a/src/ios/Accessibility.ts
+++ b/src/ios/Accessibility.ts
@@ -63,7 +63,9 @@ export class Accessibility extends NativeAccessibility {
 
         // Some versions of RN don't support this interface.
         if (RN.AccessibilityInfo) {
-            RN.AccessibilityInfo.announceForAccessibility(announcement);
+            if (RN.AccessibilityInfo.announceForAccessibility) {
+                RN.AccessibilityInfo.announceForAccessibility(announcement);
+            }
         }
     }
 

--- a/src/ios/Accessibility.ts
+++ b/src/ios/Accessibility.ts
@@ -62,10 +62,8 @@ export class Accessibility extends NativeAccessibility {
         }
 
         // Some versions of RN don't support this interface.
-        if (RN.AccessibilityInfo) {
-            if (RN.AccessibilityInfo.announceForAccessibility) {
-                RN.AccessibilityInfo.announceForAccessibility(announcement);
-            }
+        if (RN.AccessibilityInfo && RN.AccessibilityInfo.announceForAccessibility) {
+            RN.AccessibilityInfo.announceForAccessibility(announcement);
         }
     }
 

--- a/src/ios/AccessibilityUtil.ts
+++ b/src/ios/AccessibilityUtil.ts
@@ -15,10 +15,8 @@ import { AccessibilityPlatformUtil } from '../common/AccessibilityUtil';
 
 export class AccessibilityUtil extends AccessibilityPlatformUtil {
     setAccessibilityFocus(component: React.Component<any, any>): void {
-        if (RN.AccessibilityInfo && Accessibility.isScreenReaderEnabled()) {
-            if (RN.AccessibilityInfo.setAccessibilityFocus) {
-                RN.AccessibilityInfo.setAccessibilityFocus(RN.findNodeHandle(component));
-            }
+        if (Accessibility.isScreenReaderEnabled() && RN.AccessibilityInfo && RN.AccessibilityInfo.setAccessibilityFocus) {
+            RN.AccessibilityInfo.setAccessibilityFocus(RN.findNodeHandle(component));
         }
     }
 }

--- a/src/ios/AccessibilityUtil.ts
+++ b/src/ios/AccessibilityUtil.ts
@@ -16,7 +16,9 @@ import { AccessibilityPlatformUtil } from '../common/AccessibilityUtil';
 export class AccessibilityUtil extends AccessibilityPlatformUtil {
     setAccessibilityFocus(component: React.Component<any, any>): void {
         if (RN.AccessibilityInfo && Accessibility.isScreenReaderEnabled()) {
-            RN.AccessibilityInfo.setAccessibilityFocus(RN.findNodeHandle(component));
+            if (RN.AccessibilityInfo.setAccessibilityFocus) {
+                RN.AccessibilityInfo.setAccessibilityFocus(RN.findNodeHandle(component));
+            }
         }
     }
 }

--- a/src/ios/AccessibilityUtil.ts
+++ b/src/ios/AccessibilityUtil.ts
@@ -15,7 +15,9 @@ import { AccessibilityPlatformUtil } from '../common/AccessibilityUtil';
 
 export class AccessibilityUtil extends AccessibilityPlatformUtil {
     setAccessibilityFocus(component: React.Component<any, any>): void {
-        // NO-OP
+        if (RN.AccessibilityInfo && Accessibility.isScreenReaderEnabled()) {
+            RN.AccessibilityInfo.setAccessibilityFocus(RN.findNodeHandle(component));
+        }
     }
 }
 

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -196,7 +196,7 @@ export class Button extends RX.Button<{}> {
     }
 
     focus() {
-        // native mobile platforms doesn't have the notion of focus for buttons, so ignore.
+        AccessibilityUtil.setAccessibilityFocus(this);
     }
 
     blur() {

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -703,6 +703,7 @@ declare module 'react-native' {
         static addEventListener(type: string, handler: (event: any) => void): void;
         static removeEventListener(type: string, handler: (event: any) => void): void;
         static announceForAccessibility(announcement: string): void;
+        static setAccessibilityFocus(reactTag: number): void;
     }
 
     interface AlertButtonSpec {


### PR DESCRIPTION
This change enables the react-native work to programmatically set accessibility focus for iOS. Since that change will take some time to be contributed back to open source React-Native, this API will not work as expected. 

This change also exposes the .focus() behavior for RX.Button. 