### PR TITLE
Adding a timeout before focusing previous component.

### DIFF
--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -259,7 +259,7 @@ export class FocusManager {
                 if (needsFocusReset) {
                     FocusManager.resetFocus();
                 }
-            }, 0);
+            }, 100);
         }
     }
 


### PR DESCRIPTION
Adding this timeout, because of screen readers keeping reference to old aria-label and not reading correct state of components when the label changes dynamically.