### PR TITLE
Fix typo in navigator documentation

### DIFF
--- a/extensions/navigation/README.md
+++ b/extensions/navigation/README.md
@@ -1,4 +1,5 @@
-d: components/navigator
+---
+id: components/navigator
 title: Navigator
 layout: docs
 category: Components


### PR DESCRIPTION
seems like an over-deletion occurred in [this PR](https://github.com/Microsoft/reactxp/commit/e73b2b6a31572ee84b3755724cab3310e72e3b0b##commitcomment-23871642)