### PR TITLE
Preventing crash when double clicking on the popup anchor at times. 

### DIFF
--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -519,8 +519,16 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         }
 
         // Get the anchor element.
+        let anchorComponent = this.props.activePopupOptions!!!.getAnchor();
+        // if the anchor is unmounted, dismiss the popup. 
+        // Prevents app crash when we try to get dom node from unmounted Component
+        if (!anchorComponent) {
+            this._dismissPopup();
+            return;
+        }
+
         let anchor = ReactDOM.findDOMNode<HTMLElement>(
-            this.props.activePopupOptions!!!.getAnchor());
+            anchorComponent);
 
         // If the anchor has disappeared, dismiss the popup.
         if (!anchor) {


### PR DESCRIPTION
We get this error message for clicks on popup: findDOMNode was called on an unmounted component.

Theory is that popup anchor is not yet mounted and we call findDomNode. https://reactjs.org/docs/react-dom.html 
findDOMNode only works on mounted components (that is, components that have been placed in the DOM). If you try to call this on a component that has not been mounted yet (like calling findDOMNode() in render() on a component that has yet to be created) an exception will be thrown.

Adding a check to see that the anchor component is not null 
