### PR TITLE
add key attribute to KeyboardEvent

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1095,6 +1095,7 @@ export interface KeyboardEvent extends SyntheticEvent {
     shiftKey: boolean;
     keyCode: number;
     metaKey: boolean;
+    key: string;
 }
 
 //


### PR DESCRIPTION
KeyboardEvent.key attribute is supported by all the main browsers (I have checked latest: Chrome, Edge, FF, Safari, IE) and should be also supported by RN TextInput.onKeyPress.