### PR TITLE
Fix and update web Navigator component

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -967,7 +967,7 @@ export type CustomNavigatorSceneConfig = {
 };
 
 export interface NavigatorProps extends CommonProps {
-    renderScene?: (route: NavigatorRoute) => JSX.Element;
+    renderScene?: (route: NavigatorRoute, navigator: RX.Navigator<any>) => JSX.Element;
     navigateBackCompleted?: () => void;
     // NOTE: Arguments are only passed to transitionStarted by the experimental navigator
     transitionStarted?: (progress?: RX.AnimatedValue,

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -976,6 +976,8 @@ export interface NavigatorProps extends CommonProps {
     transitionCompleted?: () => void;
     cardStyle?: ViewStyleRuleSet;
     children?: ReactNode;
+    initialRouteStack?: Array<NavigatorRoute>;
+    initialRoute?: NavigatorRoute;
 }
 
 //

--- a/src/native-common/NavigatorExperimentalDelegate.tsx
+++ b/src/native-common/NavigatorExperimentalDelegate.tsx
@@ -212,7 +212,7 @@ export class NavigatorExperimentalDelegate extends NavigatorDelegate {
         // Does the route exist?
         if (sceneState && sceneState.route) {
             // Call the renderScene callback.
-            return this._owner.props.renderScene(sceneState.route);
+            return this._owner.props.renderScene(sceneState.route, this._owner);
         }
 
         // No route? Return empty scene.

--- a/src/native-common/NavigatorStandardDelegate.tsx
+++ b/src/native-common/NavigatorStandardDelegate.tsx
@@ -49,7 +49,7 @@ export class NavigatorStandardDelegate extends NavigatorDelegate {
         // route exists?
         if (route) {
             // call the renderScene callback sent from SkypeXNavigator
-            return this._owner.props.renderScene(route);
+            return this._owner.props.renderScene(route, this._owner);
         }
         // no route? return empty scene
         return <RN.View />;

--- a/src/web/Navigator.tsx
+++ b/src/web/Navigator.tsx
@@ -139,7 +139,7 @@ export class Navigator extends RX.Navigator<NavigatorState> {
 
         // handle optional initialRouteStack or initialRoute props
         let { initialRouteStack, initialRoute } = initialProps;
-        if(!Array.isArray(initialRouteStack)) {
+        if (!Array.isArray(initialRouteStack)) {
             initialRouteStack = [];
         }
 

--- a/src/web/Navigator.tsx
+++ b/src/web/Navigator.tsx
@@ -137,10 +137,21 @@ export class Navigator extends RX.Navigator<NavigatorState> {
     constructor(initialProps?: Types.NavigatorProps) {
         super(initialProps);
 
+        // handle optional initialRouteStack or initialRoute props
+        let { initialRouteStack, initialRoute } = initialProps;
+        if(!Array.isArray(initialRouteStack)) {
+            initialRouteStack = [];
+        }
+
+        if(initialRouteStack.length === 0 && initialRoute) {
+            initialRouteStack.push(initialRoute);
+        }
+        
+
         // Default navigator state
         this.state = {
             sceneConfigStack: [],
-            routeStack: [],
+            routeStack: initialRouteStack,
             transitionQueue: []
         };
     }

--- a/src/web/Navigator.tsx
+++ b/src/web/Navigator.tsx
@@ -146,10 +146,6 @@ export class Navigator extends RX.Navigator<NavigatorState> {
         if(initialRouteStack.length === 0 && initialRoute) {
             initialRouteStack.push(initialRoute);
         }
-
-        // need to initialize these or it will error 
-        (this.state as any).presentedIndex = 0;
-        (this.state as any).transitionFromIndex = null;
         
 
         // Default navigator state

--- a/src/web/Navigator.tsx
+++ b/src/web/Navigator.tsx
@@ -364,7 +364,7 @@ export class Navigator extends RX.Navigator<NavigatorState> {
                 ref={ 'scene_' + index }
                 style={ styles }
             >
-                { this.props.renderScene(route) }
+                { this.props.renderScene(route, this) }
             </View>
         );
     }

--- a/src/web/Navigator.tsx
+++ b/src/web/Navigator.tsx
@@ -146,12 +146,18 @@ export class Navigator extends RX.Navigator<NavigatorState> {
         if(initialRouteStack.length === 0 && initialRoute) {
             initialRouteStack.push(initialRoute);
         }
+
+        // need to initialize these or it will error 
+        (this.state as any).presentedIndex = 0;
+        (this.state as any).transitionFromIndex = null;
         
 
         // Default navigator state
         this.state = {
             sceneConfigStack: [],
+            presentedIndex: 0,
             routeStack: initialRouteStack,
+            transitionFromIndex: null,
             transitionQueue: []
         };
     }


### PR DESCRIPTION
The web Navigator component will error when used because presentedIndex and transitionFromIndex are not correctly initialized.

This pull request also updates the web Navigator component to honor the initialRouteStack or initialRoute props if they are provided and to pass the navigator instance as a second parameter when calling the renderScene(...) handler.