### PR TITLE
display flex removed from root view default styles

### DIFF
--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -233,7 +233,6 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         let rootViewStyle = {
             width: '100%',
             height: '100%',
-            display: 'flex',
             cursor: 'default'
         };
 


### PR DESCRIPTION
Display was being set to flex on the root element for some reason. Causing unnecessary layout issues. Doesn't seem like there would be a necessary functionality reason to have that style set especially since it's specific to web.