### PR TITLE
Nested buttons are allowed in react-native.

### DIFF
--- a/docs/versions/version_history.md
+++ b/docs/versions/version_history.md
@@ -16,6 +16,11 @@ A new version of ReactXP will be released a monthly basis (approximately), follo
 
 ### Version History
 
+#### Version 0.46.7 of reactxp
+_Released 14 Dec 2017_
+
+React-native Button is allowed to have multiple nested elements. This warning is hard to control now as View generates a Button in case onPress is defined.
+
 #### Version 0.46.6 of reactxp
 _Released 13 Dec 2017_
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactxp",
-  "version": "0.46.6",
+  "version": "0.46.7",
   "description": "Cross-platform abstraction layer for writing React-based applications a single time that work identically across web, React Native, and Electron distribution",
   "author": "ReactXP Team <reactxp@microsoft.com>",
   "license": "MIT",

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -59,10 +59,6 @@ export interface ButtonContext {
 }
 
 export class Button extends React.Component<Types.ButtonProps, {}> {
-    static propTypes = {
-        // Button should only have a single child.
-        children: PropTypes.element
-    };
 
     static contextTypes = {
         hasRxButtonAscendant: PropTypes.bool


### PR DESCRIPTION
View implementation for react-native generates a Button in case the View has the onPress property defined.  RR reverting this part of the change for now as it is hard to control.