### PR TITLE
Fixed drag & drop handlers for RN windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ node_modules
 
 
 .idea/*
+.vs

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -80,7 +80,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
             const handler = this._internalProps[name];
 
             if (handler) {
-                this._internalProps.allowDrop = true; // TODO: let RN figure this out?
+                this._internalProps.allowDrop = true;
 
                 this._internalProps[name] = (e: React.SyntheticEvent) => {
                     handler({

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -18,7 +18,6 @@ import AnimateListEdits from './listAnimations/AnimateListEdits';
 import Button from './Button';
 import Types = require('../common/Types');
 import ViewBase from './ViewBase';
-import { SyntheticEvent } from 'react';
 
 export class View extends ViewBase<Types.ViewProps, {}> {
     private _internalProps: any = {};
@@ -71,13 +70,19 @@ export class View extends ViewBase<Types.ViewProps, {}> {
             }
         }
 
+        if (RN.Platform.OS === 'windows') {
+            this._processDragAndDropProps();
+        }
+    }
+
+    private _processDragAndDropProps() {
         for (const name of ['onDragEnter', 'onDragOver', 'onDrop', 'onDragLeave']) {
             const handler = this._internalProps[name];
 
             if (handler) {
-                this._internalProps.allowDrop = true;
+                this._internalProps.allowDrop = true; // TODO: let RN figure this out?
 
-                this._internalProps[name] = (e: SyntheticEvent) => {
+                this._internalProps[name] = (e: React.SyntheticEvent) => {
                     handler({
                         dataTransfer: (e.nativeEvent as any).dataTransfer,
 

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -69,9 +69,24 @@ export class View extends ViewBase<Types.ViewProps, {}> {
                 this._internalProps.pointerEvents = 'box-none';
             }
         }
+
+        // RN sets event data in nativeEvent, but JS expects it to be directly in the event object
+        for (const name of ['onDragEnter', 'onDragOver', 'onDrop', 'onDragLeave']) {
+            const handler = this._internalProps[name];
+
+            if (handler) {
+                this._internalProps.allowDrop = true;
+
+                this._internalProps[name] = (event: any) => {
+                    const newEvent = Object.create(event);
+                    newEvent.dataTransfer = event.nativeEvent.dataTransfer;
+                    handler(newEvent);
+                };
+            }
+        }
     }
 
-    private _isButton (viewProps: Types.ViewProps): boolean {
+    private _isButton(viewProps: Types.ViewProps): boolean {
         return !!(viewProps.onPress || viewProps.onLongPress);
     }
 
@@ -79,19 +94,19 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         if (this.props.animateChildEnter || this.props.animateChildMove || this.props.animateChildLeave) {
             return (
                 <AnimateListEdits { ...this._internalProps }>
-                    { this.props.children }
+                    {this.props.children}
                 </AnimateListEdits>
             );
         } else if (this._isButton(this.props)) {
             return (
                 <Button { ...this._internalProps }>
-                    { this.props.children }
+                    {this.props.children}
                 </Button>
             );
         } else {
             return (
                 <RN.View { ...this._internalProps }>
-                    { this.props.children }
+                    {this.props.children}
                 </RN.View>
             );
         }

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -111,19 +111,19 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         if (this.props.animateChildEnter || this.props.animateChildMove || this.props.animateChildLeave) {
             return (
                 <AnimateListEdits { ...this._internalProps }>
-                    {this.props.children}
+                    { this.props.children }
                 </AnimateListEdits>
             );
         } else if (this._isButton(this.props)) {
             return (
                 <Button { ...this._internalProps }>
-                    {this.props.children}
+                    { this.props.children }
                 </Button>
             );
         } else {
             return (
                 <RN.View { ...this._internalProps }>
-                    {this.props.children}
+                    { this.props.children }
                 </RN.View>
             );
         }

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -18,6 +18,7 @@ import AnimateListEdits from './listAnimations/AnimateListEdits';
 import Button from './Button';
 import Types = require('../common/Types');
 import ViewBase from './ViewBase';
+import { SyntheticEvent } from 'react';
 
 export class View extends ViewBase<Types.ViewProps, {}> {
     private _internalProps: any = {};
@@ -70,17 +71,28 @@ export class View extends ViewBase<Types.ViewProps, {}> {
             }
         }
 
-        // RN sets event data in nativeEvent, but JS expects it to be directly in the event object
         for (const name of ['onDragEnter', 'onDragOver', 'onDrop', 'onDragLeave']) {
             const handler = this._internalProps[name];
 
             if (handler) {
                 this._internalProps.allowDrop = true;
 
-                this._internalProps[name] = (event: any) => {
-                    const newEvent = Object.create(event);
-                    newEvent.dataTransfer = event.nativeEvent.dataTransfer;
-                    handler(newEvent);
+                this._internalProps[name] = (e: SyntheticEvent) => {
+                    handler({
+                        dataTransfer: (e.nativeEvent as any).dataTransfer,
+
+                        stopPropagation() {
+                            if (e.stopPropagation) {
+                                e.stopPropagation();
+                            }
+                        },
+
+                        preventDefault() {
+                            if (e.preventDefault) {
+                                e.preventDefault();
+                            }
+                        },
+                    });
                 };
             }
         }


### PR DESCRIPTION
With this change, if the app sets either of the four drag and drop handlers on `RX.View`,
the user will be able to drag files into the view. The event will have the `dataTransfer`
property:

```tsx
<RX.View onDragEnter={ e => console.log(e.dataTransfer.files.length) }>
  ...
</RX.View>
```

This change depends on https://github.com/Microsoft/react-native-windows/pull/1549
as it sets a new `allowDrop` property on `RN.View`. If an older RNW version is used, the
`allowDrop` property will be ignored and drag & drop won't work, but the app won't crash.