### PR TITLE
Use borderWidth=0 as default in native TextInput

### DIFF
--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -18,6 +18,7 @@ import Types = require('../common/Types');
 
 const _styles = {
     defaultTextInput: Styles.createTextInputStyle({
+        borderWidth: 0,
         padding: 0
     })
 };


### PR DESCRIPTION
This is consistent with web TextInput that uses border=none
to remove the default border around HTML textarea/input
elements. In UWP a RX TextInput becomes a XAML TextBox
that has BorderThickness=2 by default.