### PR TITLE
Add ability to set accessibility focus for text input control

### DIFF
--- a/docs/docs/components/textinput.md
+++ b/docs/docs/components/textinput.md
@@ -124,6 +124,10 @@ blur(): void;
 // Gives the control focus
 focus(): void;
 
+// Gives the control accessibility-only focus
+// E.g. screen reader announcement of the focus is needed, but popping up of native keyboard is undesirable 
+setAccessibilityFocus(): void;
+
 // Does control currently have focus?
 isFocused(): boolean;
 

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -281,6 +281,7 @@ export abstract class Text<S> extends React.Component<Types.TextProps, S> {}
 export abstract class TextInput<S> extends React.Component<Types.TextInputProps, S> {
     abstract blur(): void;
     abstract focus(): void;
+    abstract setAccessibilityFocus(): void;
     abstract isFocused(): boolean;
     abstract selectAll(): void;
     abstract selectRange(start: number, end: number): void;

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -194,6 +194,10 @@ export class TextInput extends RX.TextInput<TextInputState> {
         AccessibilityUtil.setAccessibilityFocus(this);
     }
 
+    setAccessibilityFocus() {
+        AccessibilityUtil.setAccessibilityFocus(this);
+    }
+
     isFocused() {
         return this.state.isFocused;
     }

--- a/src/web/TextInput.tsx
+++ b/src/web/TextInput.tsx
@@ -200,6 +200,13 @@ export class TextInput extends RX.TextInput<TextInputState> {
         }
     }
 
+    private _focus = () => {
+        let el = ReactDOM.findDOMNode<HTMLInputElement>(this);
+        if (el) {
+            el.focus();
+        }
+    }
+
     blur() {
         let el = ReactDOM.findDOMNode<HTMLInputElement>(this);
         if (el) {
@@ -208,10 +215,11 @@ export class TextInput extends RX.TextInput<TextInputState> {
     }
 
     focus() {
-        let el = ReactDOM.findDOMNode<HTMLInputElement>(this);
-        if (el) {
-            el.focus();
-        }
+        this._focus();
+    }
+
+    setAccessibilityFocus() {
+        this._focus();
     }
 
     isFocused() {


### PR DESCRIPTION
Currently, textInput.focus() sets the focus to the input control and also requests the screen reader focus. However, it's not possible to set screen-reader-only focus without bringing up the (iOS/Android native) keyboard.