### PR TITLE
In case we are setting the scroll position manually and there is sche…

### DIFF
--- a/src/web/ScrollView.tsx
+++ b/src/web/ScrollView.tsx
@@ -276,6 +276,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
         if (!container) {
             return;
         }
+        this._onScroll.cancel();
         if (animate) {
             const start = container.scrollTop;
             const change = scrollTop - start;
@@ -304,6 +305,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
         if (!container) {
             return;
         }
+        this._onScroll.cancel();
         if (animate) {
             const start = container.scrollLeft;
             const change = scrollLeft - start;


### PR DESCRIPTION
In case we are setting the scroll position manually and there is scheduled _onScroll callback for trailing end of interval - cancel it to not report old scroll position to parent component