### PR TITLE
Keyboard navigation improvements and fixes.

### DIFF
--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -394,8 +394,9 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
 
                 if ((document.activeElement === activeElement) && activeElement && (activeElement !== document.body)) {
                     this._updateKeyboardNavigationState(false);
+                    FocusManager.resetFocus();
                 }
-            }, 200);
+            }, 500);
         }
     }
 


### PR DESCRIPTION
Backporting the keyboard navigation improvements:

- Fixing nested and consecutive restrictions and properly restoring the focus after them.
- Automatically focusing the first focusable element when the restriction happens in the keyboard navigation mode.
- Preventing the focus from going off in Electron when the Tab key is pressed on a last focusable element.