### PR TITLE
Fix incompatibility with tyescript 2.7 compiler

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -110,7 +110,7 @@ export interface AnimatedFlexboxStyle {
 // ------------------------------------------------------------
 
 export interface TransformStyle {
-    transform?: [{
+    transform?: {
         perspective?: number;
         rotate?: string;
         rotateX?: string;
@@ -121,11 +121,11 @@ export interface TransformStyle {
         scaleY?: number;
         translateX?: number;
         translateY?: number;
-    }];
+    }[];
 }
 
 export interface AnimatedTransformStyle {
-    transform?: [{
+    transform?: {
         perspective?: AnimatedValue;
         rotate?: AnimatedValue;
         rotateX?: AnimatedValue;
@@ -136,7 +136,7 @@ export interface AnimatedTransformStyle {
         scaleY?: AnimatedValue;
         translateX?: AnimatedValue;
         translateY?: AnimatedValue;
-    }];
+    }[];
 }
 
 export type StyleRuleSet<T> = T | number | undefined;


### PR DESCRIPTION
The following no longer compiles:
```
RX.Styles.createAnimatedViewStyle({
        transform: [{
            translateY: this._topValue
        }, {
            translateX: this._leftValue
        }, {
            scale: this._scaleValue
        }, {
            rotateZ: this._rotationValue.interpolate({
                inputRange: [0, 360],
                outputRange: ['0deg', '360deg']
            })
        }]
    });
```

Error: Type '[{ translateY: Value; }, { translateX: Value; }, { scale: Value; }, { rotateZ: Value; }]' is not assignable to type '[{ perspective?: AnimatedValue | undefined; rotate?: AnimatedValue | undefined; rotateX?: Animate...'.
        Types of property 'length' are incompatible.
          Type '4' is not assignable to type '1'.