### PR TITLE
Fix 2 cases where this.refs['popupContainer'] could be undefined and …

### DIFF
--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -319,7 +319,14 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
 
     private _tryClosePopup = (e: MouseEvent) => {
         // Dismiss a visible popup if there's a click outside.
-        let popupContainer = ReactDOM.findDOMNode(this.refs['popupContainer']);
+        const reactPopupContainer = this.refs['popupContainer'];
+        if (!reactPopupContainer) {
+            return;
+        }
+        let popupContainer = ReactDOM.findDOMNode(reactPopupContainer);
+        if (!popupContainer) {
+            return;
+        }
         let clickInPopup = false;
         let el = e.target as HTMLElement|undefined;
         while (el) {
@@ -513,8 +520,12 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         let newState: RootViewState = _.extend({}, this.state);
 
         if (this.state.isMeasuringPopup) {
+            const popupContainer = this.refs['popupContainer'];
+            if (!popupContainer) {
+                return;
+            }
             // Get the width/height of the popup.
-            let popup = ReactDOM.findDOMNode(this.refs['popupContainer']) as HTMLElement;
+            let popup = ReactDOM.findDOMNode(popupContainer) as HTMLElement;
             if (!popup) {
                 return;
             }


### PR DESCRIPTION
…crash inside RootView