### PR TITLE
reactxp-navigation 1.0.11: MacOS assets added. 

### DIFF
--- a/extensions/navigation/package.json
+++ b/extensions/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactxp-navigation",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Plugin for ReactXP that provides a navigation framework",
   "scripts": {
     "build": "tsc",
@@ -21,7 +21,7 @@
     "assert": "^1.3.0",
     "lodash": "^4.17.1",
     "rebound": "^0.0.13",
-    "reactxp-experimental-navigation": "^1.0.8"
+    "reactxp-experimental-navigation": "^1.0.9"
   },
   "peerDependencies": {
     "react": "^0.14.8",

--- a/samples/TodoList/package.json
+++ b/samples/TodoList/package.json
@@ -27,7 +27,7 @@
     "react-native-windows": "^0.33.0",
     "react-native-sqlite-storage": "^3.3.1",
     "reactxp": "0.46.0-rc.1",
-    "reactxp-navigation": "^1.0.10",
+    "reactxp-navigation": "^1.0.11",
     "reactxp-virtuallistview": "^0.1.3",
     "resub": "^0.0.16",
     "synctasks": "0.2.17"

--- a/samples/hello-world-js/package.json
+++ b/samples/hello-world-js/package.json
@@ -22,7 +22,7 @@
     "react-native-windows": "^0.33.0",
     "reactxp": "^0.42.0",
     "reactxp-imagesvg": "^0.2.4",
-    "reactxp-navigation": "^1.0.10",
+    "reactxp-navigation": "^1.0.11",
     "reactxp-video": "^0.2.0"
   }
 }

--- a/samples/hello-world/package.json
+++ b/samples/hello-world/package.json
@@ -26,7 +26,7 @@
     "react-native": "^0.42.0",
     "react-native-windows": "^0.33.0",
     "reactxp-imagesvg": "^0.2.4",
-    "reactxp-navigation": "^1.0.10",
+    "reactxp-navigation": "^1.0.11",
     "reactxp-video": "^0.2.0"
   }
 }


### PR DESCRIPTION
Required for react-native for Mac.