### PR TITLE
Adding support for the "switch" aria role on desktop.

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -452,6 +452,7 @@ export enum AccessibilityTrait {
     Dialog,
     HasPopup,
     Option,
+    Switch,
 
     // Desktop & mobile. This is at the end because this
     // is the highest priority trait.

--- a/src/web/AccessibilityUtil.ts
+++ b/src/web/AccessibilityUtil.ts
@@ -37,7 +37,8 @@ const roleMap = {
     [Types.AccessibilityTrait.ComboBox]: 'combobox',
     [Types.AccessibilityTrait.Log]: 'log',
     [Types.AccessibilityTrait.Status]: 'status',
-    [Types.AccessibilityTrait.Dialog]: 'dialog'
+    [Types.AccessibilityTrait.Dialog]: 'dialog',
+    [Types.AccessibilityTrait.Switch]: 'switch'
 }; 
 
 // Map of accesssibility live region to an aria-live property.


### PR DESCRIPTION
The ARIA switch role (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_switch_role) provides a better desktop and web experience for screen readers when the element is an on/off switch. It's a specialized version of the checkbox role, which has generic checked/unchecked states. The switch role signals to the screen reader that the control should be treated as on/off instead.