### PR TITLE
Fixed an issue with mailto links not working properly in Safari and opening a new tab in Chrome.

### DIFF
--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -161,6 +161,8 @@ export abstract class Linking {
     abstract openUrl(url: string): SyncTasks.Promise<void>;
     abstract launchSms(smsData: Types.SmsInfo): SyncTasks.Promise<void>;
     abstract launchEmail(emailData: Types.EmailInfo): SyncTasks.Promise<void>;
+
+    protected abstract _createEmailUrl(emailInfo: Types.EmailInfo): string;
 }
 
 export abstract class Accessibility {

--- a/src/common/Linking.ts
+++ b/src/common/Linking.ts
@@ -26,13 +26,6 @@ const emailHostConstraintViolationRegex = /\.\.|^[.-]|[.-]$|\.-|-\./i;
 export abstract class Linking extends RX.Linking {
     protected abstract _openUrl(url: string): SyncTasks.Promise<void>;
 
-    // Launches Email app
-    launchEmail(emailInfo: Types.EmailInfo): SyncTasks.Promise<void> {
-        // Format email info
-        const emailUrl = this._createEmailUrl(emailInfo);
-        return this._openUrl(emailUrl);
-    }
-
     // Launches SMS app
     launchSms(phoneInfo: Types.SmsInfo): SyncTasks.Promise<void> {
         // Format phone info
@@ -46,7 +39,7 @@ export abstract class Linking extends RX.Linking {
     }
 
     // Escaped Email uri - mailto:[emailAddress]?subject=<emailSubject>&body=<emailBody>
-    private _createEmailUrl(emailInfo: Types.EmailInfo) {
+    protected _createEmailUrl(emailInfo: Types.EmailInfo) {
         let emailUrl: string = 'mailto:';
         let validEmails: string[];
 

--- a/src/native-common/Linking.ts
+++ b/src/native-common/Linking.ts
@@ -61,6 +61,13 @@ export class Linking extends CommonLinking {
 
         return defer.promise();
     }
+    
+    // Launches Email app
+    launchEmail(emailInfo: Types.EmailInfo): SyncTasks.Promise<void> {
+        // Format email info
+        const emailUrl = this._createEmailUrl(emailInfo);
+        return this._openUrl(emailUrl);
+    }
 }
 
 export default new Linking();

--- a/src/web/Linking.ts
+++ b/src/web/Linking.ts
@@ -39,6 +39,14 @@ export class Linking extends CommonLinking {
         return SyncTasks.Resolved<void>();
     }
 
+    launchEmail(emailInfo: Types.EmailInfo): SyncTasks.Promise<void> {
+        // Format email info
+        const emailUrl = this._createEmailUrl(emailInfo);
+        window.location.href = emailUrl;
+        
+        return SyncTasks.Resolved<void>();
+    }
+
     getInitialUrl(): SyncTasks.Promise<string> {
         return SyncTasks.Resolved<string>(null);
     }

--- a/src/windows/Linking.ts
+++ b/src/windows/Linking.ts
@@ -10,6 +10,7 @@
 import SyncTasks = require('synctasks');
 
 import { Linking as CommonLinking } from '../common/Linking';
+import Types = require('../common/Types');
 
 export class Linking extends CommonLinking {
     protected _openUrl(url: string): SyncTasks.Promise<void> {
@@ -21,6 +22,11 @@ export class Linking extends CommonLinking {
     getInitialUrl(): SyncTasks.Promise<string> {
         // TODO: #694142 Not implemented
         return SyncTasks.Resolved<string>(null);
+    }
+
+    launchEmail(emailInfo: Types.EmailInfo): SyncTasks.Promise<void> {
+        // TODO: #694142 Not implemented
+        throw 'Not implemented';
     }
 }
 


### PR DESCRIPTION
Mailto links did not work at all in Safari. They worked in Chrome, but opened a new tab which is undesirable behavior. The fix is simple: just use `window.location.href` for mailto links.