### PR TITLE
setFocusRestricted() and setFocusLimited() methods and nested focus restrictions fix

### DIFF
--- a/docs/docs/components/view.md
+++ b/docs/docs/components/view.md
@@ -48,16 +48,15 @@ ignorePointerEvents: boolean = false; // web only
 // restricted the focus within some modal, and you have a popup (which
 // also desires for a restricted focus) inside this modal, the popup
 // will get the restriction, but when dismissed, the restriction will
-// be restored for the modal.
+// be restored for the modal. See also the companion method
+// setFocusRestricted() below.
 // WARNING: For the sake of performance, this property is readonly and
 // changing it during the View life cycle will produce an error.
 restrictFocusWithin: boolean = false; // web only
 
 // When the keyboard navigation is happening, do not focus on this view
-// and on all focusable elements inside this view unless the view has
-// isFocusLimited state set to false
-// (like viewInstance.setState({ isFocusLimited: false })), isFocusLimited
-// state is true by default when limitFocusWithin property is true.
+// and on all focusable elements inside this view. See also the companion
+// method setFocusLimited() below.
 // Useful for the list items, allows to skip the consecutive focusing on
 // one list item (and item's internal focusable elements) after another
 // using the Tab key and implement the switching between the items using
@@ -141,6 +140,13 @@ underlayColor: string = undefined; // ßiOS and Android only
 ``` javascript
 // Sets the accessibility focus to the component.
 focus(): void;
+
+// The focus does not go outside the view with restrictFocusWithin by default,
+// setFocusRestricted() allows to turn this restricton off and back on.
+setFocusRestricted(restricted: boolean): void; // web only
+
+
+// The focus does not go inside the view with limitFocusWithin by default,
+// setFocusLimited() allows to turn this limitation off and back on.
+setFocusLimited(limited: boolean): void; // web only
 ```
-
-

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -305,6 +305,7 @@ export abstract class ViewBase<P, S> extends React.Component<P, S> {
 }
 
 export abstract class View<S> extends ViewBase<Types.ViewProps, S> {
+    abstract setFocusLimited(limited: boolean): void;
 }
 
 export abstract class GestureView<S> extends ViewBase<Types.GestureViewProps, S> {

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -305,6 +305,7 @@ export abstract class ViewBase<P, S> extends React.Component<P, S> {
 }
 
 export abstract class View<S> extends ViewBase<Types.ViewProps, S> {
+    abstract setFocusRestricted(restricted: boolean): void;
     abstract setFocusLimited(limited: boolean): void;
 }
 

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -100,6 +100,10 @@ export class View extends ViewBase<Types.ViewProps, {}> {
     focus() {
         AccessibilityUtil.setAccessibilityFocus(this);
     }
+
+    setFocusLimited(limited: boolean) {
+        // Nothing to do.
+    }
 }
 
 export default View;

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -101,6 +101,10 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         AccessibilityUtil.setAccessibilityFocus(this);
     }
 
+    setFocusRestricted(restricted: boolean) {
+        // Nothing to do.
+    }
+
     setFocusLimited(limited: boolean) {
         // Nothing to do.
     }

--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -683,18 +683,8 @@ function createAnimatedComponent<PropsType extends Types.CommonProps>(Component:
             this.initializeComponent(this.props);
         }
 
-        componentDidUpdate(prevProps: any, prevState: any) {
+        componentDidUpdate() {
             this.initializeComponent(this.props);
-
-            if (this.refs[refName] instanceof RXView) {
-                const component = this.refs[refName] as RXView;
-                const thisState = this.state as any;
-
-                if (thisState && ('isFocusLimited' in thisState) &&
-                    (!prevState || (prevState.isFocusLimited !== thisState.isFocusLimited))) {
-                    component.setState({ isFocusLimited: thisState.isFocusLimited });
-                }
-            }
         }
 
         componentWillUnmount() {
@@ -719,6 +709,13 @@ function createAnimatedComponent<PropsType extends Types.CommonProps>(Component:
                 if (component.blur) {
                     component.blur();
                 }
+            }
+        }
+
+        setFocusLimited(limited: boolean) {
+            if (this.refs[refName] instanceof RXView) {
+                const view = this.refs[refName] as RXView;
+                view.setFocusLimited(limited);
             }
         }
 

--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -712,6 +712,13 @@ function createAnimatedComponent<PropsType extends Types.CommonProps>(Component:
             }
         }
 
+        setFocusRestricted(restricted: boolean) {
+            if (this.refs[refName] instanceof RXView) {
+                const view = this.refs[refName] as RXView;
+                view.setFocusRestricted(restricted);
+            }
+        }
+
         setFocusLimited(limited: boolean) {
             if (this.refs[refName] instanceof RXView) {
                 const view = this.refs[refName] as RXView;

--- a/src/web/Navigator.tsx
+++ b/src/web/Navigator.tsx
@@ -374,7 +374,7 @@ export class Navigator extends RX.Navigator<NavigatorState> {
     // Push a scene below the others so they don't block touches sent to the presented scenes.
     private _disableScene(sceneIndex: number) {
         if (this.refs['scene_' + sceneIndex]) {
-            this._setNativeStyles(this.refs['scene_' + sceneIndex], {
+            this._setNativeStyles(this.refs['scene_' + sceneIndex] as View, {
                 opacity: 0,
                 zIndex: -10
             });
@@ -403,7 +403,7 @@ export class Navigator extends RX.Navigator<NavigatorState> {
         }
 
         if (this.refs['scene_' + sceneIndex]) {
-            this._setNativeStyles(this.refs['scene_' + sceneIndex], enabledSceneNativeProps.style);
+            this._setNativeStyles(this.refs['scene_' + sceneIndex] as View, enabledSceneNativeProps.style);
         }
     }
 
@@ -512,7 +512,7 @@ export class Navigator extends RX.Navigator<NavigatorState> {
     }
 
     private _transitionSceneStyle(fromIndex: number, toIndex: number, progress: number, index: number) {
-        const viewAtIndex = this.refs['scene_' + index];
+        const viewAtIndex = this.refs['scene_' + index] as View;
         if (viewAtIndex === undefined) {
             return;
         }

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -130,7 +130,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         // Initialize the root FocusManager which is aware of all
         // focusable elements.
         this._focusManager = new FocusManager();
-        this._focusManager.setAsRootFocusManager();
+        this._focusManager.setParent(null);
     }
 
     getChildContext() {

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -129,8 +129,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
 
         // Initialize the root FocusManager which is aware of all
         // focusable elements.
-        this._focusManager = new FocusManager();
-        this._focusManager.setParent(null);
+        this._focusManager = new FocusManager(null);
     }
 
     getChildContext() {

--- a/src/web/UserInterface.ts
+++ b/src/web/UserInterface.ts
@@ -18,8 +18,6 @@ import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
 
 export class UserInterface extends RX.UserInterface {
-    private _layoutChangeAnimationFrame: number;
-
     measureLayoutRelativeToWindow(component: React.Component<any, any>) :
             SyncTasks.Promise<Types.LayoutInfo> {
 

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -89,11 +89,11 @@ export class View extends ViewBase<Types.ViewProps, {}> {
     private _resizeDetectorAnimationFrame: number;
     private _resizeDetectorNodes: { grow?: HTMLElement, shrink?: HTMLElement } = {};
 
-    constructor(props: Types.ViewProps) {
-        super(props);
+    constructor(props: Types.ViewProps, context: ViewContext) {
+        super(props, context);
 
         if (props.restrictFocusWithin || props.limitFocusWithin) {
-            this._focusManager = new FocusManager();
+            this._focusManager = new FocusManager(context && context.focusManager);
 
             if (props.limitFocusWithin) {
                 this.setFocusLimited(true);
@@ -218,6 +218,19 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         return this;
     }
 
+    setFocusRestricted(restricted: boolean) {
+        if (!this._focusManager || !this.props.restrictFocusWithin) {
+            console.error('View: setFocusRestricted method requires restrictFocusWithin property to be set to true');
+            return;
+        }
+
+        if (restricted) {
+            this._focusManager.restrictFocusWithin();
+        } else {
+            this._focusManager.removeFocusRestriction();
+        }
+    }
+
     setFocusLimited(limited: boolean) {
         if (!this._focusManager || !this.props.limitFocusWithin) {
             console.error('View: setFocusLimited method requires limitFocusWithin property to be set to true');
@@ -308,8 +321,6 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         super.componentDidMount();
 
         if (this._focusManager) {
-            this._focusManager.setParent(this.context && this.context.focusManager);
-
             if (this.props.restrictFocusWithin) {
                 this._focusManager.restrictFocusWithin();
             }

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -308,6 +308,8 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         super.componentDidMount();
 
         if (this._focusManager) {
+            this._focusManager.setParent(this.context && this.context.focusManager);
+
             if (this.props.restrictFocusWithin) {
                 this._focusManager.restrictFocusWithin();
             }

--- a/src/web/ViewBase.tsx
+++ b/src/web/ViewBase.tsx
@@ -206,7 +206,7 @@ export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase
         this.componentDidUpdate();
     }
 
-    componentDidUpdate(prevProps?: Types.ViewProps, prevState?: S) {
+    componentDidUpdate() {
         if (this.props.onLayout) {
             this._checkAndReportLayout();
         }


### PR DESCRIPTION
Three things:
1. setFocusRestricted() and setFocusLimited() methods for View to change the focus restrictions during the component life cycle.
2. Fix for handling nested focus restrictions.
3. subscribe(), unsubscribe() and isComponentFocusRestrictedOrLimited() methods for FocusManager to be aware of the restriction state.