### PR TITLE
Fix Text props and docs

### DIFF
--- a/docs/docs/components/text.md
+++ b/docs/docs/components/text.md
@@ -16,25 +16,23 @@ Another difference between Text and other components is that Text children are n
 ## Props
 
 ``` javascript
-// Alternate text to display if the image cannot be loaded
-// or by screen readers
-accessibilityLabel: string = undefined;
-
-// Hide the component from screen readers?
-accessibilityHidden: boolean = false;
-
-// Traits used to hint screen readers, etc.
-accessibilityTraits: AccessibilityTrait | AccessibilityTrait[] = undefined;
-
-// Region for accessibility mechanisms
-accessibilityLiveRegion: AccessibilityLiveRegion =
-    undefined; // Android and web only
-
 // Should fonts be scaled according to system setting?
 allowFontScaling: boolean = true; // Android and iOS only
 
+// When numberOfLines is set, this prop defines how text will be truncated.
+// head: The line is displayed so that the end fits in the container and the missing 
+//       text at the beginning of the line is indicated by an ellipsis glyph. e.g., "...wxyz"
+// middle: The line is displayed so that the beginning and end fit in the container and
+//         the missing text in the middle is indicated by an ellipsis glyph. "ab...yz"
+// tail: The line is displayed so that the beginning fits in the container and the missing 
+//       text at the end of the line is indicated by an ellipsis glyph. e.g., "abcd..."
+ellipsizeMode: 'head' | 'middle' | 'tail'; // Android & iOS only
+
 // Specifies a unique id for an HTML element
 id: string = undefined; // Web only
+
+// Expose the element and/or its children as accessible to Screen readers
+importantForAccessibility: ImportantForAccessibility = ImportantForAccessibility.Yes;
 
 // Should the scale multiplier be capped when allowFontScaling is set to true?
 // Possible values include the following:
@@ -56,9 +54,6 @@ onContextMenu?: (e: SyntheticEvent) => void = undefined;
 
 // See below for supported styles
 style: TextStyleRuleSet | TextStyleRuleSet[] = [];
-
-// Keyboard tab order
-tabIndex: number = undefined;
 ```
 
 ## Styles

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -558,9 +558,6 @@ export interface TextPropsShared extends CommonProps {
 
     importantForAccessibility?: ImportantForAccessibility;
 
-    // Android only
-    elevation?: number;
-
     onPress?: (e: SyntheticEvent) => void;
 
     id?: string; // Web only. Needed for accessibility.

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -41,7 +41,6 @@ export class Text extends React.Component<Types.TextProps, {}> {
                 selectable={ this.props.selectable }
                 textBreakStrategy={ 'simple' }
                 ellipsizeMode={ this.props.ellipsizeMode }
-                elevation={ this.props.elevation }
             >
                 { this.props.children }
             </RN.Text>


### PR DESCRIPTION
1. Removing the Android-only `elevation` prop from Text.  This isn't a valid `RN.Text` prop.
2. Fixing Text documentation to accurately reflect the props.