### PR TITLE
Exposing aria-checked property on button type for web

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -422,6 +422,7 @@ export enum AccessibilityTrait {
     ListBox,
     Group,
     CheckBox,
+    Checked,
     ComboBox,
     Log,
     Status,

--- a/src/web/AccessibilityUtil.ts
+++ b/src/web/AccessibilityUtil.ts
@@ -84,6 +84,17 @@ export class AccessibilityUtil extends CommonAccessibiltiyUtil {
         // as we dont want to pollute the dom with "aria-selected = false" for every falsy condition
         return undefined;
     }
+
+    accessibilityTraitToAriaChecked(traits: Types.AccessibilityTrait | Types.AccessibilityTrait[]) {
+        // Walk through each trait and check if there's a checked trait. Return if one is found.
+        if (traits && _.isArray(traits) && traits.indexOf(Types.AccessibilityTrait.CheckBox) !== -1) {
+            return traits.indexOf(Types.AccessibilityTrait.Checked) !== -1 ? true : false;
+        }
+
+        // Here we are returning undefined if the above condtion is not met
+        // as we dont want to pollute the dom with "aria-checked = false" for every falsy condition
+        return undefined;
+    }
 }
 
 export default new AccessibilityUtil();

--- a/src/web/AccessibilityUtil.ts
+++ b/src/web/AccessibilityUtil.ts
@@ -80,7 +80,7 @@ export class AccessibilityUtil extends CommonAccessibiltiyUtil {
             return traits.indexOf(Types.AccessibilityTrait.Selected) !== -1 ? true : undefined;
         }
         
-        // Here we are returning undefined if the above condtion is not met 
+        // Here we are returning undefined if the above condition is not met
         // as we dont want to pollute the dom with "aria-selected = false" for every falsy condition
         return undefined;
     }
@@ -88,10 +88,10 @@ export class AccessibilityUtil extends CommonAccessibiltiyUtil {
     accessibilityTraitToAriaChecked(traits: Types.AccessibilityTrait | Types.AccessibilityTrait[]) {
         // Walk through each trait and check if there's a checked trait. Return if one is found.
         if (traits && _.isArray(traits) && traits.indexOf(Types.AccessibilityTrait.CheckBox) !== -1) {
-            return traits.indexOf(Types.AccessibilityTrait.Checked) !== -1 ? true : false;
+            return traits.indexOf(Types.AccessibilityTrait.Checked) !== -1;
         }
 
-        // Here we are returning undefined if the above condtion is not met
+        // Here we are returning undefined if the above condition is not met
         // as we dont want to pollute the dom with "aria-checked = false" for every falsy condition
         return undefined;
     }

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -53,6 +53,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         const ariaRole = AccessibilityUtil.accessibilityTraitToString(this.props.accessibilityTraits,
             _defaultAccessibilityTrait);
         const ariaSelected = AccessibilityUtil.accessibilityTraitToAriaSelected(this.props.accessibilityTraits);
+        const ariaChecked = AccessibilityUtil.accessibilityTraitToAriaChecked(this.props.accessibilityTraits);
         const isAriaHidden = AccessibilityUtil.isHidden(this.props.importantForAccessibility);
 
         // NOTE: We use tabIndex=0 to support focus.
@@ -66,6 +67,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
                 aria-disabled={ this.props.disabled }
                 aria-hidden={ isAriaHidden }
                 aria-selected={ ariaSelected }
+                aria-checked={ ariaChecked }
                 onClick={ this.onClick }
                 onContextMenu={ this._onContextMenu }
                 onMouseDown={ this._onMouseDown }


### PR DESCRIPTION
Exposing aria-checked property on button type, to full support for role="checkbox" by screen readers.