### PR TITLE
reactxp-navigation. ExperimentalNavigation fixes for react-native 0.42.0.

### DIFF
--- a/extensions/navigation/package.json
+++ b/extensions/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactxp-navigation",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Plugin for ReactXP that provides a navigation framework",
   "scripts": {
     "build": "tsc",
@@ -22,7 +22,7 @@
     "lodash": "^4.17.1",
     "rebound": "^0.0.13",
     "react-native-deprecated-custom-components": "^0.1.1",
-    "reactxp-experimental-navigation": "^1.0.6"
+    "reactxp-experimental-navigation": "^1.0.7"
   },
   "peerDependencies": {
     "react": "^0.14.8",

--- a/extensions/navigation/src/native-common/NavigatorExperimentalDelegate.tsx
+++ b/extensions/navigation/src/native-common/NavigatorExperimentalDelegate.tsx
@@ -144,7 +144,7 @@ export class NavigatorExperimentalDelegate extends NavigatorDelegate {
                 responseDistance = route.gestureResponseDistance;
                 gestureDistanceSet = true;
             }
-            customSceneConfig = this._convertCustomTransitionConfig(route.customSceneConfig!!!);
+            customSceneConfig = this._convertCustomTransitionConfig(route.customSceneConfig);
             switch (route.sceneConfigType) {
                 case NavigatorSceneConfigType.FloatFromBottom:
                     direction = 'vertical';

--- a/samples/TodoList/package.json
+++ b/samples/TodoList/package.json
@@ -27,7 +27,7 @@
     "react-native-windows": "^0.33.0",
     "react-native-sqlite-storage": "^3.3.1",
     "reactxp": "0.42.0-rc.20",
-    "reactxp-navigation": "^1.0.5",
+    "reactxp-navigation": "^1.0.6",
     "reactxp-virtuallistview": "^0.1.3",
     "resub": "^0.0.16",
     "synctasks": "0.2.17"

--- a/samples/hello-world-js/package.json
+++ b/samples/hello-world-js/package.json
@@ -22,7 +22,7 @@
     "react-native-windows": "^0.33.0",
     "reactxp": "0.42.0-rc.9",
     "reactxp-imagesvg": "^0.2.4",
-    "reactxp-navigation": "^1.0.5",
+    "reactxp-navigation": "^1.0.6",
     "reactxp-video": "^0.2.0"
   }
 }

--- a/samples/hello-world/package.json
+++ b/samples/hello-world/package.json
@@ -26,7 +26,7 @@
     "react-native": "^0.42.0",
     "react-native-windows": "^0.33.0",
     "reactxp-imagesvg": "^0.2.4",
-    "reactxp-navigation": "^1.0.5",
+    "reactxp-navigation": "^1.0.6",
     "reactxp-video": "^0.2.0"
   }
 }

--- a/samples/hello-world/src/App.tsx
+++ b/samples/hello-world/src/App.tsx
@@ -1,8 +1,8 @@
 /*
 * This file demonstrates a basic ReactXP app.
 */
-
-import Navigator, { Types } from 'reactxp-navigation';
+// This example uses ExperimentalNavigation on iOS and Android
+import Navigator, { Types, NavigatorDelegateSelector as DelegateSelector } from 'reactxp-navigation';
 import RX = require('reactxp');
 
 import MainPanel = require('./MainPanel');
@@ -36,6 +36,7 @@ class App extends RX.Component<{}, null> {
                 ref={ this._onNavigatorRef }
                 renderScene={ this._renderScene }
                 cardStyle={ styles.navCardStyle }
+                delegateSelector={ DelegateSelector }
             />
         );
     }
@@ -59,10 +60,7 @@ class App extends RX.Component<{}, null> {
     private _onPressNavigate = () => {
         this._navigator.push({
             routeId: NavigationRouteId.SecondPanel,
-            sceneConfigType: Types.NavigatorSceneConfigType.FloatFromRight,
-            customSceneConfig: {
-                hideShadow: true
-            }
+            sceneConfigType: Types.NavigatorSceneConfigType.FloatFromRight
         });
     }
 


### PR DESCRIPTION
- the hello-world example in typescript moved to experimental navigation framework.
- Incorrect strict null check removed
- Experimental Navigation. Crash in case of navigating by the gesture fixed on react-native 0.42.