### PR TITLE
[A11Y] Fix announcement issue on Android

### DIFF
--- a/src/android/Accessibility.ts
+++ b/src/android/Accessibility.ts
@@ -1,0 +1,34 @@
+/**
+* Accessibility.ts
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* Common wrapper for accessibility helper exposed from ReactXP.
+*/
+
+import { Accessibility as NativeAccessibility, default as parentInstance } from '../native-common/Accessibility';
+
+export class Accessibility extends NativeAccessibility {
+    private _lastAnnouncement: string | undefined;
+
+    // On Android, talkback fails to announce, if the new announcement is the same as the last one.
+    // The reason is probably that in RootView, the announcement text is held in state and passed as a prop to RN.View.
+    // If the announcement is the same, the props don't change and RN doesn't see a reason to re-render
+    // the view - retrigger the announcement. This behaviour is actually expected. We work around this by checking
+    // the new announcement text and comparing it with the last one. If they are the same, append a space at the end.
+    announceForAccessibility(announcement: string): void {
+        if (announcement === this._lastAnnouncement) {
+            announcement += ' ';
+        }
+        this._lastAnnouncement = announcement;
+
+        // We cannot just call super.announceForAccessibility here, because RootView subscribes on this
+        // parent class singleton instance. Calling Accessibility.announceForAccessibility from the consumer app
+        // will then create a different event and the announcements won't work. Instead, we just call the
+        // instance method directly.
+        parentInstance.announceForAccessibility(announcement);
+    }
+}
+
+export default new Accessibility();

--- a/src/android/ReactXP.ts
+++ b/src/android/ReactXP.ts
@@ -18,7 +18,7 @@ import RXTypes = require('../common/Types');
 // -- STRANGE THINGS GOING ON HERE --
 // See web/ReactXP.tsx for more details.
 
-import AccessibilityImpl from '../native-common/Accessibility';
+import AccessibilityImpl from './Accessibility';
 import ActivityIndicatorImpl from '../native-common/ActivityIndicator';
 import AlertImpl from '../native-common/Alert';
 import AppImpl from '../native-common/App';
@@ -58,7 +58,7 @@ ViewBase.setDefaultViewStyle(_defaultViewStyle);
 
 // Initialize Android implementation of platform accessibility helpers inside the singleton
 // instance of native-common AccessibilityUtil. This is to let native-common components access
-// platform specific APIs through native-common implementation itself. 
+// platform specific APIs through native-common implementation itself.
 import AccessibilityUtil from '../native-common/AccessibilityUtil';
 import AccessibilityPlatformUtil  from './AccessibilityUtil';
 


### PR DESCRIPTION
On Android, the voice over fails to announce text if it's the same as last one. The way it's constructed, that's actually expected, because the props of RN.View don't change. Work around this by keeping the information about last announcement and append space if they are the same.