### PR TITLE
UWP: Include image dimensions in the onLoad event

### DIFF
--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -113,15 +113,8 @@ export class Image extends React.Component<Types.ImageProps, {}> {
         let nativeEvent = e.nativeEvent as any;
 
         if (nativeEvent) {
-            // TODO: #727561 Remove conditional after UWP includes width and height
-            //   with image load event.
-            if (RN.Platform.OS === 'windows') {
-                this._nativeImageWidth = 0;
-                this._nativeImageHeight = 0;
-            } else {
-                this._nativeImageWidth = nativeEvent.source.width;
-                this._nativeImageHeight = nativeEvent.source.height;
-            }
+            this._nativeImageWidth = nativeEvent.source.width;
+            this._nativeImageHeight = nativeEvent.source.height;
         }
 
         if (this.props.onLoad) {


### PR DESCRIPTION
react-native-windows has supported this for a while: https://github.com/Microsoft/react-native-windows/commit/6f244af6c9b836ea68b0da0ac6dea7c1aa1cf359