### PR TITLE
Exposing clear function in textinput

### DIFF
--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -284,6 +284,7 @@ export abstract class Text<S> extends React.Component<Types.TextProps, S> {}
 export abstract class TextInput<S> extends React.Component<Types.TextInputProps, S> {
     abstract blur(): void;
     abstract focus(): void;
+    abstract clear(): void;
     abstract isFocused(): boolean;
     abstract selectAll(): void;
     abstract selectRange(start: number, end: number): void;

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -224,6 +224,12 @@ export class TextInput extends RX.TextInput<TextInputState> {
     setValue(value: string): void {
         this._onChangeText(value);
     }
+
+    clear() {
+        if (this.refs['nativeTextInput'] as TextInput) {
+            (this.refs['nativeTextInput'] as TextInput).clear();
+        }
+    }
 }
 
 export default TextInput;

--- a/src/web/TextInput.tsx
+++ b/src/web/TextInput.tsx
@@ -213,6 +213,10 @@ export class TextInput extends RX.TextInput<TextInputState> {
         }
     }
 
+    clear() {
+        this.setValue('');
+    }
+
     isFocused() {
         let el = ReactDOM.findDOMNode<HTMLInputElement>(this);
         if (el) {


### PR DESCRIPTION
In some android devices, the auto suggestion of keyboards are not getting cleared when the text in text input is cleared. Currently we can clear text in text input by setting inputValue to ''. Trying to see if calling clear() clears the auto suggestion. 