### PR TITLE
Adding null to possible ref callback arg type

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -343,7 +343,7 @@ export type ComponentBase = React.Component<any, any>;
 // Components
 // ----------------------------------------------------------------------
 export interface CommonProps {
-    ref?: string | ((obj: ComponentBase) => void);
+    ref?: string | ((obj: ComponentBase | null) => void);
     key?: string | number;
     type?: any;
     children?: React.ReactNode | React.ReactNode[];


### PR DESCRIPTION
This is the correct type, and not having `| null` here causes build errors for users of tsc `strictNullChecks`.