### PR TITLE
adds alignContent prop to FlexboxStyle

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -30,7 +30,8 @@ export type ReactInterface = {
 export interface FlexboxStyle {
     alignItems?: 'flex-start' | 'flex-end' | 'center' | 'stretch';
     alignSelf?: 'auto' | 'flex-start' | 'flex-end' | 'center' | 'stretch';
-
+    alignContent?: 'auto' | 'flex-start' | 'flex-end' | 'center' | 'stretch';
+    
     borderWidth?: number;
     borderTopWidth?: number;
     borderRightWidth?: number;


### PR DESCRIPTION
I tested that this works on the web ReactXP. the docs from react native indicate it is also supported.
https://facebook.github.io/react-native/docs/layout-props.html#aligncontent

It also seems that we are missing 'space-between', 'space-around' on all props but I don't know if that a ReactEx specific limitation.