### PR TITLE
Use duck typing when calling functions of animated components.

### DIFF
--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -695,34 +695,30 @@ function createAnimatedComponent<PropsType extends Types.CommonProps>(Component:
         }
 
         focus() {
-            if (this.refs[refName] instanceof RXView) {
-                const component = this.refs[refName] as RXView;
-                if (component.focus) {
-                    component.focus();
-                }
+            const component = this.refs[refName] as RXView;
+            if (component.focus) {
+                component.focus();
             }
         }
 
         blur() {
-            if (this.refs[refName] instanceof RXView) {
-                const component = this.refs[refName] as RXView;
-                if (component.blur) {
-                    component.blur();
-                }
+            const component = this.refs[refName] as RXView;
+            if (component.blur) {
+                component.blur();
             }
         }
 
         setFocusRestricted(restricted: boolean) {
-            if (this.refs[refName] instanceof RXView) {
-                const view = this.refs[refName] as RXView;
-                view.setFocusRestricted(restricted);
+            const component = this.refs[refName] as RXView;
+            if (component.setFocusRestricted) {
+                component.setFocusRestricted(restricted);
             }
         }
 
         setFocusLimited(limited: boolean) {
-            if (this.refs[refName] instanceof RXView) {
-                const view = this.refs[refName] as RXView;
-                view.setFocusLimited(limited);
+            const component = this.refs[refName] as RXView;
+            if (component.setFocusLimited) {
+                component.setFocusLimited(limited);
             }
         }
 


### PR DESCRIPTION
We used to use "instance of" to check for the type of the component before calling View related functions on it. However, not all compatible components inherit from View (i.e. TextInput). Changed the code to use duck typing instead to make type checking more generic.