### PR TITLE
Exposing metaKey property on KeyboardEvent.

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1132,6 +1132,7 @@ export interface KeyboardEvent extends SyntheticEvent {
     altKey: boolean;
     shiftKey: boolean;
     keyCode: number;
+    metaKey: boolean;
 }
 
 //


### PR DESCRIPTION
Exposing metaKey property on KeyboardEvent.
Needed for keyboard shortcuts implementation on OSX.