### PR TITLE
Added context menu support for text on web.

### DIFF
--- a/docs/docs/components/text.md
+++ b/docs/docs/components/text.md
@@ -48,8 +48,8 @@ numberOfLines: number = 0;
 selectable: boolean = false;
 
 // Mouse & Touch Events
-onPress?: (e: SyntheticEvent) => void;
-onContextMenu?: (e: SyntheticEvent) => void;
+onPress?: (e: SyntheticEvent) => void = undefined;
+onContextMenu?: (e: SyntheticEvent) => void = undefined;
 
 // See below for supported styles
 style: TextStyleRuleSet | TextStyleRuleSet[] = [];

--- a/docs/docs/components/text.md
+++ b/docs/docs/components/text.md
@@ -47,6 +47,10 @@ numberOfLines: number = 0;
 // Is the text selectable (affects mouse pointer and copy command)
 selectable: boolean = false;
 
+// Mouse & Touch Events
+onPress?: (e: SyntheticEvent) => void;
+onContextMenu?: (e: SyntheticEvent) => void;
+
 // See below for supported styles
 style: TextStyleRuleSet | TextStyleRuleSet[] = [];
 

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -537,6 +537,7 @@ export interface TextPropsShared extends CommonProps {
     elevation?: number;
 
     onPress?: (e: SyntheticEvent) => void;
+    onContextMenu?: (e: React.SyntheticEvent) => void;
 }
 
 export interface TextProps extends TextPropsShared {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -537,7 +537,7 @@ export interface TextPropsShared extends CommonProps {
     elevation?: number;
 
     onPress?: (e: SyntheticEvent) => void;
-    onContextMenu?: (e: React.SyntheticEvent) => void;
+    onContextMenu?: (e: SyntheticEvent) => void;
 }
 
 export interface TextProps extends TextPropsShared {

--- a/src/web/Text.tsx
+++ b/src/web/Text.tsx
@@ -76,6 +76,7 @@ export class Text extends React.Component<Types.TextProps, {}> {
                     style={ this._getStyles() }
                     aria-hidden={ isAriaHidden }
                     onClick={ this.props.onPress }
+                    onContextMenu={ this.props.onContextMenu }
                 >
                     { this.props.children }
                 </div>
@@ -89,6 +90,7 @@ export class Text extends React.Component<Types.TextProps, {}> {
                     style={ this._getStyles() }
                     aria-hidden={ isAriaHidden }
                     onClick={ this.props.onPress }
+                    onContextMenu={ this.props.onContextMenu }
                     data-text-as-pseudo-element={ this.props.children }
                 />
             );


### PR DESCRIPTION
Context menu support is needed when you want to react to contextmenu event within nested text events.