### PR TITLE
packages updated to point to react-16

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.66",
-    "@types/react": "^15.4.1",
-    "@types/react-dom": "^15.4.1",
+    "@types/react": "^16.0.0",
+    "@types/react-dom": "^15.5.5",
     "assert": "^1.3.0",
     "ifvisible.js": "^1.0.6",
     "lodash": "^4.17.1",
@@ -21,10 +21,10 @@
     "synctasks": "^0.2.9"
   },
   "peerDependencies": {
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-native": "^0.46.0",
-    "react-native-windows": "^0.33.0"
+    "react-native-windows": "^0.46.0-rc.0"
   },
   "devDependencies": {
     "typescript": "2.6.0-dev.20170826",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactxp",
-  "version": "0.46.2",
+  "version": "0.46.3",
   "description": "Cross-platform abstraction layer for writing React-based applications a single time that work identically across web, React Native, and Electron distribution",
   "author": "ReactXP Team <reactxp@microsoft.com>",
   "license": "MIT",

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -24,7 +24,7 @@ export abstract class Alert {
         options?: Types.AlertOptions): void;
 }
 
-export abstract class AnimatedComponent<P extends Types.CommonProps, T> extends React.Component<P, T> {
+export abstract class AnimatedComponent<P extends Types.CommonProps<any>, T> extends React.Component<P, T> {
     abstract setNativeProps(props: P): void;
 }
 

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -335,8 +335,8 @@ export type PickerStyleRuleSet = StyleRuleSet<PickerStyle>;
 //
 // Components
 // ----------------------------------------------------------------------
-export interface CommonProps {
-    ref?: string | ((obj: React.Component<any, any>) => void);
+export interface CommonProps<T> {
+    ref?: React.Ref<T>;
     key?: string | number;
     type?: any;
     children?: React.ReactNode | React.ReactNode[];
@@ -444,7 +444,7 @@ export enum AccessibilityTrait {
     None
 }
 
-export interface CommonStyledProps<T> extends CommonProps {
+export interface CommonStyledProps<T> extends CommonProps<T> {
     style?: StyleRuleSetRecursive<T>;
 }
 
@@ -485,7 +485,7 @@ export interface PickerPropsItem {
     label: string;
     value: string;
 }
-export interface PickerProps extends CommonProps {
+export interface PickerProps extends CommonProps<RX.Picker> {
     items: PickerPropsItem[];
     selectedValue: string;
     onValueChange: (itemValue: string, itemPosition: number) => void;
@@ -493,7 +493,7 @@ export interface PickerProps extends CommonProps {
 }
 
 // Image
-export interface ImagePropsShared extends CommonProps {
+export interface ImagePropsShared extends CommonProps<RX.Image> {
     source: string;
     headers?: { [headerName: string]: string };
     accessibilityLabel?: string;
@@ -526,7 +526,7 @@ export interface AnimatedImageProps extends ImagePropsShared {
 // | I am a very |
 // | important   |
 // | example     |
-export interface TextPropsShared extends CommonProps {
+export interface TextPropsShared extends CommonProps<RX.Text> {
     children?: ReactNode;
     selectable?: boolean;
     numberOfLines?: number;
@@ -568,7 +568,7 @@ export interface AnimatedTextProps extends TextPropsShared {
 export type ViewLayerType = 'none' | 'software' | 'hardware';
 
 // View
-export interface ViewPropsShared extends CommonProps, CommonAccessibilityProps {
+export interface ViewPropsShared<T> extends CommonProps<T>, CommonAccessibilityProps {
     title?: string;
     ignorePointerEvents?: boolean;
     blockPointerEvents?: boolean; // Native-only prop for disabling touches on self and all child views
@@ -614,7 +614,11 @@ export interface ViewPropsShared extends CommonProps, CommonAccessibilityProps {
     underlayColor?: string;
 }
 
-export interface ViewProps extends ViewPropsShared {
+// Interface for the ViewProps
+export interface ViewProps extends ViewPropsBase<RX.View> { }
+
+// Base interface for inheritance (ScrollView and other Views sharing the same set of props)
+export interface ViewPropsBase<T> extends ViewPropsShared<T> {
     style?:  StyleRuleSetRecursive<ViewStyleRuleSet>;
     onContextMenu?: (e: React.SyntheticEvent<any>) => void;
     onStartShouldSetResponder?: (e: React.SyntheticEvent<any>) => boolean;
@@ -631,7 +635,7 @@ export interface ViewProps extends ViewPropsShared {
     onResponderTerminationRequest?: (e: React.SyntheticEvent<any>) => boolean;
 }
 
-export interface AnimatedViewProps extends ViewPropsShared {
+export interface AnimatedViewProps extends ViewPropsShared<RX.View> {
     style?: StyleRuleSetRecursive<AnimatedViewStyleRuleSet | ViewStyleRuleSet>;
 }
 
@@ -742,7 +746,7 @@ export interface ScrollIndicatorInsets {
 }
 
 // ScrollView
-export interface ScrollViewProps extends ViewProps {
+export interface ScrollViewProps extends ViewPropsBase<RX.ScrollView> {
     style?: StyleRuleSetRecursive<ScrollViewStyleRuleSet>;
     children?: ReactNode;
 
@@ -819,7 +823,7 @@ export interface LinkProps extends CommonStyledProps<LinkStyleRuleSet> {
 }
 
 // TextInput
-export interface TextInputPropsShared extends CommonProps, CommonAccessibilityProps {
+export interface TextInputPropsShared extends CommonProps<RX.TextInput>, CommonAccessibilityProps {
     autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters';
     autoCorrect?: boolean;
     autoFocus?: boolean;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -444,12 +444,12 @@ export enum AccessibilityTrait {
     None
 }
 
-export interface CommonStyledProps<T> extends CommonProps<T> {
-    style?: StyleRuleSetRecursive<T>;
+export interface CommonStyledProps<S, T> extends CommonProps<T> {
+    style?: StyleRuleSetRecursive<S>;
 }
 
 // Button
-export interface ButtonProps extends CommonStyledProps<ButtonStyleRuleSet>, CommonAccessibilityProps {
+export interface ButtonProps extends CommonStyledProps<ButtonStyleRuleSet, RX.Button>, CommonAccessibilityProps {
     title?: string;
     children?: ReactNode;
     disabled?: boolean;
@@ -710,7 +710,7 @@ export enum PreferredPanGesture {
     Vertical
 }
 
-export interface GestureViewProps extends CommonStyledProps<ViewStyleRuleSet>, CommonAccessibilityProps {
+export interface GestureViewProps extends CommonStyledProps<ViewStyleRuleSet, RX.GestureView>, CommonAccessibilityProps {
     // Gestures and attributes that apply only to touch inputs
     onPinchZoom?: (gestureState: MultiTouchGestureState) => void;
     onRotate?: (gestureState: MultiTouchGestureState) => void;
@@ -806,7 +806,7 @@ export interface ScrollViewProps extends ViewPropsBase<RX.ScrollView> {
 }
 
 // Link
-export interface LinkProps extends CommonStyledProps<LinkStyleRuleSet> {
+export interface LinkProps extends CommonStyledProps<LinkStyleRuleSet, RX.Link> {
     title?: string;
     url: string;
     children?: ReactNode;
@@ -880,7 +880,7 @@ export interface AnimatedTextInputProps extends TextInputPropsShared {
 }
 
 // ActivityIndicator
-export interface ActivityIndicatorProps extends CommonStyledProps<ActivityIndicatorStyleRuleSet> {
+export interface ActivityIndicatorProps extends CommonStyledProps<ActivityIndicatorStyleRuleSet, RX.ActivityIndicator> {
     color: string;
     size?: 'large' | 'medium' | 'small' | 'tiny';
     deferTime?: number; // Number of ms to wait before displaying
@@ -915,7 +915,7 @@ export enum WebViewSandboxMode {
     AllowTopNavigation = 1 << 9
 }
 
-export interface WebViewProps extends CommonStyledProps<WebViewStyleRuleSet> {
+export interface WebViewProps extends CommonStyledProps<WebViewStyleRuleSet, RX.WebView> {
     url: string;
     headers?: { [key: string]: string };
     onLoad?: (e: SyntheticEvent) => void;

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -59,10 +59,10 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
     touchableGetInitialState: () => RN.Touchable.State;
     touchableHandleStartShouldSetResponder: () => boolean;
     touchableHandleResponderTerminationRequest: () => boolean;
-    touchableHandleResponderGrant: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderMove: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderRelease: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderTerminate: (e: React.SyntheticEvent<any>) => void;
+    touchableHandleResponderGrant: (e: React.SyntheticEvent<Button>) => void;
+    touchableHandleResponderMove: (e: React.SyntheticEvent<Button>) => void;
+    touchableHandleResponderRelease: (e: React.SyntheticEvent<Button>) => void;
+    touchableHandleResponderTerminate: (e: React.SyntheticEvent<Button>) => void;
 
     private _isMounted = false;
     private _hideTimeout: number|undefined;

--- a/src/native-common/ModalContainer.tsx
+++ b/src/native-common/ModalContainer.tsx
@@ -10,6 +10,7 @@
 import React = require('react');
 import RN = require('react-native');
 
+import RX = require('../common/Interfaces');
 import Types= require('../common/Types');
 
 const _styles = {
@@ -29,7 +30,7 @@ const _styles = {
     }
 };
 
-export interface ModalContainerProps extends Types.CommonProps {
+export interface ModalContainerProps extends Types.CommonProps<RX.View> {
 }
 
 export class ModalContainer extends React.Component<ModalContainerProps, {}> {

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -14,6 +14,7 @@ import assert = require('assert');
 import React = require('react');
 import RN = require('react-native');
 
+import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
 
 // Width of the "alley" around popups so they don't get too close to the boundary of the screen boundary.
@@ -23,7 +24,7 @@ const ALLEY_WIDTH = 2;
 // attempting a different position?
 const MIN_ANCHOR_OFFSET = 16;
 
-export interface PopupContainerViewProps extends Types.CommonProps {
+export interface PopupContainerViewProps extends Types.CommonProps<RX.View> {
     activePopupOptions: Types.PopupOptions;
     anchorHandle: number;
     onDismissPopup?: () => void;

--- a/src/native-common/ViewBase.tsx
+++ b/src/native-common/ViewBase.tsx
@@ -13,7 +13,7 @@ import RX = require('../common/Interfaces');
 
 import Types = require('../common/Types');
 
-export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase<P, S> {
+export abstract class ViewBase<P extends Types.ViewPropsBase<any>, S> extends RX.ViewBase<P, S> {
     private static _defaultViewStyle: Types.ViewStyleRuleSet|undefined;
     private _layoutEventValues: Types.ViewOnLayoutEvent|undefined;
 

--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -613,11 +613,11 @@ function createAnimatedComponent<PropsType extends Types.CommonProps<any>>(Compo
             throw 'Called setNativeProps on web AnimatedComponent';
         }
 
-        componentWillReceiveProps(props: Types.CommonStyledProps<Types.StyleRuleSet<Object>>) {
+        componentWillReceiveProps(props: Types.CommonStyledProps<Types.StyleRuleSet<Object>, RX.Animated>) {
             this._updateStyles(props);
         }
 
-        private _updateStyles(props: Types.CommonStyledProps<Types.StyleRuleSet<Object>>) {
+        private _updateStyles(props: Types.CommonStyledProps<Types.StyleRuleSet<Object>, RX.Animated>) {
             this._propsWithoutStyle = _.omit(props, 'style');
 
             if (!props.style) {

--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -595,7 +595,7 @@ export var parallel: Types.Animated.ParallelFunction = function (
 };
 
 // Function for creating wrapper AnimatedComponent around passed in component
-function createAnimatedComponent<PropsType extends Types.CommonProps>(Component: any): any {
+function createAnimatedComponent<PropsType extends Types.CommonProps<any>>(Component: any): any {
     var refName = 'animatedNode';
 
     class AnimatedComponentGenerated extends React.Component<PropsType, void> implements RX.AnimatedComponent<PropsType, void> {
@@ -672,7 +672,7 @@ function createAnimatedComponent<PropsType extends Types.CommonProps>(Component:
             });
         }
 
-        initializeComponent(props: Types.CommonProps) {
+        initializeComponent(props: Types.CommonProps<any>) {
             // Conclude the initialization setting the element.
             const element = ReactDOM.findDOMNode<HTMLElement>(this.refs[refName]);
             if (element) {
@@ -744,7 +744,7 @@ function createAnimatedComponent<PropsType extends Types.CommonProps>(Component:
     return AnimatedComponentGenerated;
 }
 
-export var Image = createAnimatedComponent<Types.ImageProps>(RXImage) as typeof RX.AnimatedImage;
+export var Image = createAnimatedComponent(RXImage) as typeof RX.AnimatedImage;
 export var Text = createAnimatedComponent(RXText) as typeof RX.AnimatedText;
 export var TextInput = createAnimatedComponent(RXTextInput) as typeof RX.AnimatedTextInput;
 export var View = createAnimatedComponent(RXView) as typeof RX.AnimatedView;

--- a/src/web/ModalContainer.tsx
+++ b/src/web/ModalContainer.tsx
@@ -9,6 +9,7 @@
 
 import React = require('react');
 
+import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
 
 const _styles = {
@@ -29,7 +30,7 @@ const _styles = {
     }
 };
 
-export class ModalContainer extends React.Component<Types.CommonProps, {}> {
+export class ModalContainer extends React.Component<Types.CommonProps<RX.View>, {}> {
     constructor() {
         super();
     }

--- a/src/web/ScrollView.tsx
+++ b/src/web/ScrollView.tsx
@@ -156,7 +156,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
         }
     }
 
-    componentWillReceiveProps(newProps: Types.ScrollViewProps) {
+    componentWillReceiveProps(newProps: Types.ViewPropsBase<any>) {
         super.componentWillReceiveProps(newProps);
         this._onPropsChange(newProps);
     }

--- a/src/web/ViewBase.tsx
+++ b/src/web/ViewBase.tsx
@@ -21,7 +21,7 @@ import Types = require('../common/Types');
 const _layoutTimerActiveDuration = 1000;
 const _layoutTimerInactiveDuration = 10000;
 
-export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase<P, S> {
+export abstract class ViewBase<P extends Types.ViewPropsBase<any>, S> extends RX.ViewBase<P, S> {
     private static _viewCheckingTimer: number|undefined;
     private static _isResizeHandlerInstalled = false;
     private static _viewCheckingList: ViewBase<Types.ViewProps, {}>[] = [];


### PR DESCRIPTION
Moving the reactxp closer to the public react typings compatibility.
Properties are generic now. Ref<T> supported.

We are using react-16 and react-native-windows synced with react-native version