### PR TITLE
Adding the Android 'mode' property to Picker

### DIFF
--- a/docs/docs/components/picker.md
+++ b/docs/docs/components/picker.md
@@ -29,6 +29,11 @@ selectedValue: string;
 onValueChange: (itemValue: string, itemPosition: number) => void;
 
 style: PickerStyleRuleSet | PickerStyleRuleSet[] = [];
+
+// Android only.
+// 'dialog': Show a modal dialog. This is the default.
+// 'dropdown': Shows a dropdown anchored to the picker view
+mode: string;
 ```
 
 ## Styles

--- a/docs/docs/components/picker.md
+++ b/docs/docs/components/picker.md
@@ -33,7 +33,7 @@ style: PickerStyleRuleSet | PickerStyleRuleSet[] = [];
 // Android only.
 // 'dialog': Show a modal dialog. This is the default.
 // 'dropdown': Shows a dropdown anchored to the picker view
-mode: string;
+mode: 'dialog' | 'dropdown';
 ```
 
 ## Styles

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -490,7 +490,7 @@ export interface PickerProps extends CommonProps {
     selectedValue: string;
     onValueChange: (itemValue: string, itemPosition: number) => void;
     style?: StyleRuleSetRecursive<PickerStyleRuleSet>;
-    mode?: string;
+    mode?: 'dialog' | 'dropdown';
 }
 
 // Image

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -490,6 +490,7 @@ export interface PickerProps extends CommonProps {
     selectedValue: string;
     onValueChange: (itemValue: string, itemPosition: number) => void;
     style?: StyleRuleSetRecursive<PickerStyleRuleSet>;
+    mode?: string;
 }
 
 // Image

--- a/src/native-common/Picker.tsx
+++ b/src/native-common/Picker.tsx
@@ -20,6 +20,7 @@ export class Picker extends RX.Picker {
                 selectedValue={ this.props.selectedValue }
                 onValueChange={ this.onValueChange }
                 style={ this.props.style }
+                mode={ this.props.mode }
             >
                 { _.map(this.props.items, (i, idx) => <RN.Picker.Item { ...i } key={ idx } /> ) }
             </RN.Picker>

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -160,6 +160,13 @@ declare module 'react-native' {
         testId?: string
 
         ref?: string | ((obj: ReactNativeBaseComponent<any, any>) => void);
+
+        /**
+         * Android only.
+         * 'dialog': Show a modal dialog. This is the default.
+         * 'dropdown': Shows a dropdown anchored to the picker view
+         */
+        mode?: string;
     }
 
     interface TouchableWithoutFeedbackProps extends ComponentPropsBase {


### PR DESCRIPTION
This is a very widely used property for Android.  In fact, the default of 'dialog' is much less common in my experience.

Without this addition, there is no way to have the common dropdown spinner on Android.