### PR TITLE
Keyboard focusing/navigation support for the UWP platform.

### DIFF
--- a/docs/docs/components/scrollview.md
+++ b/docs/docs/components/scrollview.md
@@ -61,6 +61,9 @@ scrollEventThrottle: number = undefined;
 // or left/right (horizontal)
 scrollIndicatorInsets: ScrollIndicatorInsets = undefined;
 
+// Windows-only property to control tab navigation inside the view
+tabNavigation?: 'local' | 'cycle' | 'once';
+
 // If true, this scroll bar scrolls to the top when the user
 // taps on the status bar.
 scrollsToTop: boolean = false; // iOS only

--- a/docs/docs/components/scrollview.md
+++ b/docs/docs/components/scrollview.md
@@ -7,7 +7,7 @@ permalink: docs/components/scrollview.html
 next: components/text
 ---
 
-Like a View, this component is a container for other components. However, it supports scrolling (panning) and zooming so it is possible to view larger contents. 
+Like a View, this component is a container for other components. However, it supports scrolling (panning) and zooming so it is possible to view larger contents.
 
 ScrollViews must have a bounded height (or width, if it scrolls horizontally) since its children are of unbounded height (or width). To bound the dimensions of a ScrollView, either set the height/width directly or make sure that its parent's height/width is bounded.
 
@@ -20,7 +20,7 @@ bounces: boolean = true; // iOS only
 horizontal: boolean = false;
 vertical: boolean = true;
 
-// If the contents are smaller than the view port, should they be justified 
+// If the contents are smaller than the view port, should they be justified
 // to the top of the view (i.e. flex-start) or the end (flex-end)?
 justifyEnd: boolean = false;
 
@@ -61,9 +61,6 @@ scrollEventThrottle: number = undefined;
 // or left/right (horizontal)
 scrollIndicatorInsets: ScrollIndicatorInsets = undefined;
 
-// Windows-only property to control tab navigation inside the view
-tabNavigation?: 'local' | 'cycle' | 'once';
-
 // If true, this scroll bar scrolls to the top when the user
 // taps on the status bar.
 scrollsToTop: boolean = false; // iOS only
@@ -74,6 +71,9 @@ showsVerticalScrollIndicator: boolean = [same as horizontal];
 
 // See below for supported styles
 style: ViewStyleRuleSet | ViewStyleRuleSet[] = [];
+
+// Windows-only property to control tab navigation inside the view
+tabNavigation?: 'local' | 'cycle' | 'once';
 ```
 
 ## Styles

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -802,6 +802,9 @@ export interface ScrollViewProps extends ViewProps {
 
     // iOS-only property to control scroll indicator insets
     scrollIndicatorInsets?: ScrollIndicatorInsets;
+
+    // Windows-only property to control tab navigation inside the view
+    tabNavigation?: 'local' | 'cycle' | 'once';
 }
 
 // Link

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -63,7 +63,6 @@ export abstract class FocusManager {
     protected abstract /* static */ removeFocusListenerFromComponent(component: React.Component<any, any>, onFocus: () => void): void;
     protected abstract /* static */ focusComponent(component: React.Component<any, any>): boolean;
 
-    // protected abstract /* static */ focusFirst(last?: boolean): void;
     protected abstract /* static */ resetFocus() : void;
     protected abstract /* static */ _updateComponentFocusRestriction(storedComponent: StoredFocusableComponent): void;
 

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -18,6 +18,7 @@ export interface StoredFocusableComponent {
     onFocus: () => void;
     restricted: boolean;
     limitedCount: number;
+    latestFocused?: boolean;
     origTabIndex?: number;
     origAriaHidden?: string;
     removed?: boolean;
@@ -81,7 +82,16 @@ export abstract class FocusManager {
             restricted: false,
             limitedCount: 0,
             onFocus: () => {
-                FocusManager._currentFocusedComponent = storedComponent;
+                if (FocusManager._currentFocusedComponent !== storedComponent) {
+                    if (FocusManager._currentFocusedComponent && FocusManager._currentFocusedComponent.latestFocused) {
+                        delete FocusManager._currentFocusedComponent.latestFocused;
+                        this._updateComponentFocusRestriction(FocusManager._currentFocusedComponent);
+                    }
+
+                    FocusManager._currentFocusedComponent = storedComponent;
+                    FocusManager._currentFocusedComponent.latestFocused = true;
+                    this._updateComponentFocusRestriction(FocusManager._currentFocusedComponent);
+                }
             }
         };
 

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -1,0 +1,379 @@
+/**
+* FocusManager.ts
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* Manages focusable elements for better keyboard navigation.
+*/
+
+import React = require('react');
+import PropTypes = require('prop-types');
+
+let _lastComponentId: number = 0;
+
+export interface StoredFocusableComponent {
+    id: string;
+    component: React.Component<any, any>;
+    onFocus: () => void;
+    restricted: boolean;
+    limitedCount: number;
+    origTabIndex?: number;
+    origAriaHidden?: string;
+    removed?: boolean;
+    callbacks?: FocusableComponentStateCallback[];
+}
+
+export interface OriginalAttributeValues {
+    tabIndex: number|undefined;
+    ariaHidden: string|undefined;
+}
+
+export type FocusableComponentStateCallback = (restrictedOrLimited: boolean) => void;
+
+export abstract class FocusManager {
+    private static _rootFocusManager: FocusManager;
+
+    private static _restrictionStack: FocusManager[] = [];
+    private static _currentRestrictionOwner: FocusManager|undefined;
+    private static _restoreRestrictionTimer: number|undefined;
+    private static _pendingPrevFocusedComponent: StoredFocusableComponent|undefined;
+    private static _currentFocusedComponent: StoredFocusableComponent|undefined;
+    protected static _allFocusableComponents: { [id: string]: StoredFocusableComponent } = {};
+    protected static _skipFocusCheck = false;
+
+    private _parent: FocusManager|undefined;
+    private _isFocusLimited: boolean;
+    private _prevFocusedComponent: StoredFocusableComponent|undefined;
+    private _myFocusableComponentIds: { [id: string]: boolean } = {};
+
+    constructor(parent: FocusManager|undefined) {
+        if (parent) {
+            this._parent = parent;
+        } else if (FocusManager._rootFocusManager) {
+            console.error('FocusManager: root is already set');
+        } else {
+            FocusManager._rootFocusManager = this;
+        }
+    }
+
+    protected abstract /* static */ addFocusListenerOnComponent(component: React.Component<any, any>, onFocus: () => void): void;
+    protected abstract /* static */ removeFocusListenerFromComponent(component: React.Component<any, any>, onFocus: () => void): void;
+    protected abstract /* static */ focusComponent(component: React.Component<any, any>): boolean;
+
+    // protected abstract /* static */ focusFirst(last?: boolean): void;
+    protected abstract /* static */ resetFocus() : void;
+    protected abstract /* static */ _updateComponentFocusRestriction(storedComponent: StoredFocusableComponent): void;
+
+    // Whenever the focusable element is mounted, we let the application
+    // know so that FocusManager could account for this element during the
+    // focus restriction.
+    addFocusableComponent(component: React.Component<any, any>) {
+        if ((component as any)._focusableComponentId) {
+            return;
+        }
+
+        const componentId: string = 'fc-' + ++_lastComponentId;
+
+        let storedComponent: StoredFocusableComponent = {
+            id: componentId,
+            component: component,
+            restricted: false,
+            limitedCount: 0,
+            onFocus: () => {
+                FocusManager._currentFocusedComponent = storedComponent;
+            }
+        };
+
+        (component as any)._focusableComponentId = componentId;
+        FocusManager._allFocusableComponents[componentId] = storedComponent;
+
+        let withinRestrictionOwner: boolean = false;
+
+        for (let parent: FocusManager|undefined = this; parent; parent = parent._parent) {
+            parent._myFocusableComponentIds[componentId] = true;
+
+            if (FocusManager._currentRestrictionOwner === parent) {
+                withinRestrictionOwner = true;
+            }
+
+            if (parent._isFocusLimited) {
+                storedComponent.limitedCount++;
+            }
+        }
+
+        if (!withinRestrictionOwner && FocusManager._currentRestrictionOwner) {
+            storedComponent.restricted = true;
+        }
+
+        this._updateComponentFocusRestriction(storedComponent);
+
+        this.addFocusListenerOnComponent(component, storedComponent.onFocus);
+    }
+
+    removeFocusableComponent(component: React.Component<any, any>) {
+        const componentId: string = (component as any)._focusableComponentId;
+
+        if (componentId) {
+            const storedComponent: StoredFocusableComponent = FocusManager._allFocusableComponents[componentId];
+
+            this.removeFocusListenerFromComponent(component, storedComponent.onFocus);
+
+            storedComponent.removed = true;
+            storedComponent.restricted = false;
+            storedComponent.limitedCount = 0;
+
+            this._updateComponentFocusRestriction(storedComponent);
+
+            delete storedComponent.callbacks;
+
+            for (let parent: FocusManager|undefined = this; parent; parent = parent._parent) {
+                delete parent._myFocusableComponentIds[componentId];
+            }
+
+            delete FocusManager._allFocusableComponents[componentId];
+            delete (component as any)._focusableComponentId;
+        }
+    }
+
+    restrictFocusWithin(noFocusReset?: boolean) {
+        // Limit the focus received by the keyboard navigation to all
+        // the descendant focusable elements by setting tabIndex of all
+        // other elements to -1.
+        if (FocusManager._currentRestrictionOwner === this) {
+            return;
+        }
+
+        if (FocusManager._currentRestrictionOwner) {
+            this._removeFocusRestriction();
+        }
+
+        if (!this._prevFocusedComponent) {
+            this._prevFocusedComponent = FocusManager._pendingPrevFocusedComponent || FocusManager._currentFocusedComponent;
+        }
+
+        FocusManager._clearRestoreRestrictionTimeout();
+
+        FocusManager._restrictionStack.push(this);
+        FocusManager._currentRestrictionOwner = this;
+
+        Object.keys(FocusManager._allFocusableComponents).forEach(componentId => {
+            if (!(componentId in this._myFocusableComponentIds)) {
+                const storedComponent = FocusManager._allFocusableComponents[componentId];
+                storedComponent.restricted = true;
+                this._updateComponentFocusRestriction(storedComponent);
+            }
+        });
+
+        if (!noFocusReset) {
+            this.resetFocus();
+        }
+    }
+
+    removeFocusRestriction() {
+        // Restore the focus to the previous view with restrictFocusWithin or
+        // remove the restriction if there is no such view.
+        FocusManager._restrictionStack = FocusManager._restrictionStack.filter(focusManager => focusManager !== this);
+
+        if (FocusManager._currentRestrictionOwner === this) {
+            // We'll take care of setting the proper focus below,
+            // no need to do a regular check for focusout.
+            FocusManager._skipFocusCheck = true;
+
+            let prevFocusedComponent = this._prevFocusedComponent;
+            this._prevFocusedComponent = undefined;
+
+            this._removeFocusRestriction();
+            FocusManager._currentRestrictionOwner = undefined;
+
+            // Defer the previous restriction restoration to wait for the current view
+            // to be unmounted, or for the next restricted view to be mounted (like
+            // showing a modal after a popup).
+            FocusManager._clearRestoreRestrictionTimeout();
+            FocusManager._pendingPrevFocusedComponent = prevFocusedComponent;
+
+            FocusManager._restoreRestrictionTimer = setTimeout(() => {
+                FocusManager._restoreRestrictionTimer = undefined;
+                FocusManager._pendingPrevFocusedComponent = undefined;
+
+                const prevRestrictionOwner = FocusManager._restrictionStack.pop();
+
+                let needsFocusReset = true;
+
+                const currentFocusedComponent = FocusManager._currentFocusedComponent;
+                if (currentFocusedComponent && !currentFocusedComponent.removed &&
+                        !(currentFocusedComponent.id in this._myFocusableComponentIds)) {
+                    // The focus has been manually moved to something outside of the current
+                    // restriction scope, we should skip focusing the component which was
+                    // focused before the restriction and keep the focus as it is.
+                    prevFocusedComponent = undefined;
+                    needsFocusReset = false;
+                }
+
+                if (prevFocusedComponent && !prevFocusedComponent.removed &&
+                        !prevFocusedComponent.restricted && !prevFocusedComponent.limitedCount) {
+                    // If possible, focus the previously focused component.
+                    needsFocusReset = !this.focusComponent(prevFocusedComponent.component);
+                }
+
+                if (prevRestrictionOwner) {
+                    prevRestrictionOwner.restrictFocusWithin(true);
+                }
+
+                if (needsFocusReset) {
+                    this.resetFocus();
+                }
+            }, 100);
+        }
+    }
+
+    limitFocusWithin() {
+        if (this._isFocusLimited) {
+            return;
+        }
+
+        this._isFocusLimited = true;
+
+        Object.keys(this._myFocusableComponentIds).forEach(componentId => {
+            let storedComponent = FocusManager._allFocusableComponents[componentId];
+            storedComponent.limitedCount++;
+            this._updateComponentFocusRestriction(storedComponent);
+        });
+    }
+
+    removeFocusLimitation() {
+        if (!this._isFocusLimited) {
+            return;
+        }
+
+        Object.keys(this._myFocusableComponentIds).forEach(componentId => {
+            let storedComponent = FocusManager._allFocusableComponents[componentId];
+            storedComponent.limitedCount--;
+            this._updateComponentFocusRestriction(storedComponent);
+        });
+
+        this._isFocusLimited = false;
+    }
+
+    release() {
+        this.removeFocusRestriction();
+        this.removeFocusLimitation();
+    }
+
+    subscribe(component: React.Component<any, any>, callback: FocusableComponentStateCallback) {
+        const storedComponent = FocusManager._getStoredComponent(component);
+
+        if (storedComponent) {
+            if (!storedComponent.callbacks) {
+                storedComponent.callbacks = [];
+            }
+
+            storedComponent.callbacks.push(callback);
+        }
+    }
+
+    unsubscribe(component: React.Component<any, any>, callback: FocusableComponentStateCallback) {
+        const storedComponent = FocusManager._getStoredComponent(component);
+
+        if (storedComponent && storedComponent.callbacks) {
+            storedComponent.callbacks = storedComponent.callbacks.filter(cb => {
+                return cb !== callback;
+            });
+        }
+    }
+
+    isComponentFocusRestrictedOrLimited(component: React.Component<any, any>): boolean {
+        const storedComponent = FocusManager._getStoredComponent(component);
+        return !!storedComponent && (storedComponent.restricted || storedComponent.limitedCount > 0);
+    }
+
+    private static _getStoredComponent(component: React.Component<any, any>): StoredFocusableComponent|undefined {
+        const componentId: string = (component as any)._focusableComponentId;
+
+        if (componentId) {
+            return FocusManager._allFocusableComponents[componentId];
+        }
+
+        return undefined;
+    }
+
+    protected static _callFocusableComponentStateChangeCallbacks(storedComponent: StoredFocusableComponent, restrictedOrLimited: boolean) {
+        if (!storedComponent.callbacks) {
+            return;
+        }
+
+        storedComponent.callbacks.forEach(callback => {
+            callback.call(storedComponent.component, restrictedOrLimited);
+        });
+    }
+
+    private /* static */ _removeFocusRestriction() {
+        Object.keys(FocusManager._allFocusableComponents).forEach(componentId => {
+            let storedComponent = FocusManager._allFocusableComponents[componentId];
+            storedComponent.restricted = false;
+            this._updateComponentFocusRestriction(storedComponent);
+        });
+    }
+
+    private static _clearRestoreRestrictionTimeout() {
+        if (FocusManager._restoreRestrictionTimer) {
+            clearTimeout(FocusManager._restoreRestrictionTimer);
+            FocusManager._restoreRestrictionTimer = undefined;
+            FocusManager._pendingPrevFocusedComponent = undefined;
+        }
+    }
+}
+
+// A mixin for the focusable elements, to tell the views that
+// they exist and should be accounted during the focus restriction.
+//
+// isConditionallyFocusable is an optional callback which will be
+// called for componentDidMount() or for componentWillUpdate() to
+// determine if the component is actually focusable.
+export function applyFocusableComponentMixin(Component: any, isConditionallyFocusable?: Function) {
+    let contextTypes = Component.contextTypes || {};
+    contextTypes.focusManager = PropTypes.object;
+    Component.contextTypes = contextTypes;
+
+    inheritMethod('componentDidMount', function (this: React.Component<any, any>, focusManager: FocusManager) {
+        if (!isConditionallyFocusable || isConditionallyFocusable.call(this)) {
+            focusManager.addFocusableComponent(this);
+        }
+    });
+
+    inheritMethod('componentWillUnmount', function (this: React.Component<any, any>, focusManager: FocusManager) {
+        focusManager.removeFocusableComponent(this);
+    });
+
+    inheritMethod('componentWillUpdate', function (this: React.Component<any, any>, focusManager: FocusManager, origArguments: IArguments) {
+        if (isConditionallyFocusable) {
+            let isFocusable = isConditionallyFocusable.apply(this, origArguments);
+
+            if (isFocusable && !(this as any)._focusableComponentId) {
+                focusManager.addFocusableComponent(this);
+            } else if (!isFocusable && (this as any)._focusableComponentId) {
+                focusManager.removeFocusableComponent(this);
+            }
+        }
+    });
+
+    function inheritMethod(methodName: string, action: Function) {
+        let origCallback = Component.prototype[methodName];
+
+        Component.prototype[methodName] = function () {
+            let focusManager: FocusManager = this._focusManager || (this.context && this.context.focusManager);
+
+            if (focusManager) {
+                action.call(this, focusManager, arguments);
+            } else {
+                console.error('FocusableComponentMixin: context error!');
+            }
+
+            if (origCallback) {
+                origCallback.apply(this, arguments);
+            }
+        };
+    }
+}
+
+export default FocusManager;

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -14,11 +14,11 @@ let _lastComponentId: number = 0;
 
 export interface StoredFocusableComponent {
     id: string;
+    numericId: number;
     component: React.Component<any, any>;
     onFocus: () => void;
     restricted: boolean;
     limitedCount: number;
-    latestFocused?: boolean;
     origTabIndex?: number;
     origAriaHidden?: string;
     removed?: boolean;
@@ -39,9 +39,10 @@ export abstract class FocusManager {
     private static _currentRestrictionOwner: FocusManager|undefined;
     private static _restoreRestrictionTimer: number|undefined;
     private static _pendingPrevFocusedComponent: StoredFocusableComponent|undefined;
-    private static _currentFocusedComponent: StoredFocusableComponent|undefined;
+    protected static _currentFocusedComponent: StoredFocusableComponent|undefined;
     protected static _allFocusableComponents: { [id: string]: StoredFocusableComponent } = {};
     protected static _skipFocusCheck = false;
+    protected static _resetFocusTimer: number | undefined;
 
     private _parent: FocusManager|undefined;
     private _isFocusLimited: boolean;
@@ -74,24 +75,17 @@ export abstract class FocusManager {
             return;
         }
 
-        const componentId: string = 'fc-' + ++_lastComponentId;
+        const numericComponentId = ++_lastComponentId;
+        const componentId: string = 'fc-' + numericComponentId;
 
         let storedComponent: StoredFocusableComponent = {
             id: componentId,
+            numericId: numericComponentId,
             component: component,
             restricted: false,
             limitedCount: 0,
             onFocus: () => {
-                if (FocusManager._currentFocusedComponent !== storedComponent) {
-                    if (FocusManager._currentFocusedComponent && FocusManager._currentFocusedComponent.latestFocused) {
-                        delete FocusManager._currentFocusedComponent.latestFocused;
-                        this._updateComponentFocusRestriction(FocusManager._currentFocusedComponent);
-                    }
-
-                    FocusManager._currentFocusedComponent = storedComponent;
-                    FocusManager._currentFocusedComponent.latestFocused = true;
-                    this._updateComponentFocusRestriction(FocusManager._currentFocusedComponent);
-                }
+                FocusManager._currentFocusedComponent = storedComponent;
             }
         };
 

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -10,6 +10,8 @@
 import React = require('react');
 import PropTypes = require('prop-types');
 
+import AppConfig from '../../common/AppConfig';
+
 let _lastComponentId: number = 0;
 
 export interface StoredFocusableComponent {
@@ -53,7 +55,9 @@ export abstract class FocusManager {
         if (parent) {
             this._parent = parent;
         } else if (FocusManager._rootFocusManager) {
-            console.error('FocusManager: root is already set');
+            if (AppConfig.isDevelopmentMode()) {
+                console.error('FocusManager: root is already set');
+            }
         } else {
             FocusManager._rootFocusManager = this;
         }
@@ -373,7 +377,9 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
             if (focusManager) {
                 action.call(this, focusManager, arguments);
             } else {
-                console.error('FocusableComponentMixin: context error!');
+                if (AppConfig.isDevelopmentMode()) {
+                    console.error('FocusableComponentMixin: context error!');
+                }
             }
 
             if (origCallback) {

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -297,6 +297,10 @@ export abstract class FocusManager {
         return !!storedComponent && (storedComponent.restricted || storedComponent.limitedCount > 0);
     }
 
+    static getCurrentFocusedComponent(): string | undefined {
+        return FocusManager._currentFocusedComponent ? FocusManager._currentFocusedComponent.id : undefined;
+    }
+
     private static _getStoredComponent(component: React.Component<any, any>): StoredFocusableComponent|undefined {
         const componentId: string = (component as any)._focusableComponentId;
 

--- a/src/macos/TextInput.tsx
+++ b/src/macos/TextInput.tsx
@@ -72,7 +72,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
                 defaultValue={ this.props.value }
                 placeholderTextColor={ this.props.placeholderTextColor }
                 onSubmitEditing={this.props.onSubmitEditing }
-                onKeyPress={ this._onKeyPress as any}
+                onKeyPress={ this._onKeyPress as any }
                 onChangeText={ this._onChangeText }
                 onSelectionChange={ this._onSelectionChange as any }
                 onFocus={ this._onFocus }

--- a/src/macos/TextInput.tsx
+++ b/src/macos/TextInput.tsx
@@ -7,11 +7,11 @@
 * RN-specific implementation of the cross-platform TextInput abstraction.
 */
 
-import _ = require('../native-common/lodashMini');
 import React = require('react');
 import RN = require('react-native');
 
 import AccessibilityUtil from './AccessibilityUtil';
+import EventHelpers from '../native-common/utils/EventHelpers';
 import Styles from '../native-common/Styles';
 import Types = require('../common/Types');
 
@@ -72,7 +72,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
                 defaultValue={ this.props.value }
                 placeholderTextColor={ this.props.placeholderTextColor }
                 onSubmitEditing={this.props.onSubmitEditing }
-                onKeyPress={ this._onKeyPress as any }
+                onKeyPress={ this._onKeyPress as any}
                 onChangeText={ this._onChangeText }
                 onSelectionChange={ this._onSelectionChange as any }
                 onFocus={ this._onFocus }
@@ -142,106 +142,10 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
         this.forceUpdate();
     }
 
-    private _onKeyPress = (e: React.KeyboardEvent<TextInput>) => {
+    private _onKeyPress = (e: React.SyntheticEvent<any>) => {
+
         if (this.props.onKeyPress) {
-            let keyName: string = (e.nativeEvent as any).key;
-            let keyCode: number = 0;
-
-            if (keyName.length === 1) {
-                keyCode = keyName.charCodeAt(0);
-            } else {
-                switch (keyName) {
-                    case 'Backspace':
-                        keyCode = 8;
-                        break;
-
-                    case 'Tab':
-                        keyCode = 9;
-                        break;
-
-                    case 'Enter':
-                        keyCode = 13;
-                        break;
-
-                    case 'Shift':
-                        keyCode = 16;
-                        break;
-
-                    case 'Control':
-                        keyCode = 17;
-                        break;
-
-                    case 'Alt':
-                        keyCode = 18;
-                        break;
-
-                    case 'Escape':
-                        keyCode = 27;
-                        break;
-
-                    case 'Space':
-                        keyCode = 32;
-                        break;
-
-                    case 'PageUp':
-                        keyCode = 92;
-                        break;
-
-                    case 'PageDown':
-                        keyCode = 93;
-                        break;
-
-                    case 'ArrowLeft':
-                        keyCode = 21;
-                        break;
-
-                    case 'ArrowUp':
-                        keyCode = 19;
-                        break;
-
-                    case 'ArrowRight':
-                        keyCode = 22;
-                        break;
-
-                    case 'ArrowDown':
-                        keyCode = 20;
-                        break;
-
-                    case 'Delete':
-                        keyCode = 8;
-                        break;
-                }
-            }
-
-            // We need to add keyCode to the original event, but React Native
-            // reuses events, so we're not allowed to modify the original.
-            // Instead, we'll clone it.
-            let keyEvent = _.clone(e);
-            keyEvent.keyCode = keyCode;
-            if (e.nativeEvent.shiftKey) {
-                keyEvent.shiftKey = e.nativeEvent.shiftKey;
-            }
-            if (e.nativeEvent.ctrlKey) {
-                keyEvent.ctrlKey = e.nativeEvent.ctrlKey;
-            }
-            if (e.nativeEvent.altKey) {
-                keyEvent.altKey = e.nativeEvent.altKey;
-            }
-            if (e.nativeEvent.metaKey) {
-                keyEvent.metaKey = e.nativeEvent.metaKey;
-            }
-            keyEvent.stopPropagation = () => {
-                if (e.stopPropagation) {
-                    e.stopPropagation();
-                }
-            };
-            keyEvent.preventDefault = () => {
-                if (e.preventDefault) {
-                    e.preventDefault();
-                }
-            };
-
-            this.props.onKeyPress(keyEvent);
+            this.props.onKeyPress(EventHelpers.toKeyboardEvent(e));
         }
     }
 

--- a/src/native-common/App.ts
+++ b/src/native-common/App.ts
@@ -39,11 +39,15 @@ export class App extends RX.App {
     initialize(debug: boolean, development: boolean) {
         super.initialize(debug, development);
         window['rxdebug'] = debug;
-        RN.AppRegistry.registerComponent('RXApp', () => RootView);
+        RN.AppRegistry.registerComponent('RXApp', this.getRootViewFactory());
     }
 
     getActivationState(): Types.AppActivationState {
         return _rnStateToRxState[RN.AppState.currentState];
+    }
+
+    protected getRootViewFactory(): Function {
+        return () => RootView;
     }
 }
 

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -134,7 +134,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         let internalProps: RN.ViewProps = {
             ref: this._onButtonRef,
             style: Styles.combine([_styles.defaultButton, this.props.style, opacityStyle,
-                            this.props.disabled && _styles.disabled]),
+                this.props.disabled && _styles.disabled]),
             accessibilityLabel: this.props.accessibilityLabel || this.props.title,
             accessibilityTraits: accessibilityTrait,
             accessibilityComponentType: accessibilityComponentType,

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -86,7 +86,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
 
     private _isMounted = false;
     private _hideTimeout: number|undefined;
-    private _buttonElement: RN.Animated.View|undefined;
+    private _buttonElement: RN.Animated.View|null = null;
     private _defaultOpacityValue: number|undefined;
     private _opacityAnimatedValue: RN.Animated.Value|undefined;
     private _opacityAnimatedStyle: Types.AnimatedViewStyleRuleSet|undefined;
@@ -259,7 +259,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         }
     }
 
-    private _onButtonRef = (btn: RN.Animated.View): void => {
+    private _onButtonRef = (btn: RN.Animated.View|null): void => {
         this._buttonElement = btn;
     }
 

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -109,6 +109,17 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         }
     }
 
+    protected _render(internalProps: RN.ViewProps): JSX.Element {
+
+        return (
+            <RN.Animated.View
+                {...internalProps}
+             >
+                { this.props.children }
+            </RN.Animated.View>
+        );
+    }
+
     render() {
         // Accessibility props.
         const importantForAccessibility = AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility,
@@ -120,27 +131,25 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
 
         const opacityStyle = !this.props.disableTouchOpacityAnimation && this._opacityAnimatedStyle;
 
-        return (
-            <RN.Animated.View
-                ref={ this._onButtonRef }
-                style={ Styles.combine([_styles.defaultButton, this.props.style, opacityStyle,
-                    this.props.disabled && _styles.disabled]) }
-                accessibilityLabel={ this.props.accessibilityLabel || this.props.title }
-                accessibilityTraits={ accessibilityTrait }
-                accessibilityComponentType={ accessibilityComponentType }
-                importantForAccessibility={ importantForAccessibility }
-                onStartShouldSetResponder={ this.touchableHandleStartShouldSetResponder }
-                onResponderTerminationRequest={ this.touchableHandleResponderTerminationRequest }
-                onResponderGrant={ this.touchableHandleResponderGrant }
-                onResponderMove={ this.touchableHandleResponderMove }
-                onResponderRelease={ this.touchableHandleResponderRelease }
-                onResponderTerminate={ this.touchableHandleResponderTerminate }
-                shouldRasterizeIOS={ this.props.shouldRasterizeIOS }
-                onAccessibilityTapIOS={ this.props.onAccessibilityTapIOS }
-            >
-                { this.props.children }
-            </RN.Animated.View>
-        );
+        let internalProps: RN.ViewProps = {
+            ref: this._onButtonRef,
+            style: Styles.combine([_styles.defaultButton, this.props.style, opacityStyle,
+                            this.props.disabled && _styles.disabled]),
+            accessibilityLabel: this.props.accessibilityLabel || this.props.title,
+            accessibilityTraits: accessibilityTrait,
+            accessibilityComponentType: accessibilityComponentType,
+            importantForAccessibility: importantForAccessibility,
+            onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,
+            onResponderTerminationRequest: this.touchableHandleResponderTerminationRequest,
+            onResponderGrant: this.touchableHandleResponderGrant,
+            onResponderMove: this.touchableHandleResponderMove,
+            onResponderRelease: this.touchableHandleResponderRelease,
+            onResponderTerminate: this.touchableHandleResponderTerminate,
+            shouldRasterizeIOS: this.props.shouldRasterizeIOS,
+            onAccessibilityTapIOS: this.props.onAccessibilityTapIOS,
+        };
+
+        return this._render(internalProps);
     }
 
     componentDidMount() {

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -110,10 +110,9 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
     }
 
     protected _render(internalProps: RN.ViewProps): JSX.Element {
-
         return (
             <RN.Animated.View
-                {...internalProps}
+                { ...internalProps }
              >
                 { this.props.children }
             </RN.Animated.View>
@@ -146,7 +145,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
             onResponderRelease: this.touchableHandleResponderRelease,
             onResponderTerminate: this.touchableHandleResponderTerminate,
             shouldRasterizeIOS: this.props.shouldRasterizeIOS,
-            onAccessibilityTapIOS: this.props.onAccessibilityTapIOS,
+            onAccessibilityTapIOS: this.props.onAccessibilityTapIOS
         };
 
         return this._render(internalProps);
@@ -327,7 +326,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         this._buttonElement.setNativeProps({
             style: [{
                 backgroundColor: _underlayInactive
-            }, this.props.style],
+            }, this.props.style]
         });
     }
 }

--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -79,7 +79,7 @@ export class FrontLayerViewManager {
     public showPopup(
         popupOptions: Types.PopupOptions, popupId: string, delay?: number): boolean {
         const index = this._findIndexOfPopup(popupId);
-        
+
         if (index === -1) {
             this._overlayStack.push(new PopupStackContext(popupId, popupOptions, RN.findNodeHandle(popupOptions.getAnchor())));
 
@@ -117,9 +117,9 @@ export class FrontLayerViewManager {
             return null;
         }
 
-        const overlayContext = 
+        const overlayContext =
             _.findLast(
-                this._overlayStack, 
+                this._overlayStack,
                 context => context instanceof ModalStackContext && this.modalOptionsMatchesRootViewId(context.modalOptions, rootViewId)
             ) as ModalStackContext;
 
@@ -131,6 +131,14 @@ export class FrontLayerViewManager {
             );
         }
 
+        return null;
+    }
+
+    public getActivePopupId() : string | null {
+        let activeOverlay = this._getActiveOverlay();
+        if (activeOverlay && (activeOverlay instanceof PopupStackContext)) {
+            return activeOverlay.popupId;
+        }
         return null;
     }
 
@@ -146,9 +154,9 @@ export class FrontLayerViewManager {
             return null;
         }
 
-        const overlayContext = 
+        const overlayContext =
             _.findLast(
-                this._overlayStack, 
+                this._overlayStack,
                 context => context instanceof PopupStackContext && context.popupOptions.rootViewId === rootViewId
             ) as PopupStackContext;
 
@@ -188,16 +196,16 @@ export class FrontLayerViewManager {
                     activePopupContext.anchorHandle,
                     (x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
                         const touchEvent = e.nativeEvent as any;
-                        let anchorRect: ClientRect = { left: x, top: y, right: x + width, 
+                        let anchorRect: ClientRect = { left: x, top: y, right: x + width,
                                 bottom: y + height, width: width, height: height };
 
                         // Find out if the press event was on the anchor so we can notify the caller about it.
                         if (!_.isUndefined(touchEvent.pageX) && !_.isUndefined(touchEvent.pageY) &&
                                 touchEvent.pageX >= anchorRect.left && touchEvent.pageX < anchorRect.right
                                 && touchEvent.pageY >= anchorRect.top && touchEvent.pageY < anchorRect.bottom) {
-                            // Showing another animation while dimissing the popup creates a conflict in the 
+                            // Showing another animation while dimissing the popup creates a conflict in the
                             // UI making it not doing one of the two animations (i.e.: Opening an actionsheet
-                            // while dismissing a popup). We introduce this delay to make sure the popup 
+                            // while dismissing a popup). We introduce this delay to make sure the popup
                             // dimissing animation has finished before we call the event handler.
                             setTimeout(() => { activePopupContext.popupOptions.onAnchorPressed!!!(e); }, 500);
                         }

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -108,8 +108,8 @@ export class Image extends React.Component<Types.ImageProps, {}> implements Reac
     }
 
     getChildContext() {
-        // Let descendant Types components know that their nearest Types ancestor is not an Types.Text.
-        // Because they're in an Types.View/etc, they should use their normal styling rather than their
+        // Let descendant RX components know that their nearest RX ancestor is not an RX.Text.
+        // Because they're in an RX.View/etc, they should use their normal styling rather than their
         // special styling for appearing inline with text.
         return { isRxParentAText: false };
     }

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -7,6 +7,7 @@
 * RN-specific implementation of the cross-platform Image abstraction.
 */
 
+import PropTypes = require('prop-types');
 import React = require('react');
 import RN = require('react-native');
 import SyncTasks = require('synctasks');
@@ -24,7 +25,15 @@ const _styles = {
     })
 };
 
-export class Image extends React.Component<Types.ImageProps, {}> {
+export interface ImageContext {
+    isRxParentAText?: boolean;
+}
+
+export class Image extends React.Component<Types.ImageProps, {}> implements React.ChildContextProvider<ImageContext> {
+    static childContextTypes: React.ValidationMap<any> = {
+        isRxParentAText: PropTypes.bool.isRequired,
+    };
+
     static prefetch(url: string): SyncTasks.Promise<boolean> {
         const defer = SyncTasks.Defer<boolean>();
 
@@ -96,6 +105,13 @@ export class Image extends React.Component<Types.ImageProps, {}> {
         if (this._mountedComponent) {
             this._mountedComponent.setNativeProps(nativeProps);
         }
+    }
+
+    getChildContext() {
+        // Let descendant Types components know that their nearest Types ancestor is not an Types.Text.
+        // Because they're in an Types.View/etc, they should use their normal styling rather than their
+        // special styling for appearing inline with text.
+        return { isRxParentAText: false };
     }
 
     protected getStyles() {

--- a/src/native-common/Link.tsx
+++ b/src/native-common/Link.tsx
@@ -33,7 +33,7 @@ export class Link extends React.Component<Types.LinkProps, {}> {
             onLongPress: this._onLongPress,
             allowFontScaling: this.props.allowFontScaling,
             maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
-            children: this.props.children,
+            children: this.props.children
         };
 
         return this._render(internalProps);

--- a/src/native-common/Link.tsx
+++ b/src/native-common/Link.tsx
@@ -44,7 +44,7 @@ export class Link extends React.Component<Types.LinkProps, {}> {
         this._mountedComponent = component;
     }
 
-    private _onPress = (e: RX.Types.SyntheticEvent) => {
+    protected _onPress = (e: RX.Types.SyntheticEvent) => {
         if (this.props.onPress) {
             this.props.onPress(e, this.props.url);
             return;
@@ -58,11 +58,11 @@ export class Link extends React.Component<Types.LinkProps, {}> {
         }
     }
 
-    private _onLongPress = (e: RX.Types.SyntheticEvent) => {
+    protected _onLongPress = (e: RX.Types.SyntheticEvent) => {
         if (this.props.onLongPress) {
             this.props.onLongPress(e, this.props.url);
         }
-    }    
+    }
 }
 
 export default Link;

--- a/src/native-common/Link.tsx
+++ b/src/native-common/Link.tsx
@@ -25,18 +25,25 @@ export class Link extends React.Component<Types.LinkProps, {}> {
     }
 
     render() {
+        let internalProps: RN.TextProps = {
+            ref: this._onMount,
+            style: this.props.style,
+            numberOfLines: this.props.numberOfLines === 0 ? undefined : this.props.numberOfLines,
+            onPress: this._onPress,
+            onLongPress: this._onLongPress,
+            allowFontScaling: this.props.allowFontScaling,
+            maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
+            children: this.props.children,
+        };
+
+        return this._render(internalProps);
+    }
+
+    protected _render(internalProps: RN.TextProps) {
         return (
             <RN.Text
-                style={ this.props.style }
-                ref={ this._onMount }
-                numberOfLines={ this.props.numberOfLines === 0 ? undefined : this.props.numberOfLines }
-                onPress={ this._onPress }
-                onLongPress={ this._onLongPress }
-                allowFontScaling={ this.props.allowFontScaling }
-                maxContentSizeMultiplier={ this.props.maxContentSizeMultiplier }
-            >
-                { this.props.children }
-            </RN.Text>
+                { ...internalProps }
+            />
         );
     }
 

--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -22,9 +22,9 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
     protected _render(props: RN.ScrollViewProps): JSX.Element {
         return (
             <RN.ScrollView
-                {...props}
+                { ...props }
             >
-                {props.children}
+                { props.children }
             </RN.ScrollView>
         );
     }
@@ -38,14 +38,14 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
         }
 
         var layoutCallback = this.props.onLayout ?
-                // We have a callback function, call the wrapper
-                this._onLayout :
-                undefined;
+            // We have a callback function, call the wrapper
+            this._onLayout :
+            undefined;
 
         var scrollCallback = this.props.onScroll ?
-                // We have a callback function, call the wrapper
-                this._onScroll :
-                undefined;
+            // We have a callback function, call the wrapper
+            this._onScroll :
+            undefined;
 
         const keyboardShouldPersistTaps = (this.props.keyboardShouldPersistTaps ? 'always' : 'never');
 

--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -19,6 +19,16 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
     private _scrollLeft = 0;
     protected _nativeView: RN.ScrollView|undefined;
 
+    protected _render(props: RN.ScrollViewProps): JSX.Element {
+        return (
+            <RN.ScrollView
+                {...props}
+            >
+                {props.children}
+            </RN.ScrollView>
+        );
+    }
+
     render() {
         let scrollThrottle = this.props.scrollEventThrottle || 16;
 
@@ -37,14 +47,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
                 this._onScroll :
                 undefined;
 
-        // TODO: #737970 Remove special case for UWP when this bug is fixed. The bug
-        //   causes you to have to click twice instead of once on some pieces of UI in
-        //   order for the UI to acknowledge your interaction.
-        const keyboardShouldPersistTaps = (
-            RN.Platform.OS === 'windows'
-                ? 'always'
-                : (this.props.keyboardShouldPersistTaps ? 'always' : 'never')
-        );
+        const keyboardShouldPersistTaps = (this.props.keyboardShouldPersistTaps ? 'always' : 'never');
 
         // NOTE: We are setting `automaticallyAdjustContentInsets` to false
         // (http://facebook.github.io/react-native/docs/scrollview.html#automaticallyadjustcontentinsets). The
@@ -56,35 +59,35 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
         // set to true.
         // We also set removeClippedSubviews to false, overriding the default value. Most of the scroll views
         // we use are virtualized anyway.
-        return (
-            <RN.ScrollView
-                ref={ this._setNativeView }
-                style={ this.props.style }
-                onScroll={ scrollCallback }
-                automaticallyAdjustContentInsets={ false }
-                showsHorizontalScrollIndicator={ this.props.showsHorizontalScrollIndicator }
-                showsVerticalScrollIndicator={ this.props.showsVerticalScrollIndicator }
-                keyboardDismissMode={  this.props.keyboardDismissMode }
-                keyboardShouldPersistTaps={ keyboardShouldPersistTaps }
-                scrollEnabled={ this.props.scrollEnabled }
-                onContentSizeChange={ this.props.onContentSizeChange }
-                onLayout={ layoutCallback }
-                scrollEventThrottle={ scrollThrottle }
-                horizontal={ this.props.horizontal }
-                bounces={ this.props.bounces }
-                pagingEnabled={ this.props.pagingEnabled }
-                snapToInterval={ this.props.snapToInterval }
-                onMoveShouldSetResponder={ this.props.onMoveShouldSetResponder }
-                scrollsToTop={ this.props.scrollsToTop }
-                removeClippedSubviews={ false }
-                overScrollMode={ this.props.overScrollMode }
-                scrollIndicatorInsets={ this.props.scrollIndicatorInsets }
-                onScrollBeginDrag={ this.props.onScrollBeginDrag }
-                onScrollEndDrag={ this.props.onScrollEndDrag }
-            >
-                { this.props.children }
-            </RN.ScrollView>
-        );
+
+        const internalProps: RN.ScrollViewProps = {
+            ref: this._setNativeView,
+            style: this.props.style,
+            onScroll: scrollCallback,
+            automaticallyAdjustContentInsets: false,
+            showsHorizontalScrollIndicator: this.props.showsHorizontalScrollIndicator,
+            showsVerticalScrollIndicator: this.props.showsVerticalScrollIndicator,
+            keyboardDismissMode:  this.props.keyboardDismissMode,
+            keyboardShouldPersistTaps: keyboardShouldPersistTaps,
+            scrollEnabled: this.props.scrollEnabled,
+            onContentSizeChange: this.props.onContentSizeChange,
+            onLayout: layoutCallback,
+            scrollEventThrottle: scrollThrottle,
+            horizontal: this.props.horizontal,
+            bounces: this.props.bounces,
+            pagingEnabled: this.props.pagingEnabled,
+            snapToInterval: this.props.snapToInterval,
+            onMoveShouldSetResponder: this.props.onMoveShouldSetResponder,
+            scrollsToTop: this.props.scrollsToTop,
+            removeClippedSubviews: false,
+            overScrollMode: this.props.overScrollMode,
+            scrollIndicatorInsets: this.props.scrollIndicatorInsets,
+            onScrollBeginDrag: this.props.onScrollBeginDrag,
+            onScrollEndDrag: this.props.onScrollEndDrag,
+            children: this.props.children
+        };
+
+        return this._render(internalProps);
     }
 
     private _onScroll = (event: React.SyntheticEvent<ScrollView>) => {

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -8,6 +8,7 @@
 */
 
 import _ = require('./lodashMini');
+import PropTypes = require('prop-types');
 import React = require('react');
 import RN = require('react-native');
 
@@ -21,7 +22,14 @@ const _styles = {
     })
 };
 
-export class Text extends React.Component<Types.TextProps, {}> {
+export interface TextContext {
+    isRxParentAText?: boolean;
+}
+
+export class Text extends React.Component<Types.TextProps, {}> implements React.ChildContextProvider<TextContext> {
+    static childContextTypes: React.ValidationMap<any> = {
+        isRxParentAText: PropTypes.bool.isRequired,
+    };
     protected _mountedComponent: RN.ReactNativeBaseComponent<any, any>|null = null;
 
     // To be able to use Text inside TouchableHighlight/TouchableOpacity
@@ -53,6 +61,13 @@ export class Text extends React.Component<Types.TextProps, {}> {
 
     protected _onMount = (component: RN.ReactNativeBaseComponent<any, any>|null) => {
         this._mountedComponent = component;
+    }
+
+    getChildContext() {
+        // Let descendant Types components know that their nearest Types ancestor is an Types.Text.
+        // Because they're in an Types.Text, they should style themselves specially for appearing
+        // inline with text.
+        return { isRxParentAText: true };
     }
 
     protected _getStyles(): Types.StyleRuleSetRecursiveArray<Types.TextStyleRuleSet> {

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -64,8 +64,8 @@ export class Text extends React.Component<Types.TextProps, {}> implements React.
     }
 
     getChildContext() {
-        // Let descendant Types components know that their nearest Types ancestor is an Types.Text.
-        // Because they're in an Types.Text, they should style themselves specially for appearing
+        // Let descendant RX components know that their nearest RX ancestor is an RX.Text.
+        // Because they're in an RX.Text, they should style themselves specially for appearing
         // inline with text.
         return { isRxParentAText: true };
     }

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -54,7 +54,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
     protected _render(props: RN.TextInputProps): JSX.Element {
         return (
             <RN.TextInput
-                {...props}
+                { ...props }
             />
         );
     }
@@ -152,7 +152,6 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
     }
 
     private _onKeyPress = (e: React.SyntheticEvent<any>) => {
-
         if (this.props.onKeyPress) {
             this.props.onKeyPress(EventHelpers.toKeyboardEvent(e));
         }

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -11,7 +11,7 @@ import React = require('react');
 import RN = require('react-native');
 
 import AccessibilityUtil from './AccessibilityUtil';
-import EventHelpers from '../native-common/utils/EventHelpers';
+import EventHelpers from './utils/EventHelpers';
 import Styles from './Styles';
 import Types = require('../common/Types');
 
@@ -31,6 +31,8 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
     private _selectionStart: number = 0;
     private _selectionEnd: number = 0;
     private _mountedComponent: RN.ReactNativeBaseComponent<any, any>|null = null;
+
+    protected _textInputRef: RN.TextInput|null = null;
 
     constructor(props: Types.TextInputProps) {
         super(props);
@@ -62,7 +64,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
         const blurOnSubmit = this.props.blurOnSubmit || !this.props.multiline;
 
         const internalProps: RN.TextInputProps = {
-            ref: this._mountedComponent,
+            ref: this._onMount,
             multiline: this.props.multiline,
             style: Styles.combine([_styles.defaultTextInput, this.props.style]),
             value: this.state.inputValue,

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -1,0 +1,138 @@
+/**
+* EventHelpers.ts
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*/
+import _ = require('../../native-common/lodashMini');
+import Types = require('../../common/Types');
+
+//
+// These helpers promote a SyntheticEvent to their higher level counterparts
+export class EventHelpers {
+
+    toKeyboardEvent(e: Types.SyntheticEvent): Types.KeyboardEvent {
+        // Conversion to a KeyboardEvent-like event if needed
+        let keyEvent = e as Types.KeyboardEvent;
+        if (keyEvent.keyCode === undefined) {
+
+            // Currently some key codes are dependent on platform. React Native proper (the iOS and Android platforms) have different
+            // keycodes for arrow keys when comparing with React (JS).
+            // We align the keycodes for nativre desktop platforms to the other native ones, as a workaround.
+            // Ideally all key codes should be consistent OR a set of constants should be exposed by ReactXP.
+            let keyName: string = (e.nativeEvent as any).key;
+            let keyCode: number = 0;
+
+            if (keyName.length === 1) {
+                keyCode = keyName.charCodeAt(0);
+            } else {
+                switch (keyName) {
+                    case 'Backspace':
+                        keyCode = 8;
+                        break;
+
+                    case 'Tab':
+                        keyCode = 9;
+                        break;
+
+                    case 'Enter':
+                        keyCode = 13;
+                        break;
+
+                    case 'Shift':
+                        keyCode = 16;
+                        break;
+
+                    case 'Control':
+                        keyCode = 17;
+                        break;
+
+                    case 'Alt':
+                        keyCode = 18;
+                        break;
+
+                    case 'Escape':
+                        keyCode = 27;
+                        break;
+
+                    case 'Space':
+                        keyCode = 32;
+                        break;
+
+                    case 'PageUp':
+                        keyCode = 92;
+                        break;
+
+                    case 'PageDown':
+                        keyCode = 93;
+                        break;
+
+                    case 'Left':
+                    case 'ArrowLeft':
+                        keyCode = 21;
+                        break;
+
+                    case 'Up':
+                    case 'ArrowUp':
+                        keyCode = 19;
+                        break;
+
+                    case 'Right':
+                    case 'ArrowRight':
+                        keyCode = 22;
+                        break;
+
+                    case 'Down':
+                    case 'ArrowDown':
+                        keyCode = 20;
+                        break;
+
+                    case 'Delete':
+                        keyCode = 8;
+                        break;
+                }
+            }
+
+            // We need to add keyCode to the original event, but React Native
+            // reuses events, so we're not allowed to modify the original.
+            // Instead, we'll clone it.
+            keyEvent = _.clone(keyEvent);
+            keyEvent.keyCode = keyCode;
+
+            if ((e.nativeEvent as any).shiftKey) {
+                keyEvent.shiftKey = (e.nativeEvent as any).shiftKey;
+            }
+            if ((e.nativeEvent as any).ctrlKey) {
+                keyEvent.ctrlKey = (e.nativeEvent as any).ctrlKey;
+            }
+            if ((e.nativeEvent as any).altKey) {
+                keyEvent.altKey = (e.nativeEvent as any).altKey;
+            }
+            if ((e.nativeEvent as any).metaKey) {
+                keyEvent.metaKey = (e.nativeEvent as any).metaKey;
+            }
+
+            keyEvent.stopPropagation = () => {
+                if (e.stopPropagation) {
+                    e.stopPropagation();
+                }
+            };
+
+            keyEvent.preventDefault = () => {
+                if (e.preventDefault) {
+                    e.preventDefault();
+                }
+            };
+        }
+        return keyEvent;
+    }
+
+    toFocusEvent(e: Types.SyntheticEvent): Types.FocusEvent {
+
+        // Ideally we'd like to add a null set "relatedTarget", but the new typining doesn't allow that.
+        // So keeping it a noop for now
+        return e as Types.FocusEvent;
+    }
+}
+
+export default new EventHelpers();

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -129,9 +129,15 @@ export class EventHelpers {
 
     toFocusEvent(e: Types.SyntheticEvent): Types.FocusEvent {
 
-        // Ideally we'd like to add a null set "relatedTarget", but the new typining doesn't allow that.
+        // Ideally we'd like to add a null set "relatedTarget", but the new typing doesn't allow that.
         // So keeping it a noop for now
         return e as Types.FocusEvent;
+    }
+
+    toMouseEvent(e: Types.SyntheticEvent): Types.MouseEvent {
+
+        // Nothing for now, this will have to be enhanced based on platform support.
+        return e as Types.MouseEvent;
     }
 }
 

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -18,7 +18,7 @@ export class EventHelpers {
 
             // Currently some key codes are dependent on platform. React Native proper (the iOS and Android platforms) have different
             // keycodes for arrow keys when comparing with React (JS).
-            // We align the keycodes for nativre desktop platforms to the other native ones, as a workaround.
+            // We align the keycodes for native desktop platforms to the other native ones, as a workaround.
             // Ideally all key codes should be consistent OR a set of constants should be exposed by ReactXP.
             let keyName: string = (e.nativeEvent as any).key;
             let keyCode: number = 0;

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -28,6 +28,7 @@ export class EventHelpers {
             } else {
                 switch (keyName) {
                     case 'Backspace':
+                    case 'Delete':
                         keyCode = 8;
                         break;
 
@@ -85,10 +86,6 @@ export class EventHelpers {
                     case 'Down':
                     case 'ArrowDown':
                         keyCode = 20;
-                        break;
-
-                    case 'Delete':
-                        keyCode = 8;
                         break;
                 }
             }

--- a/src/native-desktop/App.ts
+++ b/src/native-desktop/App.ts
@@ -1,0 +1,20 @@
+/**
+* App.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* Native desktop implementation of App API namespace.
+*/
+
+import { RootView } from './RootView';
+import { App as AppCommon } from '../native-common/App';
+
+export class App extends AppCommon {
+
+    protected getRootViewFactory(): Function {
+        return () => RootView;
+    }
+}
+
+export default new App();

--- a/src/native-desktop/Input.ts
+++ b/src/native-desktop/Input.ts
@@ -9,7 +9,7 @@
 
 import Types = require('../common/Types');
 
-import {Input as InputCommon} from '../native-common/Input';
+import { Input as InputCommon } from '../native-common/Input';
 
 export class Input extends InputCommon {
     constructor() {

--- a/src/native-desktop/Input.ts
+++ b/src/native-desktop/Input.ts
@@ -1,0 +1,30 @@
+/**
+* Input.ts
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN Desktop implementation of Input interface.
+*/
+
+import Types = require('../common/Types');
+
+import {Input as InputCommon} from '../native-common/Input';
+
+export class Input extends InputCommon {
+    constructor() {
+        super();
+    }
+
+    dispatchKeyDown(e: Types.KeyboardEvent) {
+        this.keyDownEvent.fire(e);
+    }
+
+    dispatchKeyUp(e: Types.KeyboardEvent) {
+        if (this.keyUpEvent.fire(e)) {
+            e.stopPropagation();
+        }
+    }
+}
+
+export default new Input();

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -68,24 +68,21 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
             }
 
             if (kbdEvent.keyCode === KEY_CODE_ESC) {
-                /* TODO
                 // If Esc is pressed and the focused element stays the same after some time,
                 // switch the keyboard navigation off to dismiss the outline.
-                const activeElement = document.activeElement; //XXX
+                const activeComponent = FocusManager.getCurrentFocusedComponent();
 
                 if (this._isNavigatingWithKeyboardUpateTimer) {
-                    window.clearTimeout(this._isNavigatingWithKeyboardUpateTimer);
+                    clearTimeout(this._isNavigatingWithKeyboardUpateTimer);
                 }
 
-                this._isNavigatingWithKeyboardUpateTimer = window.setTimeout(() => {
+                this._isNavigatingWithKeyboardUpateTimer = setTimeout(() => {
                     this._isNavigatingWithKeyboardUpateTimer = undefined;
 
-                    if ((document.activeElement === activeElement) && activeElement && (activeElement !== document.body)) {
+                    if (activeComponent === FocusManager.getCurrentFocusedComponent()) {
                         this._updateKeyboardNavigationState(false);
                     }
                 }, 500);
-                */
-                this._updateKeyboardNavigationState(false);
             }
         }
 
@@ -99,14 +96,6 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
                 this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 
                 UserInterface.keyboardNavigationEvent.fire(isNavigatingWithKeyboard);
-
-    /* TODO: potentially useless properties
-                const focusClass = isNavigatingWithKeyboard ? this.props.keyBoardFocusOutline : this.props.mouseFocusOutline;
-
-                if (this.state.focusClass !== focusClass) {
-                    this.setState({ focusClass: focusClass });
-                }
-    */
             }
         }
 

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -129,7 +129,7 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
         render() {
             let content = super.render();
 
-            // Using "any" since onKeyDown/onKeyDown are not defined at RN.View property level
+            // Using "any" since onKeyDown/onKeyUp/etc. are not defined at RN.View property level
             // Yet the handlers are called as part of capturing/bubbling events for/from children.
             let internalProps: any = {
                 onKeyDown: this._onKeyDown,

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -16,6 +16,7 @@ import Input from './Input';
 import UserInterface from './UserInterface';
 import EventHelpers from '../native-common/utils/EventHelpers';
 import FocusManager from './utils/FocusManager';
+import FrontLayerViewManager from '../native-common/FrontLayerViewManager';
 
 type SyntheticEvent = React.SyntheticEvent<any>;
 
@@ -117,15 +118,15 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
         _onKeyUp = (e: SyntheticEvent) => {
             let kbdEvent = EventHelpers.toKeyboardEvent(e);
 
-    /* TODO fix popup processing
-            if (this.props.activePopupOptions && (e.keyCode === KEY_CODE_ESC)) {
+            let activePopupId = FrontLayerViewManager.getActivePopupId();
+            if (activePopupId && (kbdEvent.keyCode === KEY_CODE_ESC)) {
                 if (e.stopPropagation) {
                     e.stopPropagation();
                 }
-                this._dismissPopup();
+                FrontLayerViewManager.dismissPopup(activePopupId);
                 return;
             }
-    */
+
             Input.dispatchKeyUp(kbdEvent);
         }
 

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -38,7 +38,7 @@ const styles = RN.StyleSheet.create({
 type Constructor<T extends React.Component> = new (...args: any[]) => T;
 
 function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Component>>(RootViewBase: TRootViewBase) {
-    return class RootView extends RootViewBase {
+    return class RootView extends RootViewBase implements React.ChildContextProvider<any> {
         static childContextTypes: React.ValidationMap<any> = {
             focusManager: PropTypes.object
         };

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -6,12 +6,13 @@
 *
 * The top-most view that's used for proper layering or modals and popups.
 */
+
 import React = require('react');
 import RN = require('react-native');
 import PropTypes = require('prop-types');
 
-import {RootView as RootViewBase, RootViewUsingProps as RootViewUsingPropsBase,
-        BaseRootViewProps, RootViewPropsWithMainViewType, RootViewState, BaseRootView} from '../native-common/RootView';
+import { RootView as RootViewBase, RootViewUsingProps as RootViewUsingPropsBase,
+    BaseRootViewProps, RootViewPropsWithMainViewType, RootViewState, BaseRootView } from '../native-common/RootView';
 import Input from './Input';
 import UserInterface from './UserInterface';
 import EventHelpers from '../native-common/utils/EventHelpers';
@@ -25,8 +26,8 @@ const KEY_CODE_ESC = 27;
 
 const styles = RN.StyleSheet.create({
     appWrapper: {
-      flex: 1,
-    },
+      flex: 1
+    }
   });
 
 //
@@ -61,7 +62,6 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
         }
 
         _onKeyDownCapture = (e: SyntheticEvent) => {
-
             let kbdEvent = EventHelpers.toKeyboardEvent(e);
             if (kbdEvent.keyCode === KEY_CODE_TAB) {
                 this._updateKeyboardNavigationState(true);
@@ -140,10 +140,10 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
 
             return (
                 <RN.View 
-                    {...internalProps}
-                    style={styles.appWrapper}
+                    { ...internalProps }
+                    style={ styles.appWrapper }
                 >
-                    {content}
+                    { content }
                 </RN.View>
             );
         }
@@ -159,7 +159,7 @@ export {
     RootViewState,
     BaseRootView,
     RootViewUsingStore as RootView,
-    RootViewUsingProps,
+    RootViewUsingProps
 };
 
 export default RootViewUsingStore;

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -1,0 +1,175 @@
+/**
+* RootView.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* The top-most view that's used for proper layering or modals and popups.
+*/
+import React = require('react');
+import RN = require('react-native');
+import PropTypes = require('prop-types');
+
+import {RootView as RootViewBase, RootViewUsingProps as RootViewUsingPropsBase,
+        BaseRootViewProps, RootViewPropsWithMainViewType, RootViewState, BaseRootView} from '../native-common/RootView';
+import Input from './Input';
+import UserInterface from './UserInterface';
+import EventHelpers from '../native-common/utils/EventHelpers';
+import FocusManager from './utils/FocusManager';
+
+type SyntheticEvent = React.SyntheticEvent<any>;
+
+const KEY_CODE_TAB = 9;
+const KEY_CODE_ESC = 27;
+
+const styles = RN.StyleSheet.create({
+    appWrapper: {
+      flex: 1,
+    },
+  });
+
+//
+// Mixin with keyboard management behaviors. It enhances the two RootView flavors by adding:
+// 1. Support for maintaining UserInterface.keyboardNavigationEvent
+//   React Native doesn't offer a convenient mechanism to peek into keyboard/mouse events globally (the way
+// addEventListener achieves in the Web counterpart), so we rely on a spying view we render.
+// 2. Redirection to Input.ts
+// 3. A place for the root FocusManager
+type Constructor<T extends React.Component> = new (...args: any[]) => T;
+
+function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Component>>(RootViewBase: TRootViewBase) {
+    return class RootView extends RootViewBase {
+        static childContextTypes: React.ValidationMap<any> = {
+            focusManager: PropTypes.object
+        };
+
+        _focusManager: FocusManager;
+        _keyboardHandlerInstalled = false;
+        _isNavigatingWithKeyboard: boolean = false;
+        _isNavigatingWithKeyboardUpateTimer: number | undefined;
+
+        constructor(...args: any[]) {
+            super(...args);
+            // Initialize the root FocusManager which is aware of all
+            // focusable elements.
+            this._focusManager = new FocusManager(undefined);
+        }
+
+        _onTouchStartCapture = (e: SyntheticEvent) => {
+            this._updateKeyboardNavigationState(false);
+        }
+
+        _onKeyDownCapture = (e: SyntheticEvent) => {
+
+            let kbdEvent = EventHelpers.toKeyboardEvent(e);
+            if (kbdEvent.keyCode === KEY_CODE_TAB) {
+                this._updateKeyboardNavigationState(true);
+            }
+
+            if (kbdEvent.keyCode === KEY_CODE_ESC) {
+                /* TODO
+                // If Esc is pressed and the focused element stays the same after some time,
+                // switch the keyboard navigation off to dismiss the outline.
+                const activeElement = document.activeElement; //XXX
+
+                if (this._isNavigatingWithKeyboardUpateTimer) {
+                    window.clearTimeout(this._isNavigatingWithKeyboardUpateTimer);
+                }
+
+                this._isNavigatingWithKeyboardUpateTimer = window.setTimeout(() => {
+                    this._isNavigatingWithKeyboardUpateTimer = undefined;
+
+                    if ((document.activeElement === activeElement) && activeElement && (activeElement !== document.body)) {
+                        this._updateKeyboardNavigationState(false);
+                    }
+                }, 500);
+                */
+                this._updateKeyboardNavigationState(false);
+            }
+        }
+
+        _updateKeyboardNavigationState(isNavigatingWithKeyboard: boolean) {
+            if (this._isNavigatingWithKeyboardUpateTimer) {
+                window.clearTimeout(this._isNavigatingWithKeyboardUpateTimer);
+                this._isNavigatingWithKeyboardUpateTimer = undefined;
+            }
+
+            if (this._isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
+                this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+
+                UserInterface.keyboardNavigationEvent.fire(isNavigatingWithKeyboard);
+
+    /* TODO: potentially useless properties
+                const focusClass = isNavigatingWithKeyboard ? this.props.keyBoardFocusOutline : this.props.mouseFocusOutline;
+
+                if (this.state.focusClass !== focusClass) {
+                    this.setState({ focusClass: focusClass });
+                }
+    */
+            }
+        }
+
+        _onKeyDown = (e: SyntheticEvent) => {
+            let kbdEvent = EventHelpers.toKeyboardEvent(e);
+            Input.dispatchKeyDown(kbdEvent);
+        }
+
+        _onKeyUp = (e: SyntheticEvent) => {
+            let kbdEvent = EventHelpers.toKeyboardEvent(e);
+
+    /* TODO fix popup processing
+            if (this.props.activePopupOptions && (e.keyCode === KEY_CODE_ESC)) {
+                if (e.stopPropagation) {
+                    e.stopPropagation();
+                }
+                this._dismissPopup();
+                return;
+            }
+    */
+            Input.dispatchKeyUp(kbdEvent);
+        }
+
+        getChildContext() {
+            // Provide the context with root FocusManager to all descendants.
+            return {
+                focusManager: this._focusManager
+            };
+        }
+
+        render() {
+            let content = super.render();
+
+            // Using "any" since onKeyDown/onKeyDown are not defined at RN.View property level
+            // Yet the handlers are called as part of capturing/bubbling events for/from children.
+            let internalProps: any = {
+                onKeyDown: this._onKeyDown,
+                onKeyDownCapture: this._onKeyDownCapture,
+                onKeyUp: this._onKeyUp,
+                onTouchStartCapture: this._onTouchStartCapture
+            };
+
+            return (
+                <RN.View 
+                    {...internalProps}
+                    style={styles.appWrapper}
+                >
+                    {content}
+                </RN.View>
+            );
+        }
+    };
+}
+
+const RootViewUsingStore = applyDesktopBehaviorMixin(RootViewBase);
+const RootViewUsingProps = applyDesktopBehaviorMixin(RootViewUsingPropsBase);
+
+export {
+    BaseRootViewProps,
+    RootViewPropsWithMainViewType,
+    RootViewState,
+    BaseRootView,
+    RootViewUsingStore as RootView,
+    RootViewUsingProps,
+};
+
+export default RootViewUsingStore;

--- a/src/native-desktop/UserInterface.tsx
+++ b/src/native-desktop/UserInterface.tsx
@@ -8,7 +8,7 @@
 * UI (layout measurements, etc.) - desktop version.
 */
 
-import {UserInterface as UserInterfaceCommon} from '../native-common/UserInterface';
+import { UserInterface as UserInterfaceCommon } from '../native-common/UserInterface';
 
 export class UserInterface extends UserInterfaceCommon {
     private _isNavigatingWithKeyboard: boolean = false;

--- a/src/native-desktop/UserInterface.tsx
+++ b/src/native-desktop/UserInterface.tsx
@@ -1,0 +1,29 @@
+/**
+* UserInterface.ts
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN implementation of the ReactXP interfaces related to
+* UI (layout measurements, etc.) - desktop version.
+*/
+
+import {UserInterface as UserInterfaceCommon} from '../native-common/UserInterface';
+
+export class UserInterface extends UserInterfaceCommon {
+    private _isNavigatingWithKeyboard: boolean = false;
+    constructor() {
+        super();
+        this.keyboardNavigationEvent.subscribe(this._keyboardNavigationStateChanged);
+    }
+
+    isNavigatingWithKeyboard(): boolean {
+        return this._isNavigatingWithKeyboard;
+    }
+
+    private _keyboardNavigationStateChanged = (isNavigatingWithKeyboard: boolean) => {
+        this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+    }
+}
+
+export default new UserInterface();

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -9,9 +9,9 @@
 
 import React = require('react');
 
-import {FocusManager as FocusManagerBase,
+import { FocusManager as FocusManagerBase,
     applyFocusableComponentMixin as applyFocusableComponentMixinBase,
-    StoredFocusableComponent} from '../../common/utils/FocusManager';
+    StoredFocusableComponent } from '../../common/utils/FocusManager';
 
 import Platform from '../../native-common/Platform';
 import UserInterface from '../UserInterface';
@@ -24,8 +24,8 @@ UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
     _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 });
 
-import {FocusableComponentStateCallback} from  '../../common/utils/FocusManager';
-export {FocusableComponentStateCallback};
+import { FocusableComponentStateCallback } from  '../../common/utils/FocusManager';
+export { FocusableComponentStateCallback };
 
 export interface FocusManagerFocusableComponent {
     getTabIndex(): number | undefined;
@@ -66,7 +66,7 @@ export class FocusManager extends FocusManagerBase {
         return false;
     }
 
-    private static focusFirst () {
+    private static focusFirst() {
         const focusable = Object.keys(FocusManager._allFocusableComponents)
             .map(componentId => FocusManager._allFocusableComponents[componentId])
             .filter(storedComponent => !storedComponent.removed && !storedComponent.restricted && !storedComponent.limitedCount);
@@ -97,7 +97,6 @@ export class FocusManager extends FocusManagerBase {
     }
 
     protected /* static */ resetFocus() {
-
         if (FocusManager._resetFocusTimer) {
             clearTimeout(FocusManager._resetFocusTimer);
             FocusManager._resetFocusTimer = undefined;
@@ -138,7 +137,7 @@ export class FocusManager extends FocusManagerBase {
     }
 
     private  static  _setComponentTabIndexOverride(
-            component: React.Component<any, any>, tabIndex: number): number | undefined {
+        component: React.Component<any, any>, tabIndex: number): number | undefined {
 
         (component as any as FocusManagerFocusableComponentInternal).setTabIndexOverride(tabIndex);
         // Original value is not used for desktop implementation
@@ -146,13 +145,12 @@ export class FocusManager extends FocusManagerBase {
     }
 
     private  static  _removeComponentTabIndexOverride(
-            component: React.Component<any, any>): void {
+        component: React.Component<any, any>): void {
         (component as any as FocusManagerFocusableComponentInternal).removeTabIndexOverride();
     }
 }
 
 export function applyFocusableComponentMixin(Component: any, isConditionallyFocusable?: Function) {
-
     // Call base
     // This adds the basic "monitor focusable components" functionality.
     applyFocusableComponentMixinBase(Component, isConditionallyFocusable);

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -208,8 +208,13 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
             if (tabIndex !== undefined && tabIndex < 0) {
                 // A negative tabIndex maps to non focusable in UWP.
                 // We temporary apply a local override of "tabIndex=0", and then forward the focus command.
-                // A timer makes sure the tabIndex returns back to "non-overriden" state. Focus is never ejected if tabIndex becomes -1,
-                // for example, so the simulation is pretty accurate.
+                // A timer makes sure the tabIndex returns back to "non-overriden" state.
+                // - If the component is not under FocusManager control (a View with tabIndex===-1, for ex.), the only action
+                // available for user is to tab out.
+                // - If the component is under FocusManager control, the "tabIndex===-1" is usually due to a limit imposed on the component,
+                // and that limit is usually removed when component aquires focus. If not, the user has again one only choice left: to
+                // tab out.
+                // A more accurate solution would require tracking onBlur and other state.
                 this.tabIndexLocalOverride = 0;
 
                 // Refresh the native view

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -13,6 +13,7 @@ import { FocusManager as FocusManagerBase,
     applyFocusableComponentMixin as applyFocusableComponentMixinBase,
     StoredFocusableComponent } from '../../common/utils/FocusManager';
 
+import AppConfig from '../../common/AppConfig';
 import Platform from '../../native-common/Platform';
 import UserInterface from '../UserInterface';
 
@@ -160,7 +161,9 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
         if (this._onFocusSink) {
             this._onFocusSink();
         } else {
-            console.error('FocusableComponentMixin: focus sink error!');
+            if (AppConfig.isDevelopmentMode()) {
+                console.error('FocusableComponentMixin: focus sink error!');
+            }
         }
 
         origCallback.call(this);
@@ -187,7 +190,9 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
         if (this.updateNativeTabIndex) {
             this.updateNativeTabIndex();
         } else {
-            console.error('FocusableComponentMixin: updateNativeTabIndex error!');
+            if (AppConfig.isDevelopmentMode()) {
+                console.error('FocusableComponentMixin: updateNativeTabIndex error!');
+            }
         }
     };
 
@@ -200,7 +205,9 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
         if (this.updateNativeTabIndex) {
             this.updateNativeTabIndex();
         } else {
-            console.error('FocusableComponentMixin: updateNativeTabIndex error!');
+            if (AppConfig.isDevelopmentMode()) {
+                console.error('FocusableComponentMixin: updateNativeTabIndex error!');
+            }
         }
     };
 
@@ -235,7 +242,9 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
                 return action.call(this, origCallback, arguments);
             };
         } else {
-            console.error('FocusableComponentMixin: ' + methodName + ' error!');
+            if (AppConfig.isDevelopmentMode()) {
+                console.error('FocusableComponentMixin: ' + methodName + ' error!');
+            }
         }
     }
 }

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -73,7 +73,7 @@ export class FocusManager extends FocusManagerBase {
 
         if (focusable.length) {
             focusable.sort((a, b) => {
-                // This function does its best, but contrasry to DOM-land we have no idea on where the native components
+                // This function does its best, but contrary to DOM-land we have no idea on where the native components
                 // ended up on screen, unless some expensive measuring is done on them.
                 // So we defer to less than optimal "add focusable component" order. A lot of factors (absolute positioning,
                 // instance replacements, etc.) can alter the correctness of this method, but I see no other way.

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -104,7 +104,6 @@ export class FocusManager extends FocusManagerBase {
             // When we're in the keyboard navigation mode, we want to have the
             // first focusable component to be focused straight away, without the
             // necessity to press Tab.
-
             // Defer the focusing to let the view finish its initialization and to allow for manual focus setting (if any)
             // to be processed (the asynchronous nature of focus->onFocus path requires a delay)
             FocusManager._resetFocusTimer = setTimeout(() => {
@@ -114,12 +113,11 @@ export class FocusManager extends FocusManagerBase {
                 // We skip setting focus on "first" component in that case because:
                 // - focusFirst has its limits, to say it gently
                 // - We ended up in resetFocus for a reason that is not true anymore (mostly because focus was set manually)
-
                 const storedComponent = FocusManager._currentFocusedComponent;
-                if (!storedComponent || storedComponent.restricted || (storedComponent.limitedCount > 0)) {
+                if (!storedComponent || storedComponent.removed || storedComponent.restricted || (storedComponent.limitedCount > 0)) {
                     FocusManager.focusFirst();
                 }
-            }, 100);
+            }, 500);
         }
     }
 
@@ -161,7 +159,7 @@ function updateNativeTabIndex(component: FocusableComponentInternal) {
         component.updateNativeTabIndex();
     } else {
         if (AppConfig.isDevelopmentMode()) {
-            console.error('FocusableComponentMixin: updateNativeTabIndex error!');
+            console.error('FocusableComponentMixin: updateNativeTabIndex doesn\'t exist!');
         }
     }
 }
@@ -177,7 +175,7 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
             this.onFocusSink();
         } else {
             if (AppConfig.isDevelopmentMode()) {
-                console.error('FocusableComponentMixin: focus sink error!');
+                console.error('FocusableComponentMixin: onFocusSink doesn\'t exist!');
             }
         }
 
@@ -206,7 +204,6 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
         // We try to simulate the right behavior through a trick.
         inheritMethod('focus', function (this: FocusableComponentInternal, origCallback: any) {
             let tabIndex: number | undefined = this.getTabIndex();
-
             // Check effective tabIndex
             if (tabIndex !== undefined && tabIndex < 0) {
                 // A negative tabIndex maps to non focusable in UWP.
@@ -251,7 +248,7 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
             };
         } else {
             if (AppConfig.isDevelopmentMode()) {
-                console.error('FocusableComponentMixin: ' + methodName + ' error!');
+                console.error('FocusableComponentMixin: ' + methodName + ' is expected to exist and it doesn\'t!');
             }
         }
     }

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -163,9 +163,7 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
             console.error('FocusableComponentMixin: focus sink error!');
         }
 
-        if (origCallback) {
-            origCallback.call(this);
-        }
+        origCallback.call(this);
     });
 
     // Hook 'getTabIndex'

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -1,0 +1,229 @@
+/**
+* FocusManager.ts
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* Manages focusable elements for better keyboard navigation (RN desktop version)
+*/
+
+import React = require('react');
+
+import {FocusManager as FocusManagerBase,
+    applyFocusableComponentMixin as applyFocusableComponentMixinBase,
+    StoredFocusableComponent} from '../../common/utils/FocusManager';
+
+import UserInterface from '../UserInterface';
+
+let _isNavigatingWithKeyboard: boolean;
+//let _isShiftPressed: boolean;
+
+UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
+    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+});
+
+import {FocusableComponentStateCallback} from  '../../common/utils/FocusManager';
+export {FocusableComponentStateCallback};
+
+export interface FocusManagerFocusableComponent {
+    getTabIndex(): number | undefined;
+    onFocus(): void;
+    focus(): void;
+    updateNativeTabIndex(): void;
+}
+
+interface FocusManagerFocusableComponentInternal extends FocusManagerFocusableComponent {
+    _tabIndexOverride?: number;
+    setTabIndexOverride(tabIndex: number): void;
+    removeTabIndexOverride(): void;
+    _onFocusSink?: () => void;
+}
+
+export class FocusManager extends FocusManagerBase {
+
+    constructor(parent: FocusManager | undefined) {
+        super(parent);
+    }
+
+    protected /* static */ addFocusListenerOnComponent(component: React.Component<any, any>, onFocus: () => void): void {
+        // We intercept the "onFocus" all the focusable elements have to have
+        (component as any as FocusManagerFocusableComponentInternal)._onFocusSink = onFocus;
+    }
+
+    protected /* static */ removeFocusListenerFromComponent(component: React.Component<any, any>, onFocus: () => void): void {
+        delete  (component as any as FocusManagerFocusableComponentInternal)._onFocusSink;
+    }
+
+    protected /* static */ focusComponent(component: React.Component<any, any>): boolean {
+        let fc = component as any as FocusManagerFocusableComponent;
+
+        if (fc && fc.focus) {
+            fc.focus();
+            return true;
+        }
+        return false;
+    }
+
+   /*
+    private static focusFirst (last?: boolean) {
+        const focusable = Object.keys(FocusManager._allFocusableComponents)
+            .map(componentId => FocusManager._allFocusableComponents[componentId])
+            .filter(storedComponent => !storedComponent.removed && !storedComponent.restricted && !storedComponent.limitedCount)
+            .map(storedComponent => ReactDOM.findDOMNode<HTMLElement>(storedComponent.component))
+            .filter(el => el && el.focus);
+
+        if (focusable.length) {
+            focusable.sort((a, b) => {
+                // Some element which is mounted later could come earlier in the DOM,
+                // so, we sort the elements by their appearance in the DOM.
+                if (a === b) {
+                    return 0;
+                }
+                return a.compareDocumentPosition(b) & document.DOCUMENT_POSITION_PRECEDING ? 1 : -1;
+            });
+
+            focusable[last ? focusable.length - 1 : 0].focus();
+        }
+    } */
+
+    protected /* static */ resetFocus() {
+        if (_isNavigatingWithKeyboard) {
+            return;
+        }
+
+        /*
+        if (FocusManager._resetFocusTimer) {
+            clearTimeout(FocusManager._resetFocusTimer);
+            FocusManager._resetFocusTimer = undefined;
+        }
+
+        if (_isNavigatingWithKeyboard) {
+            // When we're in the keyboard navigation mode, we want to have the
+            // first focusable component to be focused straight away, without the
+            // necessity to press Tab.
+
+            // Defer the focusing to let the view finish its initialization.
+            FocusManager._resetFocusTimer = setTimeout(() => {
+                FocusManager._resetFocusTimer = undefined;
+                FocusManager.focusFirst();
+            }, 0);
+        } else if ((typeof document !== 'undefined') && document.body && document.body.focus && document.body.blur) {
+            // An example to explain this part:
+            // We've shown a modal dialog which is higher in the DOM by clicking
+            // on a button which is lower in the DOM, we've applied the restrictions
+            // and only the elements from the modal dialog are focusable now.
+            // But internally the browser keeps the last focus position in the DOM
+            // (even if we do blur() for the button) and when Tab is pressed again,
+            // the browser will start searching for the next focusable element from
+            // this position.
+            // This means that the first Tab press will get us to the browser's address
+            // bar (or nowhere in case of Electron) and only the second Tab press will
+            // lead us to focusing the first focusable element in the modal dialog.
+            // In order to avoid losing this first Tab press, we're making <body>
+            // focusable, focusing it, removing the focus and making it unfocusable
+            // back again.
+            const prevTabIndex = FocusManager._setTabIndex(document.body, 0);
+            document.body.focus();
+            document.body.blur();
+            FocusManager._setTabIndex(document.body, prevTabIndex);
+        }
+
+        */
+    }
+
+    protected /* static */  _updateComponentFocusRestriction(storedComponent: StoredFocusableComponent) {
+        if ((storedComponent.restricted || (storedComponent.limitedCount > 0)) && !('origTabIndex' in storedComponent)) {
+            storedComponent.origTabIndex = FocusManager._setComponentTabIndexOverride(storedComponent.component, -1);
+            FocusManager._callFocusableComponentStateChangeCallbacks(storedComponent, true);
+        } else if (!storedComponent.restricted && !storedComponent.limitedCount && ('origTabIndex' in storedComponent)) {
+            FocusManager._removeComponentTabIndexOverride(storedComponent.component);
+            delete storedComponent.origTabIndex;
+            FocusManager._callFocusableComponentStateChangeCallbacks(storedComponent, false);
+        }
+    }
+
+    private  static  _setComponentTabIndexOverride(
+            component: React.Component<any, any>, tabIndex: number): number | undefined {
+
+        (component as any as FocusManagerFocusableComponentInternal).setTabIndexOverride(tabIndex);
+        // Original value is not used for desktop implementation
+        return undefined;
+    }
+
+    private  static  _removeComponentTabIndexOverride(
+            component: React.Component<any, any>): void {
+        (component as any as FocusManagerFocusableComponentInternal).removeTabIndexOverride();
+    }
+}
+
+export function applyFocusableComponentMixin(Component: any, isConditionallyFocusable?: Function) {
+
+    // Call base
+    // This adds the basic "monitor focusable components" functionality.
+    applyFocusableComponentMixinBase(Component, isConditionallyFocusable);
+
+    // Hook 'onFocus'
+    inheritMethod('onFocus', function (this: FocusManagerFocusableComponentInternal, origCallback: Function) {
+        if (this._onFocusSink) {
+            this._onFocusSink();
+        } else {
+            console.error('FocusableComponentMixin: focus sink error!');
+        }
+
+        if (origCallback) {
+            origCallback.call(this);
+        }
+    });
+
+    // Hook 'getTabIndex'
+    inheritMethod('getTabIndex', function (this: FocusManagerFocusableComponentInternal, origCallback: any) {
+        // Check override available
+        if (this._tabIndexOverride !== undefined) {
+            // Override available, use this one
+            return this._tabIndexOverride;
+        } else {
+            // Override not available, defer to original handler to return the prop
+            return origCallback.call(this);
+        }
+    });
+
+    // Implement 'setTabIndexOverride'
+    Component.prototype['setTabIndexOverride'] = function (this: FocusManagerFocusableComponentInternal, tabIndex: number) {
+        // Save the override on a custom property
+        this._tabIndexOverride = tabIndex;
+
+        // Call special method on component avoiding state changes/re-renderings
+        if (this.updateNativeTabIndex) {
+            this.updateNativeTabIndex();
+        } else {
+            console.error('FocusableComponentMixin: updateNativeTabIndex error!');
+        }
+    };
+
+    // Implement 'setTabIndexOverride'
+    Component.prototype['removeTabIndexOverride'] = function (this: FocusManagerFocusableComponentInternal) {
+        // Remove the cached override
+        delete this._tabIndexOverride;
+
+        // Reset to original value avoiding state changes/re-renderings
+        if (this.updateNativeTabIndex) {
+            this.updateNativeTabIndex();
+        } else {
+            console.error('FocusableComponentMixin: updateNativeTabIndex error!');
+        }
+    };
+
+    function inheritMethod(methodName: string, action: Function) {
+        let origCallback = Component.prototype[methodName];
+
+        if (origCallback) {
+            Component.prototype[methodName] = function () {
+                return action.call(this, origCallback, arguments);
+            };
+        } else {
+            console.error('FocusableComponentMixin: ' + methodName + ' error!');
+        }
+    }
+}
+
+export default FocusManager;

--- a/src/typings/react-native-windows.d.ts
+++ b/src/typings/react-native-windows.d.ts
@@ -1,0 +1,56 @@
+/**
+* react-native-windows.d.ts
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* Type definition file for React Native Windows
+*/
+
+declare module 'react-native-windows' {
+    //
+    // React
+    // ----------------------------------------------------------------------
+
+    import React = require('react');
+    import RN = require('react-native');
+
+    //
+    // Focusable view related declarations
+    // ----------------------------------------------------------------------
+    interface FocusableProps extends RN.ViewProps {
+        isTabStop?                      : boolean;
+        tabIndex?                       : number;
+        tabNavigation?                  : string; // enum( 'local', 'cycle', 'once' );
+        disableSystemFocusVisuals?      : boolean;
+        onFocus?                        : Function;
+        onBlur?                         : Function;
+        handledKeyDownKeys?             : number[];
+        handledKeyUpKeys?               : number[];
+        onKeyDown?                      : Function;
+        onKeyUp?                        : Function;
+    }
+
+    class FocusableWindows extends RN.ReactNativeBaseComponent<FocusableProps, {}> { }
+
+    //
+    // Declarations for "enhanced" components
+    // Even though this is a good place to define these and to avoid poluting react-native.d.ts, truth is
+    // the real life objects will be visible in the ReactNative namespace rather than ReactWindows
+    // ----------------------------------------------------------------------
+    interface ScrollViewProps extends RN.ScrollViewProps {
+        onKeyDown?                      : Function;
+        onKeyUp?                        : Function;
+        tabNavigation?                  : string; // enum( 'local', 'cycle', 'once' );
+        disableKeyboardBasedScrolling?  : boolean;
+    }
+    class ScrollView extends RN.ReactNativeBaseComponent<ScrollViewProps, {}> { }
+
+    interface TextInputProps extends RN.TextInputProps {
+        tabIndex?                       : number;
+    }
+    class TextInput extends RN.ReactNativeBaseComponent<TextInputProps, {}>
+    {
+        static State: RN.TextInputState;
+    }
+}

--- a/src/typings/react-native-windows.d.ts
+++ b/src/typings/react-native-windows.d.ts
@@ -19,7 +19,7 @@ declare module 'react-native-windows' {
     //
     // Focusable view related declarations
     // ----------------------------------------------------------------------
-    interface FocusableProps extends RN.ViewProps {
+    type FocusableWindowsProps<P={}> = P & {
         isTabStop?: boolean;
         tabIndex?: number;
         tabNavigation?: 'local' | 'cycle' | 'once';
@@ -30,7 +30,15 @@ declare module 'react-native-windows' {
         handledKeyUpKeys?: number[];
         onKeyDown?: Function;
         onKeyUp?: Function;
+        componentRef?: Function;
+    };
+
+    interface FocusableWindows<P> extends RN.ReactNativeBaseComponent<FocusableWindowsProps<P>, {}>{
+        focus(): void;
+        blur(): void;
     }
 
-    class FocusableWindows extends RN.ReactNativeBaseComponent<FocusableProps, {}> { }
+    type FocusableComponentConstructor<P> = new() => FocusableWindows<P>;
+
+    function createFocusableComponent<P>(Component: any): FocusableComponentConstructor<P>;
 }

--- a/src/typings/react-native-windows.d.ts
+++ b/src/typings/react-native-windows.d.ts
@@ -20,16 +20,16 @@ declare module 'react-native-windows' {
     // Focusable view related declarations
     // ----------------------------------------------------------------------
     interface FocusableProps extends RN.ViewProps {
-        isTabStop?                      : boolean;
-        tabIndex?                       : number;
-        tabNavigation?                  : string; // enum( 'local', 'cycle', 'once' );
-        disableSystemFocusVisuals?      : boolean;
-        onFocus?                        : Function;
-        onBlur?                         : Function;
-        handledKeyDownKeys?             : number[];
-        handledKeyUpKeys?               : number[];
-        onKeyDown?                      : Function;
-        onKeyUp?                        : Function;
+        isTabStop?: boolean;
+        tabIndex?: number;
+        tabNavigation?: 'local' | 'cycle' | 'once';
+        disableSystemFocusVisuals?: boolean;
+        onFocus?: Function;
+        onBlur?: Function;
+        handledKeyDownKeys?: number[];
+        handledKeyUpKeys?: number[];
+        onKeyDown?: Function;
+        onKeyUp?: Function;
     }
 
     class FocusableWindows extends RN.ReactNativeBaseComponent<FocusableProps, {}> { }

--- a/src/typings/react-native-windows.d.ts
+++ b/src/typings/react-native-windows.d.ts
@@ -4,7 +4,8 @@
 * Copyright (c) Microsoft Corporation. All rights reserved.
 * Licensed under the MIT license.
 *
-* Type definition file for React Native Windows
+* Type definition file for React Native Windows only components and modules
+* Definitions for extensions pertaining to existing React Native components are merged into the reaxt-native.d.ts file.
 */
 
 declare module 'react-native-windows' {
@@ -32,25 +33,4 @@ declare module 'react-native-windows' {
     }
 
     class FocusableWindows extends RN.ReactNativeBaseComponent<FocusableProps, {}> { }
-
-    //
-    // Declarations for "enhanced" components
-    // Even though this is a good place to define these and to avoid poluting react-native.d.ts, truth is
-    // the real life objects will be visible in the ReactNative namespace rather than ReactWindows
-    // ----------------------------------------------------------------------
-    interface ScrollViewProps extends RN.ScrollViewProps {
-        onKeyDown?                      : Function;
-        onKeyUp?                        : Function;
-        tabNavigation?                  : string; // enum( 'local', 'cycle', 'once' );
-        disableKeyboardBasedScrolling?  : boolean;
-    }
-    class ScrollView extends RN.ReactNativeBaseComponent<ScrollViewProps, {}> { }
-
-    interface TextInputProps extends RN.TextInputProps {
-        tabIndex?                       : number;
-    }
-    class TextInput extends RN.ReactNativeBaseComponent<TextInputProps, {}>
-    {
-        static State: RN.TextInputState;
-    }
 }

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -70,7 +70,7 @@ declare module 'react-native' {
     // ----------------------------------------------------------------------
 
     interface ComponentPropsBase {
-        ref?: string | ((obj: ReactNativeBaseComponent<any, any>) => void);
+        ref?: string | ((obj: ReactNativeBaseComponent<any, any> | null) => void);
         key?: string | number;
     }
 
@@ -794,7 +794,7 @@ declare module 'react-native' {
         scale: number;
         fontScale: number;
     }
-    
+
     type DimensionEventType = 'change';
 
     interface DimensionChangeEvent {

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -267,6 +267,13 @@ declare module 'react-native' {
         // iOS
         onAccessibilityTapIOS?: Function;
         shouldRasterizeIOS? : boolean;
+
+        // Windows
+        onKeyDown?: Function;
+        onMouseEnter?: Function;
+        onMouseLeave?: Function;
+        onMouseOver?: Function;
+        onMouseMove?: Function;
     }
 
     interface ScrollViewProps extends ViewProps {
@@ -310,6 +317,11 @@ declare module 'react-native' {
         overScrollMode?: string; //enum( 'always', 'always-if-content-scrolls', 'never' )
         // iOS
         scrollIndicatorInsets?: {top: number, left: number, bottom: number, right: number };
+        // Windows only
+        onKeyDown? : Function;
+        onKeyUp? : Function;
+        tabNavigation? : string; // enum( 'local', 'cycle', 'once' );
+        disableKeyboardBasedScrolling?: boolean;
     }
 
     interface ListViewDataSourceCallback {
@@ -397,6 +409,8 @@ declare module 'react-native' {
         textBreakStrategy?: 'highQuality' | 'simple' | 'balanced';
         // macOS only property for submitting the text on enter
         submitTextOnEnter?: boolean;
+        // Windows only
+        tabIndex?: number;
     }
 
     interface TextInputState {

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -320,7 +320,7 @@ declare module 'react-native' {
         // Windows only
         onKeyDown? : Function;
         onKeyUp? : Function;
-        tabNavigation? : string; // enum( 'local', 'cycle', 'once' );
+        tabNavigation? : 'local' | 'cycle' | 'once';
         disableKeyboardBasedScrolling?: boolean;
     }
 

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -258,7 +258,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         const ariaRole = AccessibilityUtil.accessibilityTraitToString(this.props.accessibilityTraits);
         const ariaSelected = AccessibilityUtil.accessibilityTraitToAriaSelected(this.props.accessibilityTraits);
         const isAriaHidden = AccessibilityUtil.isHidden(this.props.importantForAccessibility);
-        const ariaLive = this.props.accessibilityLiveRegion ? 
+        const ariaLive = this.props.accessibilityLiveRegion ?
             AccessibilityUtil.accessibilityLiveRegionToString(this.props.accessibilityLiveRegion) :
             undefined;
 

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -326,7 +326,8 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         if (AppConfig.isDevelopmentMode()) {
             if (!!this.props.restrictFocusWithin !== !!nextProps.restrictFocusWithin) {
                 console.error('View: restrictFocusWithin is readonly and changing it during the component life cycle has no effect');
-            } else if (!!this.props.limitFocusWithin !== !!nextProps.limitFocusWithin) {
+            } 
+            if (!!this.props.limitFocusWithin !== !!nextProps.limitFocusWithin) {
                 console.error('View: limitFocusWithin is readonly and changing it during the component life cycle has no effect');
             }
         }

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -31,8 +31,6 @@ export {applyFocusableComponentMixin, FocusableComponentStateCallback};
 
 export class FocusManager extends FocusManagerBase {
 
-    private static _resetFocusTimer: number | undefined;
-
     constructor(parent: FocusManager | undefined) {
         super(parent);
     }

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -10,9 +10,9 @@
 import React = require('react');
 import ReactDOM = require('react-dom');
 
-import {FocusManager as FocusManagerBase,
+import { FocusManager as FocusManagerBase,
     StoredFocusableComponent,
-    OriginalAttributeValues} from '../../common/utils/FocusManager';
+    OriginalAttributeValues } from '../../common/utils/FocusManager';
 
 import UserInterface from '../UserInterface';
 
@@ -26,8 +26,8 @@ UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
     _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 });
 
-import {applyFocusableComponentMixin, FocusableComponentStateCallback} from  '../../common/utils/FocusManager';
-export {applyFocusableComponentMixin, FocusableComponentStateCallback};
+import { applyFocusableComponentMixin, FocusableComponentStateCallback } from  '../../common/utils/FocusManager';
+export { applyFocusableComponentMixin, FocusableComponentStateCallback };
 
 export class FocusManager extends FocusManagerBase {
 

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -11,6 +11,7 @@ import React = require('react');
 import ReactDOM = require('react-dom');
 
 import { FocusManager as FocusManagerBase,
+    FocusableComponentInternal,
     StoredFocusableComponent,
     OriginalAttributeValues } from '../../common/utils/FocusManager';
 
@@ -81,21 +82,21 @@ export class FocusManager extends FocusManagerBase {
         });
     }
 
-    protected /* static */ addFocusListenerOnComponent(component: React.Component<any, any>, onFocus: () => void): void {
+    protected /* static */ addFocusListenerOnComponent(component: FocusableComponentInternal, onFocus: () => void): void {
         const el = ReactDOM.findDOMNode(component) as HTMLElement;
         if (el) {
             el.addEventListener('focus', onFocus);
         }
     }
 
-    protected /* static */ removeFocusListenerFromComponent(component: React.Component<any, any>, onFocus: () => void): void {
+    protected /* static */ removeFocusListenerFromComponent(component: FocusableComponentInternal, onFocus: () => void): void {
         const el = ReactDOM.findDOMNode(component) as HTMLElement;
         if (el) {
             el.removeEventListener('focus', onFocus);
         }
     }
 
-    protected /* static */ focusComponent(component: React.Component<any, any>): boolean {
+    protected /* static */ focusComponent(component: FocusableComponentInternal): boolean {
         const el = ReactDOM.findDOMNode(component) as HTMLElement;
         if (el && el.focus) {
             el.focus();

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -4,37 +4,20 @@
 * Copyright (c) Microsoft Corporation. All rights reserved.
 * Licensed under the MIT license.
 *
-* Manages focusable elements for better keyboard navigation.
+* Manages focusable elements for better keyboard navigation (web version)
 */
 
 import React = require('react');
 import ReactDOM = require('react-dom');
-import PropTypes = require('prop-types');
 
-import AppConfig from '../../common/AppConfig';
+import {FocusManager as FocusManagerBase,
+    StoredFocusableComponent,
+    OriginalAttributeValues} from '../../common/utils/FocusManager';
+
 import UserInterface from '../UserInterface';
 
 const ATTR_NAME_TAB_INDEX = 'tabindex';
 const ATTR_NAME_ARIA_HIDDEN = 'aria-hidden';
-
-let _lastComponentId: number = 0;
-
-interface StoredFocusableComponent {
-    id: string;
-    component: React.Component<any, any>;
-    onFocus: EventListener;
-    restricted: boolean;
-    limitedCount: number;
-    origTabIndex?: number;
-    origAriaHidden?: string;
-    removed?: boolean;
-    callbacks?: FocusableComponentStateCallback[];
-}
-
-interface OriginalAttributeValues {
-    tabIndex: number|undefined;
-    ariaHidden: string|undefined;
-}
 
 let _isNavigatingWithKeyboard: boolean;
 let _isShiftPressed: boolean;
@@ -43,313 +26,84 @@ UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
     _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 });
 
-let _skipFocusCheck = false;
+import {applyFocusableComponentMixin, FocusableComponentStateCallback} from  '../../common/utils/FocusManager';
+export {applyFocusableComponentMixin, FocusableComponentStateCallback};
 
-if ((typeof document !== 'undefined') && (typeof window !== 'undefined')) {
-    // The default behaviour on Electron is to release the focus after the
-    // Tab key is pressed on a last focusable element in the page and focus
-    // the first focusable element on a consecutive Tab key press.
-    // We want to avoid losing this first Tab key press.
-    let _checkFocusTimer: number|undefined;
+export class FocusManager extends FocusManagerBase {
 
-    // Checking if Shift is pressed to move the focus into the right direction.
-    window.addEventListener('keydown', event => {
-        _isShiftPressed = event.shiftKey;
-    });
-    window.addEventListener('keyup', event => {
-        _isShiftPressed = event.shiftKey;
-    });
+    private static _resetFocusTimer: number | undefined;
 
-    document.body.addEventListener('focusout', event => {
-        if (!_isNavigatingWithKeyboard || (event.target === document.body)) {
-            return;
-        }
-
-        if (_checkFocusTimer) {
-            clearTimeout(_checkFocusTimer);
-        }
-
-        if (_skipFocusCheck) {
-            // When in between the FocusManager restrictions,
-            // don't check for the focus change here, FocusManager
-            // will take care of it.
-            _skipFocusCheck = false;
-            return;
-        }
-
-        _checkFocusTimer = setTimeout(() => {
-            _checkFocusTimer = undefined;
-
-            if (_isNavigatingWithKeyboard &&
-                    (!document.activeElement || (document.activeElement === document.body))) {
-                // This should work for Electron and the browser should
-                // send the focus to the address bar anyway.
-                FocusManager.focusFirst(_isShiftPressed);
-            }
-        }, 0);
-    });
-}
-
-export type FocusableComponentStateCallback = (restrictedOrLimited: boolean) => void;
-
-export class FocusManager {
-    private static _rootFocusManager: FocusManager;
-
-    private static _restrictionStack: FocusManager[] = [];
-    private static _currentRestrictionOwner: FocusManager|undefined;
-    private static _restoreRestrictionTimer: number|undefined;
-    private static _pendingPrevFocusedComponent: StoredFocusableComponent|undefined;
-    private static _currentFocusedComponent: StoredFocusableComponent|undefined;
-    private static _allFocusableComponents: { [id: string]: StoredFocusableComponent } = {};
-    private static _resetFocusTimer: number|undefined;
-
-    private _parent: FocusManager|undefined;
-    private _isFocusLimited: boolean;
-    private _prevFocusedComponent: StoredFocusableComponent|undefined;
-    private _myFocusableComponentIds: { [id: string]: boolean } = {};
-
-    constructor(parent: FocusManager|undefined) {
-        if (parent) {
-            this._parent = parent;
-        } else if (FocusManager._rootFocusManager) {
-            if (AppConfig.isDevelopmentMode()) {
-                console.error('FocusManager: root is already set');
-            }
-        } else {
-            FocusManager._rootFocusManager = this;
-        }
+    constructor(parent: FocusManager | undefined) {
+        super(parent);
     }
 
-    // Whenever the focusable element is mounted, we let the application
-    // know so that FocusManager could account for this element during the
-    // focus restriction.
-    addFocusableComponent(component: React.Component<any, any>) {
-        if ((component as any)._focusableComponentId) {
-            return;
-        }
+    // Not really public
+    public static initListeners(): void {
+        // The default behaviour on Electron is to release the focus after the
+        // Tab key is pressed on a last focusable element in the page and focus
+        // the first focusable element on a consecutive Tab key press.
+        // We want to avoid losing this first Tab key press.
+        let _checkFocusTimer: number|undefined;
 
-        const componentId: string = 'fc-' + ++_lastComponentId;
+        // Checking if Shift is pressed to move the focus into the right direction.
+        window.addEventListener('keydown', event => {
+            _isShiftPressed = event.shiftKey;
+        });
+        window.addEventListener('keyup', event => {
+            _isShiftPressed = event.shiftKey;
+        });
 
-        let storedComponent: StoredFocusableComponent = {
-            id: componentId,
-            component: component,
-            restricted: false,
-            limitedCount: 0,
-            onFocus: () => {
-                FocusManager._currentFocusedComponent = storedComponent;
-            }
-        };
-
-        (component as any)._focusableComponentId = componentId;
-        FocusManager._allFocusableComponents[componentId] = storedComponent;
-
-        let withinRestrictionOwner: boolean = false;
-
-        for (let parent: FocusManager|undefined = this; parent; parent = parent._parent) {
-            parent._myFocusableComponentIds[componentId] = true;
-
-            if (FocusManager._currentRestrictionOwner === parent) {
-                withinRestrictionOwner = true;
+        document.body.addEventListener('focusout', event => {
+            if (!_isNavigatingWithKeyboard || (event.target === document.body)) {
+                return;
             }
 
-            if (parent._isFocusLimited) {
-                storedComponent.limitedCount++;
+            if (_checkFocusTimer) {
+                clearTimeout(_checkFocusTimer);
             }
-        }
 
-        if (!withinRestrictionOwner && FocusManager._currentRestrictionOwner) {
-            storedComponent.restricted = true;
-        }
+            if (FocusManager._skipFocusCheck) {
+                // When in between the FocusManager restrictions,
+                // don't check for the focus change here, FocusManager
+                // will take care of it.
+                FocusManager._skipFocusCheck = false;
+                return;
+            }
 
-        FocusManager._updateComponentFocusRestriction(storedComponent);
+            _checkFocusTimer = setTimeout(() => {
+                _checkFocusTimer = undefined;
 
+                if (_isNavigatingWithKeyboard &&
+                        (!document.activeElement || (document.activeElement === document.body))) {
+                    // This should work for Electron and the browser should
+                    // send the focus to the address bar anyway.
+                    FocusManager.focusFirst(_isShiftPressed);
+                }
+            }, 0);
+        });
+    }
+
+    protected /* static */ addFocusListenerOnComponent(component: React.Component<any, any>, onFocus: () => void): void {
         const el = ReactDOM.findDOMNode(component) as HTMLElement;
         if (el) {
-            el.addEventListener('focus', storedComponent.onFocus);
+            el.addEventListener('focus', onFocus);
         }
     }
 
-    removeFocusableComponent(component: React.Component<any, any>) {
-        const componentId: string = (component as any)._focusableComponentId;
-
-        if (componentId) {
-            const storedComponent: StoredFocusableComponent = FocusManager._allFocusableComponents[componentId];
-
-            const el = ReactDOM.findDOMNode(component) as HTMLElement;
-            if (storedComponent && el) {
-                el.removeEventListener('focus', storedComponent.onFocus);
-            }
-
-            storedComponent.removed = true;
-            storedComponent.restricted = false;
-            storedComponent.limitedCount = 0;
-
-            FocusManager._updateComponentFocusRestriction(storedComponent);
-
-            delete storedComponent.callbacks;
-
-            for (let parent: FocusManager|undefined = this; parent; parent = parent._parent) {
-                delete parent._myFocusableComponentIds[componentId];
-            }
-
-            delete FocusManager._allFocusableComponents[componentId];
-            delete (component as any)._focusableComponentId;
+    protected /* static */ removeFocusListenerFromComponent(component: React.Component<any, any>, onFocus: () => void): void {
+        const el = ReactDOM.findDOMNode(component) as HTMLElement;
+        if (el) {
+            el.removeEventListener('focus', onFocus);
         }
     }
 
-    restrictFocusWithin(noFocusReset?: boolean) {
-        // Limit the focus received by the keyboard navigation to all
-        // the descendant focusable elements by setting tabIndex of all
-        // other elements to -1.
-        if (FocusManager._currentRestrictionOwner === this) {
-            return;
+    protected /* static */ focusComponent(component: React.Component<any, any>): boolean {
+        const el = ReactDOM.findDOMNode(component) as HTMLElement;
+        if (el && el.focus) {
+            el.focus();
+            return true;
         }
-
-        if (FocusManager._currentRestrictionOwner) {
-            FocusManager._removeFocusRestriction();
-        }
-
-        if (!this._prevFocusedComponent) {
-            this._prevFocusedComponent = FocusManager._pendingPrevFocusedComponent || FocusManager._currentFocusedComponent;
-        }
-
-        FocusManager._clearRestoreRestrictionTimeout();
-
-        FocusManager._restrictionStack.push(this);
-        FocusManager._currentRestrictionOwner = this;
-
-        Object.keys(FocusManager._allFocusableComponents).forEach(componentId => {
-            if (!(componentId in this._myFocusableComponentIds)) {
-                const storedComponent = FocusManager._allFocusableComponents[componentId];
-                storedComponent.restricted = true;
-                FocusManager._updateComponentFocusRestriction(storedComponent);
-            }
-        });
-
-        if (!noFocusReset) {
-            FocusManager.resetFocus();
-        }
-    }
-
-    removeFocusRestriction() {
-        // Restore the focus to the previous view with restrictFocusWithin or
-        // remove the restriction if there is no such view.
-        FocusManager._restrictionStack = FocusManager._restrictionStack.filter(focusManager => focusManager !== this);
-
-        if (FocusManager._currentRestrictionOwner === this) {
-            // We'll take care of setting the proper focus below,
-            // no need to do a regular check for focusout.
-            _skipFocusCheck = true;
-
-            let prevFocusedComponent = this._prevFocusedComponent;
-            this._prevFocusedComponent = undefined;
-
-            FocusManager._removeFocusRestriction();
-            FocusManager._currentRestrictionOwner = undefined;
-
-            // Defer the previous restriction restoration to wait for the current view
-            // to be unmounted, or for the next restricted view to be mounted (like
-            // showing a modal after a popup).
-            FocusManager._clearRestoreRestrictionTimeout();
-            FocusManager._pendingPrevFocusedComponent = prevFocusedComponent;
-
-            FocusManager._restoreRestrictionTimer = setTimeout(() => {
-                FocusManager._restoreRestrictionTimer = undefined;
-                FocusManager._pendingPrevFocusedComponent = undefined;
-
-                const prevRestrictionOwner = FocusManager._restrictionStack.pop();
-
-                let needsFocusReset = true;
-
-                const currentFocusedComponent = FocusManager._currentFocusedComponent;
-                if (currentFocusedComponent && !currentFocusedComponent.removed &&
-                        !(currentFocusedComponent.id in this._myFocusableComponentIds)) {
-                    // The focus has been manually moved to something outside of the current
-                    // restriction scope, we should skip focusing the component which was
-                    // focused before the restriction and keep the focus as it is.
-                    prevFocusedComponent = undefined;
-                    needsFocusReset = false;
-                }
-
-                if (prevFocusedComponent && !prevFocusedComponent.removed &&
-                        !prevFocusedComponent.restricted && !prevFocusedComponent.limitedCount) {
-                    // If possible, focus the previously focused component.
-                    const el = ReactDOM.findDOMNode(prevFocusedComponent.component) as HTMLElement;
-                    if (el && el.focus) {
-                        el.focus();
-                        needsFocusReset = false;
-                    }
-                }
-
-                if (prevRestrictionOwner) {
-                    prevRestrictionOwner.restrictFocusWithin(true);
-                }
-
-                if (needsFocusReset) {
-                    FocusManager.resetFocus();
-                }
-            }, 100);
-        }
-    }
-
-    limitFocusWithin() {
-        if (this._isFocusLimited) {
-            return;
-        }
-
-        this._isFocusLimited = true;
-
-        Object.keys(this._myFocusableComponentIds).forEach(componentId => {
-            let storedComponent = FocusManager._allFocusableComponents[componentId];
-            storedComponent.limitedCount++;
-            FocusManager._updateComponentFocusRestriction(storedComponent);
-        });
-    }
-
-    removeFocusLimitation() {
-        if (!this._isFocusLimited) {
-            return;
-        }
-
-        Object.keys(this._myFocusableComponentIds).forEach(componentId => {
-            let storedComponent = FocusManager._allFocusableComponents[componentId];
-            storedComponent.limitedCount--;
-            FocusManager._updateComponentFocusRestriction(storedComponent);
-        });
-
-        this._isFocusLimited = false;
-    }
-
-    release() {
-        this.removeFocusRestriction();
-        this.removeFocusLimitation();
-    }
-
-    subscribe(component: React.Component<any, any>, callback: FocusableComponentStateCallback) {
-        const storedComponent = FocusManager._getStoredComponent(component);
-
-        if (storedComponent) {
-            if (!storedComponent.callbacks) {
-                storedComponent.callbacks = [];
-            }
-
-            storedComponent.callbacks.push(callback);
-        }
-    }
-
-    unsubscribe(component: React.Component<any, any>, callback: FocusableComponentStateCallback) {
-        const storedComponent = FocusManager._getStoredComponent(component);
-
-        if (storedComponent && storedComponent.callbacks) {
-            storedComponent.callbacks = storedComponent.callbacks.filter(cb => {
-                return cb !== callback;
-            });
-        }
-    }
-
-    isComponentFocusRestrictedOrLimited(component: React.Component<any, any>): boolean {
-        const storedComponent = FocusManager._getStoredComponent(component);
-        return !!storedComponent && (storedComponent.restricted || storedComponent.limitedCount > 0);
+        return false;
     }
 
     static focusFirst(last?: boolean) {
@@ -373,7 +127,7 @@ export class FocusManager {
         }
     }
 
-    static resetFocus() {
+    protected /* static */ resetFocus() {
         if (FocusManager._resetFocusTimer) {
             clearTimeout(FocusManager._resetFocusTimer);
             FocusManager._resetFocusTimer = undefined;
@@ -411,39 +165,18 @@ export class FocusManager {
         }
     }
 
-    private static _getStoredComponent(component: React.Component<any, any>): StoredFocusableComponent|undefined {
-        const componentId: string = (component as any)._focusableComponentId;
-
-        if (componentId) {
-            return FocusManager._allFocusableComponents[componentId];
-        }
-
-        return undefined;
-    }
-
-    private static _callFocusableComponentStateChangeCallbacks(storedComponent: StoredFocusableComponent, restrictedOrLimited: boolean) {
-        if (!storedComponent.callbacks) {
-            return;
-        }
-
-        storedComponent.callbacks.forEach(callback => {
-            callback.call(storedComponent.component, restrictedOrLimited);
-        });
-    }
-
-    private static _removeFocusRestriction() {
-        Object.keys(FocusManager._allFocusableComponents).forEach(componentId => {
-            let storedComponent = FocusManager._allFocusableComponents[componentId];
-            storedComponent.restricted = false;
-            FocusManager._updateComponentFocusRestriction(storedComponent);
-        });
-    }
-
-    private static _clearRestoreRestrictionTimeout() {
-        if (FocusManager._restoreRestrictionTimer) {
-            clearTimeout(FocusManager._restoreRestrictionTimer);
-            FocusManager._restoreRestrictionTimer = undefined;
-            FocusManager._pendingPrevFocusedComponent = undefined;
+    protected /* static */  _updateComponentFocusRestriction(storedComponent: StoredFocusableComponent) {
+        if ((storedComponent.restricted || (storedComponent.limitedCount > 0)) && !('origTabIndex' in storedComponent)) {
+            const origValues = FocusManager._setComponentTabIndexAndAriaHidden(storedComponent.component, -1, 'true');
+            storedComponent.origTabIndex = origValues ? origValues.tabIndex : undefined;
+            storedComponent.origAriaHidden = origValues ? origValues.ariaHidden : undefined;
+            FocusManager._callFocusableComponentStateChangeCallbacks(storedComponent, true);
+        } else if (!storedComponent.restricted && !storedComponent.limitedCount && ('origTabIndex' in storedComponent)) {
+            FocusManager._setComponentTabIndexAndAriaHidden(storedComponent.component,
+                    storedComponent.origTabIndex, storedComponent.origAriaHidden);
+            delete storedComponent.origTabIndex;
+            delete storedComponent.origAriaHidden;
+            FocusManager._callFocusableComponentStateChangeCallbacks(storedComponent, false);
         }
     }
 
@@ -488,75 +221,10 @@ export class FocusManager {
 
         return prev;
     }
-
-    private static _updateComponentFocusRestriction(storedComponent: StoredFocusableComponent) {
-        if ((storedComponent.restricted || (storedComponent.limitedCount > 0)) && !('origTabIndex' in storedComponent)) {
-            const origValues = FocusManager._setComponentTabIndexAndAriaHidden(storedComponent.component, -1, 'true');
-            storedComponent.origTabIndex = origValues ? origValues.tabIndex : undefined;
-            storedComponent.origAriaHidden = origValues ? origValues.ariaHidden : undefined;
-            FocusManager._callFocusableComponentStateChangeCallbacks(storedComponent, true);
-        } else if (!storedComponent.restricted && !storedComponent.limitedCount && ('origTabIndex' in storedComponent)) {
-            FocusManager._setComponentTabIndexAndAriaHidden(storedComponent.component,
-                    storedComponent.origTabIndex, storedComponent.origAriaHidden);
-            delete storedComponent.origTabIndex;
-            delete storedComponent.origAriaHidden;
-            FocusManager._callFocusableComponentStateChangeCallbacks(storedComponent, false);
-        }
-    }
 }
 
-// A mixin for the focusable elements, to tell the views that
-// they exist and should be accounted during the focus restriction.
-//
-// isConditionallyFocusable is an optional callback which will be
-// called for componentDidMount() or for componentWillUpdate() to
-// determine if the component is actually focusable.
-export function applyFocusableComponentMixin(Component: any, isConditionallyFocusable?: Function) {
-    let contextTypes = Component.contextTypes || {};
-    contextTypes.focusManager = PropTypes.object;
-    Component.contextTypes = contextTypes;
-
-    inheritMethod('componentDidMount', function (this: React.Component<any, any>, focusManager: FocusManager) {
-        if (!isConditionallyFocusable || isConditionallyFocusable.call(this)) {
-            focusManager.addFocusableComponent(this);
-        }
-    });
-
-    inheritMethod('componentWillUnmount', function (this: React.Component<any, any>, focusManager: FocusManager) {
-        focusManager.removeFocusableComponent(this);
-    });
-
-    inheritMethod('componentWillUpdate', function (this: React.Component<any, any>, focusManager: FocusManager, origArguments: IArguments) {
-        if (isConditionallyFocusable) {
-            let isFocusable = isConditionallyFocusable.apply(this, origArguments);
-
-            if (isFocusable && !(this as any)._focusableComponentId) {
-                focusManager.addFocusableComponent(this);
-            } else if (!isFocusable && (this as any)._focusableComponentId) {
-                focusManager.removeFocusableComponent(this);
-            }
-        }
-    });
-
-    function inheritMethod(methodName: string, action: Function) {
-        let origCallback = Component.prototype[methodName];
-
-        Component.prototype[methodName] = function () {
-            let focusManager: FocusManager = this._focusManager || (this.context && this.context.focusManager);
-
-            if (focusManager) {
-                action.call(this, focusManager, arguments);
-            } else {
-                if (AppConfig.isDevelopmentMode()) {
-                    console.error('FocusableComponentMixin: context error!');
-                }
-            }
-
-            if (origCallback) {
-                origCallback.apply(this, arguments);
-            }
-        };
-    }
+if ((typeof document !== 'undefined') && (typeof window !== 'undefined')) {
+    FocusManager.initListeners();
 }
 
 export default FocusManager;

--- a/src/windows/Animated.tsx
+++ b/src/windows/Animated.tsx
@@ -12,7 +12,7 @@ import RN = require('react-native');
 import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
 import RXView from './View';
-import {Animated as AnimatedBase} from '../native-common/Animated';
+import { Animated as AnimatedBase } from '../native-common/Animated';
 
 var ReactAnimatedView = RN.Animated.createAnimatedComponent(RXView, true);
 

--- a/src/windows/Animated.tsx
+++ b/src/windows/Animated.tsx
@@ -1,0 +1,101 @@
+/**
+* Animated.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN Windows-specific implementation of Animated wrapper.
+*/
+
+import React = require('react');
+import RN = require('react-native');
+import RX = require('../common/Interfaces');
+import Types = require('../common/Types');
+import RXView from './View';
+import {Animated as AnimatedBase} from '../native-common/Animated';
+
+var ReactAnimatedView = RN.Animated.createAnimatedComponent(RXView, true);
+
+export class AnimatedView extends RX.AnimatedView {
+
+    private _animatedComponent: typeof ReactAnimatedView;
+
+    constructor(props: Types.AnimatedViewProps) {
+        super(props);
+    }
+
+    setNativeProps(props: Types.AnimatedViewProps) {
+        if (this._animatedComponent) {
+            if (!this._animatedComponent.setNativeProps) {
+                throw 'Component does not implement setNativeProps';
+            }
+            this._animatedComponent.setNativeProps(props);
+        }
+    }
+
+    render() {
+        return (
+            <ReactAnimatedView
+                ref={ this._onAnimatedComponentRef }
+                { ...this.props }
+            >
+                { this.props.children }
+            </ReactAnimatedView>
+        );
+    }
+
+    focus() {
+        if (this._animatedComponent && this._animatedComponent._component) {
+            this._animatedComponent._component.focus();
+        }
+    }
+
+    blur() {
+        if (this._animatedComponent && this._animatedComponent._component) {
+            this._animatedComponent._component.blur();
+        }
+    }
+
+    setFocusRestricted(restricted: boolean) {
+        if (this._animatedComponent && this._animatedComponent._component) {
+            this._animatedComponent._component.setFocusRestricted(restricted);
+        }
+    }
+
+    setFocusLimited(limited: boolean) {
+        if (this._animatedComponent && this._animatedComponent._component) {
+            this._animatedComponent._component.setFocusLimited(limited);
+        }
+    }
+
+    private _onAnimatedComponentRef = (ref: typeof ReactAnimatedView) => {
+        this._animatedComponent = ref;
+    }
+}
+
+export type AnimatedValue = typeof AnimatedBase.Value;
+
+export var Animated = {
+    Image: AnimatedBase.Image as typeof RX.AnimatedImage,
+    Text: AnimatedBase.Text as typeof RX.AnimatedText,
+    TextInput: AnimatedBase.TextInput as typeof RX.AnimatedTextInput,
+    View: AnimatedView as typeof RX.AnimatedView,
+    Easing: AnimatedBase.Easing as Types.Animated.Easing,
+    timing: AnimatedBase.timing as Types.Animated.TimingFunction,
+    delay: AnimatedBase.delay,
+    parallel: AnimatedBase.parallel,
+    sequence: AnimatedBase.sequence,
+
+    // NOTE: Direct access to "Value" will be going away in the near future.
+    // Please move to createValue and interpolate instead.
+    Value: RN.Animated.Value,
+    createValue: (initialValue: number) => new RN.Animated.Value(initialValue),
+    interpolate: (animatedValue: RN.Animated.Value, inputRange: number[], outputRange: string[]) => {
+        return animatedValue.interpolate({
+            inputRange: inputRange,
+            outputRange: outputRange
+        });
+    }
+};
+
+export default Animated;

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -23,7 +23,6 @@ const UP_KEYCODES = [KEY_CODE_SPACE];
 
 let _isNavigatingWithKeyboard = false;
 
-// TODO: take this into account
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 });
@@ -183,6 +182,7 @@ export class Button extends ButtonBase implements FocusManagerFocusableComponent
             }
         }
     }
+
     onFocus() {
         // Focus Manager hook
     }

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -28,7 +28,7 @@ UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
 });
 
 // Simple check for the presence of the updated React Native for Windows
-const IsUpdatedReactNativeForWindows = (RNW.FocusableWindows !== undefined);
+const HasFocusableWindows = (RNW.FocusableWindows !== undefined);
 
 export class Button extends ButtonBase implements FocusManagerFocusableComponent {
 
@@ -45,7 +45,7 @@ export class Button extends ButtonBase implements FocusManagerFocusableComponent
     protected _render(internalProps: RN.ViewProps): JSX.Element {
 
         // Fallback to native-common fast if the keyboard enabled component is not available
-        if (!IsUpdatedReactNativeForWindows) {
+        if (!HasFocusableWindows) {
             return super._render(internalProps);
         }
 
@@ -115,7 +115,6 @@ export class Button extends ButtonBase implements FocusManagerFocusableComponent
                 // ENTER triggers press on key down
                 if (key === KEY_CODE_ENTER) {
                     this.props.onPress(keyEvent);
-                    return;
                 }
             }
         }

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -1,0 +1,167 @@
+/**
+* Button.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN Windows-specific implementation of the cross-platform Button abstraction.
+*/
+
+import React = require('react');
+import {Button as ButtonBase} from '../native-common/Button';
+import EventHelpers from '../native-common/utils/EventHelpers';
+import UserInterface from '../native-desktop/UserInterface';
+import RN = require('react-native');
+import RNW = require('react-native-windows');
+import { applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
+
+const KEY_CODE_ENTER = 13;
+const KEY_CODE_SPACE = 32;
+
+const DOWN_KEYCODES = [KEY_CODE_SPACE, KEY_CODE_ENTER];
+const UP_KEYCODES = [KEY_CODE_SPACE];
+
+// let _isNavigatingWithKeyboard = false;
+
+// TODO: take this into account
+UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
+   // _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+});
+
+// Simple check for the presence of the updated React Native for Windows
+const IsUpdatedReactNativeForWindows = (RNW.FocusableWindows !== undefined);
+
+export class Button extends ButtonBase implements FocusManagerFocusableComponent {
+
+    private _focusableElement : RNW.FocusableWindows | null = null;
+
+    private _onFocusableRef = (btn: RNW.FocusableWindows): void => {
+        this._focusableElement = btn;
+    }
+
+    protected _render(internalProps: RN.ViewProps): JSX.Element {
+
+        // Fallback to native-common fast if the keyboard enabled component is not available
+        if (!IsUpdatedReactNativeForWindows) {
+            return super._render(internalProps);
+        }
+
+        // RNW.FocusableProps tabIndex: default is 0.
+        // -1 has no special semantic similar to DOM.
+        let tabIndex: number | undefined = this.getTabIndex();
+        // RNW.FocusableProps windowsTabFocusable:
+        // - true: keyboard focusable through any mean, receives keyboard input
+        // - false: not focusable at all, doesn't receive keyboard input
+        // The intermediate "focusable, but not in the tab order" case is not supported.
+        let windowsTabFocusable: boolean = !this.props.disabled && tabIndex !== undefined && tabIndex >= 0;
+
+        // RNW.FocusableWindows doesn't participate in layouting, it basically mimics the position/size of the child
+        let focusableViewProps: RNW.FocusableProps = {
+            ref: this._onFocusableRef,
+            isTabStop: windowsTabFocusable,
+            tabIndex: tabIndex,
+            disableSystemFocusVisuals: false,
+            handledKeyDownKeys: DOWN_KEYCODES,
+            handledKeyUpKeys: UP_KEYCODES,
+            onKeyDown: this._onKeyDown,
+            onKeyUp: this._onKeyUp,
+            onFocus: this._onFocus,
+            onBlur: this._onBlur
+        };
+
+        return (
+            <RNW.FocusableWindows
+                {...focusableViewProps}
+            >
+                <RN.Animated.View
+                    {...internalProps}
+                >
+                    { this.props.children }
+                </RN.Animated.View>
+            </RNW.FocusableWindows>
+        );
+    }
+
+    focus() {
+        super.focus();
+        if (this._focusableElement && this._focusableElement.focus) {
+            this._focusableElement.focus();
+        }
+
+    }
+
+    blur() {
+        super.blur();
+        if (this._focusableElement && this._focusableElement.blur) {
+            this._focusableElement.blur();
+        }
+    }
+
+    private _onKeyDown = (e: React.SyntheticEvent<any>): void => {
+
+        if (!this.props.disabled) {
+            let keyEvent = EventHelpers.toKeyboardEvent(e);
+            if (this.props.onKeyPress) {
+                this.props.onKeyPress(keyEvent);
+            }
+
+            if (this.props.onPress) {
+                let key = keyEvent.keyCode;
+                // ENTER triggers press on key down
+                if (key === KEY_CODE_ENTER) {
+                    this.props.onPress(keyEvent);
+                    return;
+                }
+            }
+        }
+    }
+
+    private _onKeyUp = (e: React.SyntheticEvent<any>): void => {
+
+        let keyEvent = EventHelpers.toKeyboardEvent(e);
+        if (keyEvent.keyCode === KEY_CODE_SPACE) {
+            if (!this.props.disabled && this.props.onPress) {
+                this.props.onPress(keyEvent);
+            }
+        }
+    }
+
+    private _onFocus = (e: React.SyntheticEvent<any>): void => {
+        this.onFocus();
+        if (this.props.onFocus) {
+            this.props.onFocus(EventHelpers.toFocusEvent(e));
+        }
+    }
+
+    private _onBlur = (e: React.SyntheticEvent<any>): void => {
+        if (this.props.onBlur) {
+            this.props.onBlur(EventHelpers.toFocusEvent(e));
+        }
+    }
+
+    onFocus() {
+        // Focus Manager hook
+    }
+
+    getTabIndex(): number | undefined {
+        // Button defaults to a tabIndex of 0
+        // Focus Manager may override this
+        return this.props.tabIndex || 0;
+    }
+
+    updateNativeTabIndex(): void {
+        if (this._focusableElement) {
+            let tabIndex: number | undefined = this.getTabIndex();
+            let windowsTabFocusable: boolean = !this.props.disabled && tabIndex !== undefined && tabIndex >= 0;
+
+            this._focusableElement.setNativeProps({
+                tabIndex: tabIndex,
+                isTabStop: windowsTabFocusable
+            });
+        }
+    }
+}
+
+applyFocusableComponentMixin(Button);
+
+export default Button;

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -8,7 +8,7 @@
 */
 
 import React = require('react');
-import {Button as ButtonBase} from '../native-common/Button';
+import { Button as ButtonBase } from '../native-common/Button';
 import EventHelpers from '../native-common/utils/EventHelpers';
 import UserInterface from '../native-desktop/UserInterface';
 import RN = require('react-native');
@@ -49,7 +49,6 @@ export class Button extends ButtonBase implements FocusManagerFocusableComponent
     }
 
     protected _render(internalProps: RN.ViewProps): JSX.Element {
-
         // Fallback to native-common fast if the keyboard enabled component is not available
         if (!HasFocusableWindows) {
             return super._render(internalProps);
@@ -105,7 +104,7 @@ export class Button extends ButtonBase implements FocusManagerFocusableComponent
 
     }
 
-blur() {
+    blur() {
         super.blur();
         if (this._focusableElement && this._focusableElement.blur) {
             this._focusableElement.blur();
@@ -122,7 +121,6 @@ blur() {
     }
 
     private _onKeyDown = (e: React.SyntheticEvent<any>): void => {
-
         if (!this.props.disabled) {
             let keyEvent = EventHelpers.toKeyboardEvent(e);
             if (this.props.onKeyPress) {
@@ -140,7 +138,6 @@ blur() {
     }
 
     private _onKeyUp = (e: React.SyntheticEvent<any>): void => {
-
         let keyEvent = EventHelpers.toKeyboardEvent(e);
         if (keyEvent.keyCode === KEY_CODE_SPACE) {
             if (!this.props.disabled && this.props.onPress) {
@@ -203,17 +200,17 @@ blur() {
 
     // From FocusManagerFocusableComponent interface
     //
-onFocus() {
+    onFocus() {
         // Focus Manager hook
     }
 
-getTabIndex(): number | undefined {
+    getTabIndex(): number | undefined {
         // Button defaults to a tabIndex of 0
         // Focus Manager may override this
         return this.props.tabIndex || 0;
     }
 
-updateNativeTabIndex(): void {
+    updateNativeTabIndex(): void {
         if (this._focusableElement) {
             let tabIndex: number | undefined = this.getTabIndex();
             let windowsTabFocusable: boolean = !this.props.disabled && tabIndex !== undefined && tabIndex >= 0;

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -182,6 +182,8 @@ export class Button extends ButtonBase implements FocusManagerFocusableComponent
         }
     }
 
+    // From FocusManagerFocusableComponent interface
+    //
     onFocus() {
         // Focus Manager hook
     }

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -159,7 +159,9 @@ export class Button extends ButtonBase implements FocusManagerFocusableComponent
     // When we get focus on an element, show the hover effect on the element.
     // This ensures that users using keyboard also get the similar experience as mouse users for accessibility.
     private _onFocus = (e: React.SyntheticEvent<any>): void => {
-        this.onFocus();
+        if (e.currentTarget === e.target) {
+            this.onFocus();
+        }
 
         this._isFocusedWithKeyboard = _isNavigatingWithKeyboard;
         this._onHoverStart(e);

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -38,7 +38,7 @@ export class Button extends ButtonBase implements FocusManagerFocusableComponent
     private _isFocusedWithKeyboard = false;
     private _isHoverStarted = false;
 
-    private _onFocusableRef = (btn: RNW.FocusableWindows): void => {
+    private _onFocusableRef = (btn: RNW.FocusableWindows | null): void => {
         this._focusableElement = btn;
     }
 

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -144,8 +144,9 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     }
 
     getTabIndex(): number | undefined {
+        // Link defaults to a tabIndex of 0
         // Focus Manager may override this
-        return 0;
+        return this.props.tabIndex || 0;
     }
 
     updateNativeTabIndex(): void {

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -1,0 +1,148 @@
+/**
+* Link.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN Desktop-specific implementation of the cross-platform Link abstraction.
+*/
+
+import React = require('react');
+import RNW = require('react-native-windows');
+import {applyFocusableComponentMixin, FocusManagerFocusableComponent} from '../native-desktop/utils/FocusManager';
+import PropTypes = require('prop-types');
+
+import EventHelpers from '../native-common/utils/EventHelpers';
+import {Link as LinkCommon } from '../native-common/Link';
+
+const KEY_CODE_ENTER = 13;
+const KEY_CODE_SPACE = 32;
+
+const DOWN_KEYCODES = [KEY_CODE_SPACE, KEY_CODE_ENTER];
+const UP_KEYCODES = [KEY_CODE_SPACE];
+
+export interface LinkContext {
+    isRxParentAText?: boolean;
+}
+
+// Simple check for the presence of the updated React Native for Windows
+const IsUpdatedReactNativeForWindows = (RNW.FocusableWindows !== undefined);
+
+export class Link extends LinkCommon implements FocusManagerFocusableComponent {
+    static contextTypes: React.ValidationMap<any> = {
+        isRxParentAText: PropTypes.bool,
+    };
+    context: LinkContext;
+
+    private _focusableElement : RNW.FocusableWindows | null = null;
+
+    private _onFocusableRef = (btn: RNW.FocusableWindows): void => {
+        this._focusableElement = btn;
+    }
+
+    render() {
+
+        // Fallback to native-common fast if the keyboard enabled component is not available
+        if (!IsUpdatedReactNativeForWindows) {
+            return super.render();
+        }
+
+        let content: JSX.Element = super.render();
+
+        // The "in text parent" case requires a special nyi control.
+        if (this.context && !this.context.isRxParentAText) {
+
+            let tabIndex: number | undefined = this.getTabIndex();
+            let windowsTabFocusable: boolean =  tabIndex !== undefined && tabIndex >= 0;
+
+            // RNW.FocusableWindows doesn't participate in layouting, it basically mimics the position/size of the child
+            let focusableViewProps: RNW.FocusableProps = {
+                ref: this._onFocusableRef,
+                isTabStop: windowsTabFocusable,
+                tabIndex: tabIndex,
+                disableSystemFocusVisuals: false,
+                handledKeyDownKeys: DOWN_KEYCODES,
+                handledKeyUpKeys: UP_KEYCODES,
+                onKeyDown: this._onKeyDown,
+                onKeyUp: this._onKeyUp,
+                onFocus: this._onFocus,
+            };
+
+            content = (
+                <RNW.FocusableWindows
+                    {...focusableViewProps}
+                >
+                    {content}
+                </RNW.FocusableWindows>
+            );
+        }
+
+        return content;
+    }
+
+    focus() {
+        if (this._focusableElement &&
+            this._focusableElement.focus) {
+                this._focusableElement.focus();
+        }
+    }
+
+    blur() {
+        if (this._focusableElement &&
+            this._focusableElement.blur) {
+                this._focusableElement.blur();
+        }
+    }
+
+    private _onKeyDown = (e: React.SyntheticEvent<any>): void => {
+        if (this.props.onPress) {
+            let keyEvent = EventHelpers.toKeyboardEvent(e);
+            let key = keyEvent.keyCode;
+            // ENTER triggers press on key down
+            if (key === KEY_CODE_ENTER) {
+                // Defer to base class
+                this._onPress(keyEvent);
+                return;
+            }
+        }
+    }
+
+    private _onKeyUp = (e: React.SyntheticEvent<any>): void => {
+        if (this.props.onPress) {
+            let keyEvent = EventHelpers.toKeyboardEvent(e);
+            if (keyEvent.keyCode === KEY_CODE_SPACE) {
+                 // Defer to base class
+                this._onPress(keyEvent);
+            }
+        }
+    }
+
+    private _onFocus = (e: React.SyntheticEvent<any>): void => {
+        this.onFocus();
+    }
+
+    onFocus() {
+        // Focus Manager hook
+    }
+
+    getTabIndex(): number | undefined {
+        // Focus Manager may override this
+        return 0;
+    }
+
+    updateNativeTabIndex(): void {
+        if (this._focusableElement) {
+            let tabIndex: number | undefined = this.getTabIndex();
+            let windowsTabFocusable: boolean = tabIndex !== undefined && tabIndex >= 0;
+
+            this._focusableElement.setNativeProps({
+                tabIndex: tabIndex,
+                isTabStop: windowsTabFocusable
+            });
+        }
+    }
+}
+
+applyFocusableComponentMixin(Link);
+
+export default Link;

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -102,7 +102,6 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
             if (key === KEY_CODE_ENTER) {
                 // Defer to base class
                 this._onPress(keyEvent);
-                return;
             }
         }
     }

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -121,6 +121,8 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
         this.onFocus();
     }
 
+    // From FocusManagerFocusableComponent interface
+    //
     onFocus() {
         // Focus Manager hook
     }

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -26,7 +26,7 @@ export interface LinkContext {
 }
 
 // Simple check for the presence of the updated React Native for Windows
-const IsUpdatedReactNativeForWindows = (RNW.FocusableWindows !== undefined);
+const HasFocusableWindows = (RNW.FocusableWindows !== undefined);
 
 export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     static contextTypes: React.ValidationMap<any> = {
@@ -43,7 +43,7 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     render() {
 
         // Fallback to native-common fast if the keyboard enabled component is not available
-        if (!IsUpdatedReactNativeForWindows) {
+        if (!HasFocusableWindows) {
             return super.render();
         }
 

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -53,7 +53,6 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
             return super._render(internalProps);
         }
 
-        // The "in text parent" case requires a special nyi control.
         if (this.context && !this.context.isRxParentAText) {
 
             let tabIndex: number | undefined = this.getTabIndex();
@@ -86,6 +85,8 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
                 />
             );
         } else {
+            // TODO: The "in text parent" case requires a React Native view that maps to
+            // XAML Hyperlink but this RN view isn't implemented yet.
             return super._render(internalProps);
         }
     }
@@ -134,7 +135,9 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     }
 
     private _onFocus = (e: React.SyntheticEvent<any>): void => {
-        this.onFocus();
+        if (e.currentTarget === e.target) {
+            this.onFocus();
+        }
     }
 
     // From FocusManagerFocusableComponent interface

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -10,11 +10,11 @@
 import React = require('react');
 import RN = require('react-native');
 import RNW = require('react-native-windows');
-import {applyFocusableComponentMixin, FocusManagerFocusableComponent} from '../native-desktop/utils/FocusManager';
+import { applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
 import PropTypes = require('prop-types');
 
 import EventHelpers from '../native-common/utils/EventHelpers';
-import {Link as LinkCommon } from '../native-common/Link';
+import { Link as LinkCommon } from '../native-common/Link';
 
 const KEY_CODE_ENTER = 13;
 const KEY_CODE_SPACE = 32;
@@ -37,7 +37,7 @@ if (HasFocusableWindows) {
 
 export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     static contextTypes: React.ValidationMap<any> = {
-        isRxParentAText: PropTypes.bool,
+        isRxParentAText: PropTypes.bool
     };
     context: LinkContext;
 
@@ -48,7 +48,6 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     }
 
     protected _render(internalProps: RN.TextProps) {
-
         // Fallback to native-common fast if the keyboard enabled component is not available
         if (!HasFocusableWindows) {
             return super._render(internalProps);
@@ -78,12 +77,12 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
                 handledKeyUpKeys: UP_KEYCODES,
                 onKeyDown: this._onKeyDown,
                 onKeyUp: this._onKeyUp,
-                onFocus: this._onFocus,
+                onFocus: this._onFocus
             };
 
             return (
                 <FocusableText
-                    {...focusableTextProps}
+                    { ...focusableTextProps }
                 />
             );
         } else {
@@ -92,16 +91,14 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     }
 
     focus() {
-        if (this._focusableElement &&
-            this._focusableElement.focus) {
-                this._focusableElement.focus();
+        if (this._focusableElement && this._focusableElement.focus) {
+            this._focusableElement.focus();
         }
     }
 
     blur() {
-        if (this._focusableElement &&
-            this._focusableElement.blur) {
-                this._focusableElement.blur();
+        if (this._focusableElement && this._focusableElement.blur) {
+            this._focusableElement.blur();
         }
     }
 

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -36,7 +36,7 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
 
     private _focusableElement : RNW.FocusableWindows | null = null;
 
-    private _onFocusableRef = (btn: RNW.FocusableWindows): void => {
+    private _onFocusableRef = (btn: RNW.FocusableWindows | null): void => {
         this._focusableElement = btn;
     }
 

--- a/src/windows/ReactXP.ts
+++ b/src/windows/ReactXP.ts
@@ -66,7 +66,6 @@ AccessibilityUtil.setAccessibilityPlatformUtil(AccessibilityPlatformUtil);
 // -- STRANGE THINGS GOING ON HERE --
 // See web/ReactXP.tsx for more details.
 
-// TODO change
 module ReactXP {
     export type Accessibility = RXInterfaces.Accessibility;
     export var Accessibility: RXInterfaces.Accessibility = AccessibilityImpl;

--- a/src/windows/ReactXP.ts
+++ b/src/windows/ReactXP.ts
@@ -10,7 +10,7 @@
 
 import React = require('react');
 
-import AnimatedImpl = require('../native-common/Animated');
+import AnimatedImpl = require('./Animated');
 import RXInterfaces = require('../common/Interfaces');
 import RXModuleInterface = require('../common/ModuleInterface');
 import RXTypes = require('../common/Types');
@@ -22,29 +22,29 @@ import AccessibilityImpl from './Accessibility';
 import ActivityIndicatorImpl from '../native-common/ActivityIndicator';
 import AlertImpl from '../native-common/Alert';
 import AppImpl from '../native-common/App';
-import ButtonImpl from '../native-common/Button';
+import ButtonImpl from './Button';
 import PickerImpl from '../native-common/Picker';
 import ImageImpl from '../native-common/Image';
 import ClipboardImpl from '../native-common/Clipboard';
 import GestureViewImpl from './GestureView';
 import InputImpl from '../native-common/Input';
 import InternationalImpl from '../native-common/International';
-import LinkImpl from '../native-common/Link';
+import LinkImpl from './Link';
 import LinkingImpl from './Linking';
 import LocationImpl from '../common/Location';
 import ModalImpl from '../native-common/Modal';
 import NetworkImpl from '../native-common/Network';
 import PlatformImpl from '../native-common/Platform';
 import PopupImpl from '../native-common/Popup';
-import ScrollViewImpl from '../native-common/ScrollView';
+import ScrollViewImpl from './ScrollView';
 import StatusBarImpl from './StatusBar';
 import StorageImpl from '../native-common/Storage';
 import StylesImpl from '../native-common/Styles';
 import TextImpl from '../native-common/Text';
-import TextInputImpl from '../native-common/TextInput';
+import TextInputImpl from './TextInput';
 import UserInterfaceImpl from '../native-common/UserInterface';
 import UserPresenceImpl from '../native-common/UserPresence';
-import ViewImpl from '../native-common/View';
+import ViewImpl from './View';
 import WebViewImpl from '../native-common/WebView';
 import ViewBase from '../native-common/ViewBase';
 
@@ -57,7 +57,7 @@ ViewBase.setDefaultViewStyle(_defaultViewStyle);
 
 // Initialize Windows implementation of platform accessibility helpers inside the singleton
 // instance of native-common AccessibilityUtil. This is to let native-common components access
-// platform specific APIs through native-common implementation itself. 
+// platform specific APIs through native-common implementation itself.
 import AccessibilityUtil from '../native-common/AccessibilityUtil';
 import AccessibilityPlatformUtil from './AccessibilityUtil';
 
@@ -66,6 +66,7 @@ AccessibilityUtil.setAccessibilityPlatformUtil(AccessibilityPlatformUtil);
 // -- STRANGE THINGS GOING ON HERE --
 // See web/ReactXP.tsx for more details.
 
+// TODO change
 module ReactXP {
     export type Accessibility = RXInterfaces.Accessibility;
     export var Accessibility: RXInterfaces.Accessibility = AccessibilityImpl;

--- a/src/windows/ReactXP.ts
+++ b/src/windows/ReactXP.ts
@@ -21,7 +21,7 @@ import RXTypes = require('../common/Types');
 import AccessibilityImpl from './Accessibility';
 import ActivityIndicatorImpl from '../native-common/ActivityIndicator';
 import AlertImpl from '../native-common/Alert';
-import AppImpl from '../native-common/App';
+import AppImpl from '../native-desktop/App';
 import ButtonImpl from './Button';
 import PickerImpl from '../native-common/Picker';
 import ImageImpl from '../native-common/Image';

--- a/src/windows/ScrollView.tsx
+++ b/src/windows/ScrollView.tsx
@@ -9,13 +9,9 @@
 
 import React = require('react');
 import RN = require('react-native');
-import RNW = require('react-native-windows');
 import {ScrollView as ScrollViewBase} from '../native-common/ScrollView';
 
 import EventHelpers from '../native-common/utils/EventHelpers';
-
-// The enhanced ScrollView can be accessed through the RN realm
-RNW.ScrollView = RN.ScrollView;
 
 export class ScrollView extends ScrollViewBase {
 
@@ -33,7 +29,7 @@ export class ScrollView extends ScrollViewBase {
 
         return (
 
-            <RNW.ScrollView
+            <RN.ScrollView
                 {...props}
                 onKeyDown={ onKeyDownCallback }
                 keyboardShouldPersistTaps={ keyboardShouldPersistTaps }
@@ -41,7 +37,7 @@ export class ScrollView extends ScrollViewBase {
                 disableKeyboardBasedScrolling={true}
             >
                 {props.children}
-            </RNW.ScrollView>
+            </RN.ScrollView>
         );
     }
 

--- a/src/windows/ScrollView.tsx
+++ b/src/windows/ScrollView.tsx
@@ -1,0 +1,55 @@
+/**
+* ScrollView.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN Windows-specific implementation of the cross-platform ScrollView abstraction.
+*/
+
+import React = require('react');
+import RN = require('react-native');
+import RNW = require('react-native-windows');
+import {ScrollView as ScrollViewBase} from '../native-common/ScrollView';
+
+import EventHelpers from '../native-common/utils/EventHelpers';
+
+// The enhanced ScrollView can be accessed through the RN realm
+RNW.ScrollView = RN.ScrollView;
+
+export class ScrollView extends ScrollViewBase {
+
+    protected _render(props: RN.ScrollViewProps): JSX.Element {
+
+        var onKeyDownCallback = this.props.onKeyPress ?
+                // We have a callback function, call the wrapper
+                this._onKeyDown :
+                undefined;
+
+        // TODO: #737970 Remove special case for UWP when this bug is fixed. The bug
+        //   causes you to have to click twice instead of once on some pieces of UI in
+        //   order for the UI to acknowledge your interaction.
+        const keyboardShouldPersistTaps = 'always';
+
+        return (
+
+            <RNW.ScrollView
+                {...props}
+                onKeyDown={ onKeyDownCallback }
+                keyboardShouldPersistTaps={ keyboardShouldPersistTaps }
+                tabNavigation={ this.props.tabNavigation }
+                disableKeyboardBasedScrolling={true}
+            >
+                {props.children}
+            </RNW.ScrollView>
+        );
+    }
+
+    private _onKeyDown = (e: React.SyntheticEvent<any>) => {
+        if (this.props.onKeyPress) {
+            this.props.onKeyPress(EventHelpers.toKeyboardEvent(e));
+        }
+    }
+}
+
+export default ScrollView;

--- a/src/windows/ScrollView.tsx
+++ b/src/windows/ScrollView.tsx
@@ -9,18 +9,14 @@
 
 import React = require('react');
 import RN = require('react-native');
-import {ScrollView as ScrollViewBase} from '../native-common/ScrollView';
+import { ScrollView as ScrollViewBase } from '../native-common/ScrollView';
 
 import EventHelpers from '../native-common/utils/EventHelpers';
 
 export class ScrollView extends ScrollViewBase {
 
     protected _render(props: RN.ScrollViewProps): JSX.Element {
-
-        var onKeyDownCallback = this.props.onKeyPress ?
-            // We have a callback function, call the wrapper
-            this._onKeyDown :
-            undefined;
+        var onKeyDownCallback = this.props.onKeyPress ? this._onKeyDown : undefined;
 
         // TODO: #737970 Remove special case for UWP when this bug is fixed. The bug
         //   causes you to have to click twice instead of once on some pieces of UI in
@@ -29,13 +25,13 @@ export class ScrollView extends ScrollViewBase {
 
         return (
             <RN.ScrollView
-                {...props}
+                { ...props }
                 onKeyDown={ onKeyDownCallback }
                 keyboardShouldPersistTaps={ keyboardShouldPersistTaps }
                 tabNavigation={ this.props.tabNavigation }
-                disableKeyboardBasedScrolling={true}
+                disableKeyboardBasedScrolling={ true }
             >
-                {props.children}
+                { props.children }
             </RN.ScrollView>
         );
     }

--- a/src/windows/ScrollView.tsx
+++ b/src/windows/ScrollView.tsx
@@ -18,9 +18,9 @@ export class ScrollView extends ScrollViewBase {
     protected _render(props: RN.ScrollViewProps): JSX.Element {
 
         var onKeyDownCallback = this.props.onKeyPress ?
-                // We have a callback function, call the wrapper
-                this._onKeyDown :
-                undefined;
+            // We have a callback function, call the wrapper
+            this._onKeyDown :
+            undefined;
 
         // TODO: #737970 Remove special case for UWP when this bug is fixed. The bug
         //   causes you to have to click twice instead of once on some pieces of UI in
@@ -28,7 +28,6 @@ export class ScrollView extends ScrollViewBase {
         const keyboardShouldPersistTaps = 'always';
 
         return (
-
             <RN.ScrollView
                 {...props}
                 onKeyDown={ onKeyDownCallback }

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -1,0 +1,61 @@
+/**
+* TextInput.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN Windows-specific implementation of the cross-platform TextInput abstraction.
+*/
+
+import React = require('react');
+import RN = require('react-native');
+import RNW = require('react-native-windows');
+
+import {applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
+
+import {TextInput as TextInputBase} from '../native-common/TextInput';
+
+// The enhanced TextInput can be accessed through the RN realm
+RNW.TextInput = RN.TextInput;
+
+export class TextInput extends TextInputBase implements FocusManagerFocusableComponent {
+
+    protected _render(props: RN.TextInputProps): JSX.Element {
+
+        return (
+            <RNW.TextInput
+            {...props}
+            tabIndex = {this.getTabIndex()}
+            onFocus = { (e: React.FocusEvent<any>) => this._onFocusEx(e, props.onFocus)}
+        />)
+            ;
+    }
+
+    private _onFocusEx (e: React.FocusEvent<any>, origHandler: ((e: React.FocusEvent<any>) => void) | undefined) {
+        this.onFocus();
+
+        if (origHandler) {
+            origHandler(e);
+        }
+    }
+
+    onFocus() {
+        // Focus Manager hook
+    }
+
+    getTabIndex(): number | undefined {
+        // Focus Manager may override this
+        return this.props.tabIndex;
+    }
+
+    updateNativeTabIndex(): void {
+        let tabIndex: number | undefined = this.getTabIndex();
+        (this.refs['nativeTextInput'] as any).setNativeProps({
+            tabIndex: tabIndex
+        });
+    }
+}
+
+applyFocusableComponentMixin(TextInput);
+
+export default TextInput;

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -21,10 +21,10 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
         return (
             <RN.TextInput
             {...props}
-            tabIndex = {this.getTabIndex()}
-            onFocus = { (e: React.FocusEvent<any>) => this._onFocusEx(e, props.onFocus)}
-        />)
-            ;
+            tabIndex={this.getTabIndex()}
+            onFocus={ (e: React.FocusEvent<any>) => this._onFocusEx(e, props.onFocus)}
+            />
+        );
     }
 
     private _onFocusEx (e: React.FocusEvent<any>, origHandler: ((e: React.FocusEvent<any>) => void) | undefined) {

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -27,7 +27,9 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
     }
 
     private _onFocusEx (e: React.FocusEvent<any>, origHandler: ((e: React.FocusEvent<any>) => void) | undefined) {
-        this.onFocus();
+        if (e.currentTarget === e.target) {
+            this.onFocus();
+        }
 
         if (origHandler) {
             origHandler(e);

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -35,6 +35,8 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
         }
     }
 
+    // From FocusManagerFocusableComponent interface
+    //
     onFocus() {
         // Focus Manager hook
     }

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -45,10 +45,13 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
     }
 
     updateNativeTabIndex(): void {
-        let tabIndex: number | undefined = this.getTabIndex();
-        (this.refs['nativeTextInput'] as any).setNativeProps({
-            tabIndex: tabIndex
-        });
+        if (this._textInputRef) {
+            let tabIndex: number | undefined = this.getTabIndex();
+            this._textInputRef.setNativeProps({
+                tabIndex: tabIndex,
+                value: this.state.inputValue, // mandatory for some reason
+            });
+        }
     }
 }
 

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -9,21 +9,17 @@
 
 import React = require('react');
 import RN = require('react-native');
-import RNW = require('react-native-windows');
 
 import {applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
 
 import {TextInput as TextInputBase} from '../native-common/TextInput';
-
-// The enhanced TextInput can be accessed through the RN realm
-RNW.TextInput = RN.TextInput;
 
 export class TextInput extends TextInputBase implements FocusManagerFocusableComponent {
 
     protected _render(props: RN.TextInputProps): JSX.Element {
 
         return (
-            <RNW.TextInput
+            <RN.TextInput
             {...props}
             tabIndex = {this.getTabIndex()}
             onFocus = { (e: React.FocusEvent<any>) => this._onFocusEx(e, props.onFocus)}

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -10,19 +10,18 @@
 import React = require('react');
 import RN = require('react-native');
 
-import {applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
+import { applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
 
-import {TextInput as TextInputBase} from '../native-common/TextInput';
+import { TextInput as TextInputBase } from '../native-common/TextInput';
 
 export class TextInput extends TextInputBase implements FocusManagerFocusableComponent {
 
     protected _render(props: RN.TextInputProps): JSX.Element {
-
         return (
             <RN.TextInput
-            {...props}
-            tabIndex={this.getTabIndex()}
-            onFocus={ (e: React.FocusEvent<any>) => this._onFocusEx(e, props.onFocus)}
+                { ...props }
+                tabIndex={ this.getTabIndex() }
+                onFocus={ (e: React.FocusEvent<any>) => this._onFocusEx(e, props.onFocus) }
             />
         );
     }
@@ -51,7 +50,7 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
             let tabIndex: number | undefined = this.getTabIndex();
             this._textInputRef.setNativeProps({
                 tabIndex: tabIndex,
-                value: this.state.inputValue, // mandatory for some reason
+                value: this.state.inputValue // mandatory for some reason
             });
         }
     }

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -311,9 +311,10 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     }
 }
 
+// A value for tabIndex (even <0) marks a View as being potential keyboard focusable
 applyFocusableComponentMixin(View, function (this: View, nextProps?: Types.ViewProps) {
     let tabIndex = nextProps && ('tabIndex' in nextProps) ? nextProps.tabIndex : this.props.tabIndex;
-    return tabIndex !== undefined && tabIndex >= 0;
+    return tabIndex !== undefined;
 });
 
 export default View;

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -342,7 +342,10 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     }
 
     private _onFocus = (e: React.SyntheticEvent<any>): void => {
-        this.onFocus();
+        if (e.currentTarget === e.target) {
+            this.onFocus();
+        }
+
         if (this.props.onFocus) {
             this.props.onFocus(EventHelpers.toFocusEvent(e));
         }

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -1,0 +1,319 @@
+/**
+* View.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* Windows-specific implementation of View.
+*/
+
+import React = require('react');
+import RNW = require('react-native-windows');
+import Types = require('../common/Types');
+import PropTypes = require('prop-types');
+
+import {View as ViewCommon} from '../native-common/View';
+import EventHelpers from '../native-common/utils/EventHelpers';
+import { applyFocusableComponentMixin, FocusManagerFocusableComponent, FocusManager } from '../native-desktop/utils/FocusManager';
+
+const KEY_CODE_ENTER = 13;
+const KEY_CODE_SPACE = 32;
+
+const DOWN_KEYCODES = [KEY_CODE_SPACE, KEY_CODE_ENTER];
+const UP_KEYCODES = [KEY_CODE_SPACE];
+
+export interface ViewContext {
+    isRxParentAText?: boolean;
+    focusManager?: FocusManager;
+}
+
+// Simple check for the presence of the updated React Native for Windows
+const IsUpdatedReactNativeForWindows = (RNW.FocusableWindows !== undefined);
+
+export class View extends ViewCommon implements React.ChildContextProvider<ViewContext>, FocusManagerFocusableComponent {
+    static contextTypes: React.ValidationMap<any> = {
+        isRxParentAText: PropTypes.bool,
+        focusManager: PropTypes.object
+    };
+    context: ViewContext;
+
+    static childContextTypes: React.ValidationMap<any> = {
+        isRxParentAText: PropTypes.bool.isRequired,
+        focusManager: PropTypes.object
+    };
+
+    private _onKeyDown: (e: Types.SyntheticEvent) => void;
+
+    private _focusableElement : RNW.FocusableWindows | null = null;
+
+    private _focusManager: FocusManager;
+    private _isFocusLimited: boolean;
+
+    constructor(props: Types.ViewProps, context: ViewContext) {
+        super(props);
+
+        if (props.restrictFocusWithin || props.limitFocusWithin) {
+            this._focusManager = new FocusManager(context && context.focusManager);
+
+            if (props.limitFocusWithin) {
+                this.setFocusLimited(true);
+            }
+        }
+    }
+
+    componentWillReceiveProps(nextProps: Types.ViewProps) {
+        super.componentWillReceiveProps(nextProps);
+
+        if (!!this.props.restrictFocusWithin !== !!nextProps.restrictFocusWithin) {
+            console.error('View: restrictFocusWithin is readonly and changing it during the component life cycle has no effect');
+        } else if (!!this.props.limitFocusWithin !== !!nextProps.limitFocusWithin) {
+            console.error('View: limitFocusWithin is readonly and changing it during the component life cycle has no effect');
+        }
+    }
+
+    componentDidMount() {
+        super.componentDidMount();
+        if (this._focusManager) {
+            if (this.props.restrictFocusWithin) {
+                this._focusManager.restrictFocusWithin();
+            }
+
+            if (this.props.limitFocusWithin && this._isFocusLimited) {
+                this._focusManager.limitFocusWithin();
+            }
+        }
+    }
+
+    componentWillUnmount() {
+        super.componentWillUnmount();
+        if (this._focusManager) {
+            this._focusManager.release();
+        }
+        // Mixins may have added this
+        if (super.componentWillUnmount !== undefined) {
+            super.componentWillUnmount();
+        }
+    }
+
+    protected _buildInternalProps(props: Types.ViewProps) {
+
+        // Base class does the bulk of _internalprops creation
+        super._buildInternalProps(props);
+
+        if (props.onKeyPress) {
+
+            // Define the handler for "onKeyDown" on first use, it's the safest way when functions
+            // called from super constructors are involved.
+            if (this._onKeyDown === undefined) {
+                this._onKeyDown =  (e: Types.SyntheticEvent) => {
+                    if (this.props.onKeyPress) {
+                        // A conversion to a KeyboardEvent looking event is needed
+                        this.props.onKeyPress(EventHelpers.toKeyboardEvent(e));
+                    }
+                };
+            }
+            // "onKeyDown" is fired by native buttons and bubbles up to views
+            this._internalProps.onKeyDown = this._onKeyDown;
+        }
+
+        // Drag and drop related properties
+        for (const name of ['onDragEnter', 'onDragOver', 'onDrop', 'onDragLeave']) {
+            const handler = this._internalProps[name];
+
+            if (handler) {
+                this._internalProps.allowDrop = true;
+
+                this._internalProps[name] = (e: React.SyntheticEvent<View>) => {
+                    handler({
+                        dataTransfer: (e.nativeEvent as any).dataTransfer,
+
+                        stopPropagation() {
+                            if (e.stopPropagation) {
+                                e.stopPropagation();
+                            }
+                        },
+
+                        preventDefault() {
+                            if (e.preventDefault) {
+                                e.preventDefault();
+                            }
+                        },
+                    });
+                };
+            }
+        }
+    }
+
+    render(): JSX.Element {
+
+        let content: JSX.Element = super.render();
+
+        // Exit fast if the keyboard enabled component is not available
+        if (!IsUpdatedReactNativeForWindows) {
+            return content;
+        }
+
+        if (this.props.tabIndex !== undefined) {
+            let tabIndex: number = this.getTabIndex() || 0;
+            let windowsTabFocusable: boolean =  tabIndex >= 0;
+
+            // RNW.FocusableWindows doesn't participate in layouting, it basically mimics the position/size of the child
+            let focusableViewProps: RNW.FocusableProps = {
+                ref: this._onFocusableRef,
+                isTabStop: windowsTabFocusable,
+                tabIndex: tabIndex,
+                disableSystemFocusVisuals: false,
+                handledKeyDownKeys: DOWN_KEYCODES,
+                handledKeyUpKeys: UP_KEYCODES,
+                onKeyDown: this._onFocusableKeyDown,
+                onKeyUp: this._onFocusableKeyUp,
+                onFocus: this._onFocus,
+                onBlur: this._onBlur
+            };
+
+            content = (
+                <RNW.FocusableWindows
+                    {...focusableViewProps}
+                >
+                    {content}
+                </RNW.FocusableWindows>
+            );
+        }
+
+        return content;
+    }
+
+    private _onFocusableRef = (btn: RNW.FocusableWindows): void => {
+        this._focusableElement = btn;
+    }
+
+    focus() {
+        super.focus();
+        // Only forward to Button.
+        // The other cases are RN.View based elements with no meaningful focus support
+        if (this._focusableElement) {
+            this._focusableElement.focus();
+        }
+    }
+
+    blur() {
+        super.blur();
+        // Only forward to Button.
+        // The other cases are RN.View based elements with no meaningful focus support
+        if (this._focusableElement) {
+            this._focusableElement.blur();
+        }
+    }
+
+    getChildContext() {
+        // Let descendant Types components know that their nearest Types ancestor is not an Types.Text.
+        // Because they're in an Types.View, they should use their normal styling rather than their
+        // special styling for appearing inline with text.
+        let childContext: ViewContext = {
+            isRxParentAText: false
+        };
+
+        // Provide the descendants with the focus manager (if any).
+        if (this._focusManager) {
+            childContext.focusManager = this._focusManager;
+        }
+
+        return childContext;
+    }
+
+    setFocusRestricted(restricted: boolean) {
+        if (!this._focusManager || !this.props.restrictFocusWithin) {
+            console.error('View: setFocusRestricted method requires restrictFocusWithin property to be set to true');
+            return;
+        }
+
+        if (restricted) {
+            this._focusManager.restrictFocusWithin();
+        } else {
+            this._focusManager.removeFocusRestriction();
+        }
+    }
+
+    setFocusLimited(limited: boolean) {
+        if (!this._focusManager || !this.props.limitFocusWithin) {
+            console.error('View: setFocusLimited method requires limitFocusWithin property to be set to true');
+            return;
+        }
+
+        if (limited && !this._isFocusLimited) {
+            this._isFocusLimited = true;
+            this._focusManager.limitFocusWithin();
+        } else if (!limited && this._isFocusLimited) {
+            this._isFocusLimited = false;
+            this._focusManager.removeFocusLimitation();
+        }
+    }
+
+    private _onFocusableKeyDown = (e: React.SyntheticEvent<any>): void => {
+
+        let keyEvent = EventHelpers.toKeyboardEvent(e);
+        if (this.props.onKeyPress) {
+            this.props.onKeyPress(keyEvent);
+        }
+
+        if (this.props.onPress) {
+            let key = keyEvent.keyCode;
+            // ENTER triggers press on key down
+            if (key === KEY_CODE_ENTER) {
+                this.props.onPress(keyEvent);
+                return;
+            }
+        }
+    }
+
+    private _onFocusableKeyUp = (e: React.SyntheticEvent<any>): void => {
+
+        let keyEvent = EventHelpers.toKeyboardEvent(e);
+        if (keyEvent.keyCode === KEY_CODE_SPACE) {
+            if (this.props.onPress) {
+                this.props.onPress(keyEvent);
+            }
+        }
+    }
+
+    private _onFocus = (e: React.SyntheticEvent<any>): void => {
+        this.onFocus();
+        if (this.props.onFocus) {
+            this.props.onFocus(EventHelpers.toFocusEvent(e));
+        }
+    }
+
+    private _onBlur = (e: React.SyntheticEvent<any>): void => {
+        if (this.props.onBlur) {
+            this.props.onBlur(EventHelpers.toFocusEvent(e));
+        }
+    }
+
+    onFocus() {
+        // Focus Manager hook
+    }
+
+    getTabIndex(): number | undefined {
+        // Focus Manager may override this
+        return this.props.tabIndex;
+    }
+
+    updateNativeTabIndex(): void {
+        if (this._focusableElement) {
+            let tabIndex: number = this.getTabIndex() || 0;
+            let windowsTabFocusable: boolean = tabIndex >= 0;
+
+            this._focusableElement.setNativeProps({
+                tabIndex: tabIndex,
+                isTabStop: windowsTabFocusable
+            });
+        }
+    }
+}
+
+applyFocusableComponentMixin(View, function (this: View, nextProps?: Types.ViewProps) {
+    let tabIndex = nextProps && ('tabIndex' in nextProps) ? nextProps.tabIndex : this.props.tabIndex;
+    return tabIndex !== undefined && tabIndex >= 0;
+});
+
+export default View;

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -28,7 +28,7 @@ export interface ViewContext {
 }
 
 // Simple check for the presence of the updated React Native for Windows
-const IsUpdatedReactNativeForWindows = (RNW.FocusableWindows !== undefined);
+const HasFocusableWindows = (RNW.FocusableWindows !== undefined);
 
 export class View extends ViewCommon implements React.ChildContextProvider<ViewContext>, FocusManagerFocusableComponent {
     static contextTypes: React.ValidationMap<any> = {
@@ -198,7 +198,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         let content: JSX.Element = super.render();
 
         // Exit fast if the keyboard enabled component is not available
-        if (!IsUpdatedReactNativeForWindows) {
+        if (!HasFocusableWindows) {
             return content;
         }
 

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -13,7 +13,7 @@ import RNW = require('react-native-windows');
 import Types = require('../common/Types');
 import PropTypes = require('prop-types');
 
-import {View as ViewCommon} from '../native-common/View';
+import { View as ViewCommon } from '../native-common/View';
 import EventHelpers from '../native-common/utils/EventHelpers';
 import { applyFocusableComponentMixin, FocusManagerFocusableComponent, FocusManager } from '../native-desktop/utils/FocusManager';
 
@@ -104,7 +104,6 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     }
 
     protected _buildInternalProps(props: Types.ViewProps) {
-
         // Base class does the bulk of _internalprops creation
         super._buildInternalProps(props);
 
@@ -231,7 +230,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
             return (
                 <FocusableView
-                    {...focusableViewProps}
+                    { ...focusableViewProps }
                 />
             );
         } else {
@@ -331,7 +330,6 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     }
 
     private _onFocusableKeyUp = (e: React.SyntheticEvent<any>): void => {
-
         let keyEvent = EventHelpers.toKeyboardEvent(e);
         if (keyEvent.keyCode === KEY_CODE_SPACE) {
             if (this.props.onPress) {

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -360,7 +360,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     }
 }
 
-// A value for tabIndex (even <0) marks a View as being potential keyboard focusable
+// A value for tabIndex (even <0) marks a View as being potentially keyboard focusable
 applyFocusableComponentMixin(View, function (this: View, nextProps?: Types.ViewProps) {
     let tabIndex = nextProps && ('tabIndex' in nextProps) ? nextProps.tabIndex : this.props.tabIndex;
     return tabIndex !== undefined;

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -42,7 +42,11 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         focusManager: PropTypes.object
     };
 
-    private _onKeyDown: (e: Types.SyntheticEvent) => void;
+    private _onKeyDown: (e: React.SyntheticEvent<any>) => void;
+    private _onMouseEnter: (e: React.SyntheticEvent<any>) => void;
+    private _onMouseLeave: (e: React.SyntheticEvent<any>) => void;
+    private _onMouseOver: (e: React.SyntheticEvent<any>) => void;
+    private _onMouseMove: (e: React.SyntheticEvent<any>) => void;
 
     private _focusableElement : RNW.FocusableWindows | null = null;
 
@@ -141,6 +145,51 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
                     });
                 };
             }
+        }
+
+        // Mouse events (using same lazy initialization as for onKeyDown)
+        if (props.onMouseEnter) {
+            if (this._onMouseEnter === undefined) {
+                this._onMouseEnter =  (e: React.SyntheticEvent<any>) => {
+                    if (this.props.onMouseEnter) {
+                         this.props.onMouseEnter(EventHelpers.toMouseEvent(e));
+                    }
+                };
+            }
+            this._internalProps.onMouseEnter = this._onMouseEnter;
+        }
+
+        if (props.onMouseLeave) {
+            if (this._onMouseLeave === undefined) {
+                this._onMouseLeave =  (e: React.SyntheticEvent<any>) => {
+                    if (this.props.onMouseLeave) {
+                         this.props.onMouseLeave(EventHelpers.toMouseEvent(e));
+                    }
+                };
+            }
+            this._internalProps.onMouseLeave = this._onMouseLeave;
+        }
+
+        if (props.onMouseOver) {
+            if (this._onMouseOver === undefined) {
+                this._onMouseOver =  (e: React.SyntheticEvent<any>) => {
+                    if (this.props.onMouseOver) {
+                         this.props.onMouseOver(EventHelpers.toMouseEvent(e));
+                    }
+                };
+            }
+            this._internalProps.onMouseOver = this._onMouseOver;
+        }
+
+        if (props.onMouseMove) {
+            if (this._onMouseMove === undefined) {
+                this._onMouseMove =  (e: React.SyntheticEvent<any>) => {
+                    if (this.props.onMouseMove) {
+                         this.props.onMouseMove(EventHelpers.toMouseEvent(e));
+                    }
+                };
+            }
+            this._internalProps.onMouseMove = this._onMouseMove;
         }
     }
 

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -13,6 +13,7 @@ import RNW = require('react-native-windows');
 import Types = require('../common/Types');
 import PropTypes = require('prop-types');
 
+import AppConfig from '../common/AppConfig';
 import { View as ViewCommon } from '../native-common/View';
 import EventHelpers from '../native-common/utils/EventHelpers';
 import { applyFocusableComponentMixin, FocusManagerFocusableComponent, FocusManager } from '../native-desktop/utils/FocusManager';
@@ -74,12 +75,14 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
     componentWillReceiveProps(nextProps: Types.ViewProps) {
         super.componentWillReceiveProps(nextProps);
-
-        if (!!this.props.restrictFocusWithin !== !!nextProps.restrictFocusWithin) {
-            console.error('View: restrictFocusWithin is readonly and changing it during the component life cycle has no effect');
-        }
-        if (!!this.props.limitFocusWithin !== !!nextProps.limitFocusWithin) {
-            console.error('View: limitFocusWithin is readonly and changing it during the component life cycle has no effect');
+        
+        if (AppConfig.isDevelopmentMode()) {
+            if (!!this.props.restrictFocusWithin !== !!nextProps.restrictFocusWithin) {
+                console.error('View: restrictFocusWithin is readonly and changing it during the component life cycle has no effect');
+            }
+            if (!!this.props.limitFocusWithin !== !!nextProps.limitFocusWithin) {
+                console.error('View: limitFocusWithin is readonly and changing it during the component life cycle has no effect');
+            }
         }
     }
 

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -75,7 +75,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
     componentWillReceiveProps(nextProps: Types.ViewProps) {
         super.componentWillReceiveProps(nextProps);
-        
+
         if (AppConfig.isDevelopmentMode()) {
             if (!!this.props.restrictFocusWithin !== !!nextProps.restrictFocusWithin) {
                 console.error('View: restrictFocusWithin is readonly and changing it during the component life cycle has no effect');
@@ -378,10 +378,10 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     }
 }
 
-// A value for tabIndex (even <0) marks a View as being potentially keyboard focusable
+// A value for tabIndex marks a View as being potentially keyboard focusable
 applyFocusableComponentMixin(View, function (this: View, nextProps?: Types.ViewProps) {
     let tabIndex = nextProps && ('tabIndex' in nextProps) ? nextProps.tabIndex : this.props.tabIndex;
-    return tabIndex !== undefined;
+    return tabIndex !== undefined && tabIndex >= 0;
 });
 
 export default View;

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -338,6 +338,8 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         }
     }
 
+    // From FocusManagerFocusableComponent interface
+    //
     onFocus() {
         // Focus Manager hook
     }

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -70,7 +70,8 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
         if (!!this.props.restrictFocusWithin !== !!nextProps.restrictFocusWithin) {
             console.error('View: restrictFocusWithin is readonly and changing it during the component life cycle has no effect');
-        } else if (!!this.props.limitFocusWithin !== !!nextProps.limitFocusWithin) {
+        }
+        if (!!this.props.limitFocusWithin !== !!nextProps.limitFocusWithin) {
             console.error('View: limitFocusWithin is readonly and changing it during the component life cycle has no effect');
         }
     }
@@ -93,10 +94,6 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         if (this._focusManager) {
             this._focusManager.release();
         }
-        // Mixins may have added this
-        if (super.componentWillUnmount !== undefined) {
-            super.componentWillUnmount();
-        }
     }
 
     protected _buildInternalProps(props: Types.ViewProps) {
@@ -108,7 +105,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
             // Define the handler for "onKeyDown" on first use, it's the safest way when functions
             // called from super constructors are involved.
-            if (this._onKeyDown === undefined) {
+            if (!this._onKeyDown) {
                 this._onKeyDown =  (e: Types.SyntheticEvent) => {
                     if (this.props.onKeyPress) {
                         // A conversion to a KeyboardEvent looking event is needed
@@ -149,7 +146,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
         // Mouse events (using same lazy initialization as for onKeyDown)
         if (props.onMouseEnter) {
-            if (this._onMouseEnter === undefined) {
+            if (!this._onMouseEnter) {
                 this._onMouseEnter =  (e: React.SyntheticEvent<any>) => {
                     if (this.props.onMouseEnter) {
                          this.props.onMouseEnter(EventHelpers.toMouseEvent(e));
@@ -160,7 +157,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         }
 
         if (props.onMouseLeave) {
-            if (this._onMouseLeave === undefined) {
+            if (!this._onMouseLeave) {
                 this._onMouseLeave =  (e: React.SyntheticEvent<any>) => {
                     if (this.props.onMouseLeave) {
                          this.props.onMouseLeave(EventHelpers.toMouseEvent(e));
@@ -171,7 +168,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         }
 
         if (props.onMouseOver) {
-            if (this._onMouseOver === undefined) {
+            if (!this._onMouseOver) {
                 this._onMouseOver =  (e: React.SyntheticEvent<any>) => {
                     if (this.props.onMouseOver) {
                          this.props.onMouseOver(EventHelpers.toMouseEvent(e));
@@ -182,7 +179,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         }
 
         if (props.onMouseMove) {
-            if (this._onMouseMove === undefined) {
+            if (!this._onMouseMove) {
                 this._onMouseMove =  (e: React.SyntheticEvent<any>) => {
                     if (this.props.onMouseMove) {
                          this.props.onMouseMove(EventHelpers.toMouseEvent(e));
@@ -255,8 +252,8 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     }
 
     getChildContext() {
-        // Let descendant Types components know that their nearest Types ancestor is not an Types.Text.
-        // Because they're in an Types.View, they should use their normal styling rather than their
+        // Let descendant RX components know that their nearest RX ancestor is not an RX.Text.
+        // Because they're in an RX.View, they should use their normal styling rather than their
         // special styling for appearing inline with text.
         let childContext: ViewContext = {
             isRxParentAText: false
@@ -310,7 +307,6 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
             // ENTER triggers press on key down
             if (key === KEY_CODE_ENTER) {
                 this.props.onPress(keyEvent);
-                return;
             }
         }
     }


### PR DESCRIPTION

Existing React Native for UWP uses Border/Canvas based implementation for RCTView, with no support for keyboard input of any kind.
An updated version (covered by a concurrent PR) contains a helper FocusableWindows component that maps to a UserControl/Canvas based native view, component that can be used to add keyboard input/focusing capability to other components.

Main Changes:
1. "windows" flavors of View, Button, Link, TextInput, and ScrollViewer. We keep "Text" as is, with a "focus" method used strictly for narrator purposes.
2. The existing Web FocusManager is now refactored into:
	- Common implementation (in common/utils)
	- Web and Desktop flavors through derived classes.
   Methods marked as "xxxx /* static */" are logically static, yet Typescript is not nice with us on that regard..
3. A native-desktop folder containing what would be common between uwp and the macos platforms: App, RootView, UserInterface, etc.
Some more refined refactoring may happen when macos platform is merged in.

