### PR TITLE
#1053906 For textInput we need to separate setting the focus from SR focus

### DIFF
--- a/docs/docs/components/textinput.md
+++ b/docs/docs/components/textinput.md
@@ -121,11 +121,11 @@ value: string = undefined;
 // Forces the control to give up focus
 blur(): void;
 
-// Gives the control focus
+// Gives the control focus. For mobile, use setAccessibilityFocus() for setting screen reader focus
 focus(): void;
 
 // Gives the control accessibility-only focus
-// E.g. screen reader announcement of the focus is needed, but popping up of native keyboard is undesirable 
+// E.g. screen reader focus is needed, but popping up of native keyboard is undesirable 
 setAccessibilityFocus(): void;
 
 // Does control currently have focus?

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -191,7 +191,6 @@ export class TextInput extends RX.TextInput<TextInputState> {
 
     focus() {
         (this.refs['nativeTextInput'] as any).focus();
-        AccessibilityUtil.setAccessibilityFocus(this);
     }
 
     setAccessibilityFocus() {


### PR DESCRIPTION
Currently When we call focus() we always move the screen reader focus back to the textinput. But when we dont want screen reader focus to be tied to textinput focus for several scenarios. For other components like button/view/text, there is no concept of 'focus' so they wont hit this scenario. 

In text input on mobile, focus brings up the keyboard and sets the insertion pointer in the text box. We will have cases where we want the insertion pointer to be set in the text box and we dont want the screen reader focus to jump from where it is. 

On web, screen reader focus and actual focus (document.activeElement) is the same. The screen reader follows whatever is the active element. 

This PR removes settingAccessibilityFocus in textInput in focus() api to address these scenarios. 
