### PR TITLE
Pass initialProps from RootView to inner mainView

### DIFF
--- a/src/native-common/RootView.tsx
+++ b/src/native-common/RootView.tsx
@@ -113,8 +113,14 @@ export class RootView extends React.Component<{}, RootViewState> {
     }
 
     private _getStateFromStore(): RootViewState {
+        let mainView = MainViewStore.getMainView();
+
+        if (this.props) {
+            mainView = React.cloneElement(mainView, this.props);
+        }
+
         return {
-            mainView: MainViewStore.getMainView()
+            mainView: mainView
         };
     }
 }


### PR DESCRIPTION
Fix for issue #181.

This is the simplest fix imaginable, simply pass all the `RootViews` props to the `mainView` if they exist.  This seems fine right now, since `RootView` doesn't have any props, and I don't think that's likely to change in the future.  However, if it does, then we should guard against passing down props that are RootView-specific.  There isn't a nice way to pre-guard against that now IMO, since we'd have to work around naming conflicts.  I'm of the opinion that this simple fix is appropriate for now, and we shouldn't future-proof any further.  Open to opinions though.

(I'm pretty new to TS and React, so comments or alternative solutions are very welcome).