### PR TITLE
Fix double "Code" decoration on code regions.

### DIFF
--- a/docs/css/reactxp.scss
+++ b/docs/css/reactxp.scss
@@ -976,7 +976,7 @@ p a code {
 
 /* Echo out a label for the example */
 
-.highlight:after {
+div.highlight:after {
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
Fix double "Code" decoration on code regions hiding first line of code region.
![image](https://user-images.githubusercontent.com/907136/32304057-ae9dea42-bf29-11e7-82c9-31d6d1969512.png)
![image](https://user-images.githubusercontent.com/907136/32304072-c45157e8-bf29-11e7-9592-1e720d382f1d.png)
