### PR TITLE
Virtuallistview extension missing index files added

### DIFF
--- a/extensions/virtuallistview/index.android.js
+++ b/extensions/virtuallistview/index.android.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./dist/VirtualListView.js');

--- a/extensions/virtuallistview/index.ios.js
+++ b/extensions/virtuallistview/index.ios.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./dist/VirtualListView.js');

--- a/extensions/virtuallistview/index.js
+++ b/extensions/virtuallistview/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./dist/VirtualListView.js');

--- a/extensions/virtuallistview/index.windows.js
+++ b/extensions/virtuallistview/index.windows.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./dist/VirtualListView.js');


### PR DESCRIPTION
reactxp-virtuallistview npm package is missing index files - I've added them here so that example at https://microsoft.github.io/reactxp/docs/extensions/virtuallistview.html works (given you update import line to
`import { VirtualListView, VirtualListViewItemInfo } from 'reactxp-virtuallistview';`)