### PR TITLE
Add a space character to the text in aria-live region if it is the same

### DIFF
--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -124,6 +124,14 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         // Update announcement text.
         this._newAnnouncementEventChangedSubscription =
             Accessibility.newAnnouncementReadyEvent.subscribe(announcement => {
+                if (this.state.announcementText === announcement) {
+                    // If the previous announcement is the same as the current announcement
+                    // we will apapend a ' ' to it. This ensures that the text in DOM of aria-live region changes 
+                    // and  will be read by screen Reader
+
+                    announcement += ' '
+                }
+
                 this.setState({
                     announcementText: announcement
                 });

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -129,7 +129,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                     // we will apapend a ' ' to it. This ensures that the text in DOM of aria-live region changes 
                     // and  will be read by screen Reader
 
-                    announcement += ' '
+                    announcement += ' ';
                 }
 
                 this.setState({


### PR DESCRIPTION
In react xp, the way we announce updates to screen reader is we have a div element with aria-live region and update the contents of it. Every time the content of this div changes, screen reader reads this out. 

But it wont update if the announcement is the same as the previous announcement. we want to send an update to the user everytime the announcement is fired. So adding a space character at the end of the message to ensure this happens. 