### PR TITLE
UWP: Make the popup background overlay clickable

### DIFF
--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -29,7 +29,8 @@ const _styles = {
     fullScreenView: {
         flex: 1,
         alignSelf: 'stretch',
-        overflow: 'visible'
+        overflow: 'visible',
+        backgroundColor: 'transparent' // otherwise RNW will remove this view form the tree and it won't receive mouse events
     }
 };
 

--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -30,7 +30,7 @@ const _styles = {
         flex: 1,
         alignSelf: 'stretch',
         overflow: 'visible',
-        backgroundColor: 'transparent' // otherwise RNW will remove this view form the tree and it won't receive mouse events
+        backgroundColor: 'transparent' // otherwise in UWP it will be removed from the tree and won't receive mouse events
     }
 };
 


### PR DESCRIPTION
I haven't figured out yet why this works on Android and iOS - they also remove layout-only views.