### PR TITLE
docs(Picker): Added Picker Simple Usage

### DIFF
--- a/docs/docs/components/picker.md
+++ b/docs/docs/components/picker.md
@@ -47,3 +47,63 @@ color: 'string';
 ## Methods
 
 No methods
+
+## Sample Usage
+
+Below is an example of a `Picker` which stores the picked value in the `RX.Component`'s [`state`](/reactxp/docs/react_concepts.html#state) and updates based on the users selected choice. The code produce content visually similar to this HTML version:
+
+<!-- HTML version NOT the ReactRX compiled form -->
+<div style="margin: 20px">
+    <span>How do you feel about ReactXP? ;) Is it: </span>
+    <select>
+        <option value="Cool" selected>Cool</option>
+        <option value="Super Cool">Super Cool</option>
+        <option value="Great">Great</option>
+    </select>
+</div>
+
+``` javascript
+import RX = require('reactxp');
+
+// Pickable items
+const pickerItems: RX.Types.PickerPropsItem[] = [
+    {
+        label: "Cool",
+        value: "Cool",
+    },
+    {
+        label: "Super Cool",
+        value: "Super Cool",
+    },
+    {
+        label: "Great",
+        value: "Great",
+    }
+];
+
+class App extends RX.Component<null, { selectedValue: string }> {
+    constructor() {
+        super();
+
+        // Setup the starting state
+        this.state = {
+            selectedValue: "Cool",
+        }
+    }
+
+    render(): JSX.Element {
+        return (
+            <RX.Text numberOfLines={ 1 }>
+                <RX.Text> { 'How do you feel about ReactXP? ;) Is it: ' } </RX.Text>
+                <RX.Picker items={pickerItems}
+                    selectedValue={this.state.selectedValue}
+                    onValueChange={(itemValue, itemIndex) => {
+                        this.setState({ selectedValue: itemValue });
+                    }} />
+            </RX.Text>
+        );
+    }
+}
+
+export = App;
+```


### PR DESCRIPTION
# Goal

`RX.Picker` docs didn't have a sample usage example. See [https://microsoft.github.io/reactxp/docs/components/picker.html](). Thus I added one for those of who like to just look at code.

# Parts

- [x] Sample Code `.tsx`
- [x] HTML example for the docs

# Remaining

There is no directions on the repository regarding contributions so let me know what I need to change and/or add to get this added!