### PR TITLE
Fix View component docs

### DIFF
--- a/docs/docs/components/view.md
+++ b/docs/docs/components/view.md
@@ -13,9 +13,9 @@ This component is a generic container for other components.
 In addition to the [common accessibility props](/reactxp/docs/accessibility.html), the following props are supported.
 
 ``` javascript
-// Alternate text to display if the image cannot be loaded
-// or by screen readers
-accessibilityHidden: boolean = false;
+// Alternate text for screen readers.
+// If not defined, title prop is used.
+accessibilityLabel?: string = undefined;
 
 // Hide the component from screen readers?
 accessibilityHidden: boolean = false;


### PR DESCRIPTION
There was duplicate `accessibilityHidden` mention where one of them was clearly supposed to be `accessibilityLabel`. Also I improved the comment for it.