### PR TITLE
 Fixing undefined is not an object error

### DIFF
--- a/src/native-common/NavigatorExperimentalDelegate.tsx
+++ b/src/native-common/NavigatorExperimentalDelegate.tsx
@@ -27,8 +27,6 @@ type NavigationState = Navigation.NavigationState;
 type NavigationRoute = Navigation.NavigationRoute;
 type NavigationTransitionProps = Navigation.NavigationTransitionProps;
 
-const StateUtils = Navigation.StateUtils;
-
 interface NavigationRouteState extends NavigationRoute {
     route: Types.NavigatorRoute;
 }
@@ -239,7 +237,7 @@ export class NavigatorExperimentalDelegate extends NavigatorDelegate {
         switch (command.type) {
             case CommandType.Push:
                 useNewStateAsScene = true;
-                this._state = StateUtils.push(this._state, this._createState(route));
+                this._state = Navigation.StateUtils.push(this._state, this._createState(route));
                 break;
 
             case CommandType.Pop:
@@ -252,17 +250,17 @@ export class NavigatorExperimentalDelegate extends NavigatorDelegate {
                         this._state = this._popToTop(this._state);
                     }
                 } else {
-                    this._state = StateUtils.pop(this._state);
+                    this._state = Navigation.StateUtils.pop(this._state);
                 }
 
                 break;
 
             case CommandType.Replace:
                 if (value === -1) {
-                    this._state = StateUtils.replaceAtIndex(this._state, this._state.routes.length - 2,
+                    this._state = Navigation.StateUtils.replaceAtIndex(this._state, this._state.routes.length - 2,
                         this._createState(route));
                 } else {
-                    this._state = StateUtils.replaceAtIndex(this._state, this._state.routes.length - 1,
+                    this._state = Navigation.StateUtils.replaceAtIndex(this._state, this._state.routes.length - 1,
                         this._createState(route));
                 }
 


### PR DESCRIPTION
When using `reactxp` 0.42.x with `react-native` 0.49+, the following error occurs: `undefined is not an object (evaluating 'Navigation.StateUtils')`.  This is because of the fact that `NavigationExperimental` is no longer a part of `react-native`.

This appears to be caused by [Line 30 of `NavigatorExperimentalDelegate`](https://github.com/Microsoft/reactxp/blob/0.42.0/src/native-common/NavigatorExperimentalDelegate.tsx#L30).  This was even occurring if the Navigation portions of `reactxp` were unused.

This is the initial issue talked about in #216.

This PR aims to fix the error by deferring the evaluation of `Navigation.StateUtils` until the delegate is actually used.  This way, it doesn't cause any backwards compatibility issues, but also fixes the error.

### Screenshot:
![undefined is not an object](https://user-images.githubusercontent.com/595616/31417038-21c05306-adfb-11e7-9ac8-e5b291f8ca03.png)