### PR TITLE
Moving argument validation from FrontLayerViewManager to public Popup…

### DIFF
--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -70,18 +70,8 @@ export class FrontLayerViewManager {
 
     public showPopup(
         popupOptions: Types.PopupOptions, popupId: string, delay?: number): boolean {
-
-        if (!popupId || popupId === '') {
-            console.error('FrontLayerViewManager: popupId must be valid!');
-            return false;
-        }
-
-        if (!popupOptions.getAnchor()) {
-            console.error('FrontLayerViewManager: getAnchor() must be valid!');
-            return false;
-        }
-
         const index = this._findIndexOfPopup(popupId);
+        
         if (index === -1) {
             this._overlayStack.push(new PopupStackContext(popupId, popupOptions, RN.findNodeHandle(popupOptions.getAnchor())));
 

--- a/src/native-common/Modal.ts
+++ b/src/native-common/Modal.ts
@@ -16,14 +16,30 @@ import Types= require('../common/Types');
 
 export class Modal extends RX.Modal {
     isDisplayed(modalId: string): boolean {
+        if (!modalId || modalId === '') {
+            throw new Error(`modalId must be a non-empty string. Actual: ${modalId}`);
+        }
+
         return FrontLayerViewManager.isModalDisplayed(modalId);
     }
 
     show(modal: React.ReactElement<Types.ViewProps>, modalId: string): void {
-         FrontLayerViewManager.showModal(modal, modalId);
+        if (!modal) {
+            throw new Error(`modal must be valid. Actual ${modal}`);
+        }
+
+        if (!modalId || modalId === '') {
+            throw new Error(`modalId must be a non-empty string. Actual: ${modalId}`);
+        }
+
+        FrontLayerViewManager.showModal(modal, modalId);
     }
 
     dismiss(modalId: string): void {
+        if (!modalId || modalId === '') {
+            throw new Error(`modalId must be a non-empty string. Actual: ${modalId}`);
+        }
+
         FrontLayerViewManager.dismissModal(modalId);
     }
 

--- a/src/native-common/Popup.ts
+++ b/src/native-common/Popup.ts
@@ -13,16 +13,32 @@ import Types = require('../common/Types');
 
 export class Popup extends RX.Popup {
     show(options: Types.PopupOptions, popupId: string, delay?: number): boolean {
+        if (!popupId || popupId === '') {
+            throw new Error(`popupId must be a non-empty string. Actual: ${popupId}`);
+        }
+
+        if (!options || !options.getAnchor || !options.getAnchor()) {
+            throw new Error(`options must have a valid getAnchor().`);
+        }
+
         return FrontLayerViewManager.showPopup(options, popupId, delay);
     }
 
     autoDismiss(popupId: string, delay?: number): void {
+        if (!popupId || popupId === '') {
+            throw new Error(`popupId must be a non-empty string. Actual: ${popupId}`);
+        }
+
         setTimeout(() => {
             FrontLayerViewManager.dismissPopup(popupId);
         }, delay || 0);
     }
 
     dismiss(popupId: string): void {
+        if (!popupId || popupId === '') {
+            throw new Error(`popupId must be a non-empty string. Actual: ${popupId}`);
+        }
+
         FrontLayerViewManager.dismissPopup(popupId);
     }
 

--- a/src/web/FrontLayerViewManager.tsx
+++ b/src/web/FrontLayerViewManager.tsx
@@ -35,10 +35,6 @@ export class FrontLayerViewManager {
     }
 
     showModal(modal: React.ReactElement<Types.ViewProps>, modalId: string) {
-        if (!modalId) {
-            console.error('modal must have valid ID');
-        }
-
         // Dismiss any active popups.
         if (this._activePopupOptions) {
             this.dismissPopup(this._activePopupId!!!);

--- a/src/web/Modal.ts
+++ b/src/web/Modal.ts
@@ -15,14 +15,30 @@ import Types = require('../common/Types');
 
 export class Modal extends RX.Modal {
     isDisplayed(modalId: string): boolean {
+        if (!modalId || modalId === '') {
+            throw new Error(`modalId must be a non-empty string. Actual: ${modalId}`);
+        }
+
         return FrontLayerViewManager.isModalDisplayed(modalId);
     }
 
     show(modal: React.ReactElement<Types.ViewProps>, modalId: string): void {
-         FrontLayerViewManager.showModal(modal, modalId);
+        if (!modal) {
+            throw new Error(`modal must be valid. Actual ${modal}`);
+        }
+
+        if (!modalId || modalId === '') {
+            throw new Error(`modalId must be a non-empty string. Actual: ${modalId}`);
+        }
+
+        FrontLayerViewManager.showModal(modal, modalId);
     }
 
     dismiss(modalId: string): void {
+        if (!modalId || modalId === '') {
+            throw new Error(`modalId must be a non-empty string. Actual: ${modalId}`);
+        }
+        
         FrontLayerViewManager.dismissModal(modalId);
     }
 

--- a/src/web/Popup.ts
+++ b/src/web/Popup.ts
@@ -12,16 +12,27 @@ import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
 
 export class Popup extends RX.Popup {
-
     show(options: Types.PopupOptions, popupId: string, delay?: number): boolean {
+        if (!popupId || popupId === '') {
+            throw new Error(`popupId must be a non-empty string. Actual: ${popupId}`);
+        }
+
         return FrontLayerViewManager.showPopup(options, popupId, delay);
     }
 
     autoDismiss(popupId: string, delay?: number): void {
+        if (!popupId || popupId === '') {
+            throw new Error(`popupId must be a non-empty string. Actual: ${popupId}`);
+        }
+
         FrontLayerViewManager.autoDismissPopup(popupId, delay);
     }
 
     dismiss(popupId: string): void {
+        if (!popupId || popupId === '') {
+            throw new Error(`popupId must be a non-empty string. Actual: ${popupId}`);
+        }
+
         FrontLayerViewManager.dismissPopup(popupId);
     }
 


### PR DESCRIPTION
… and Modal APIs.

Issue #301. 

This moves (and adds some) argument validation from the `FrontLayerViewManager` to the `Popup` and `Modal` API entry points.  This is a better place for these IMO, since we are failing quicker on arguments we know are invalid, and providing a nicer stacktrace for consumers. 

I choose these validations (rather than validate every possible value/field) because they are the ones that the API will hard-fail on if not satisfied.  