### PR TITLE
[backport] Prevent web page reload when hitting enter in RX.TextInput

### DIFF
--- a/src/web/TextInput.tsx
+++ b/src/web/TextInput.tsx
@@ -137,7 +137,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
             if (wrapInForm) {
                 // Wrap the input in a form tag if required
                 input = (
-                    <form action=''>
+                    <form action='' onSubmit={ (ev) => { /* prevent form submission/page reload */ ev.preventDefault(); } }>
                         { input }
                     </form>
                 );


### PR DESCRIPTION
In RX.TextInput pressing enter in <input> submits enclosing
<form> element which leads in most cases to page reload.

It happens when component is in uncontrolled mode (no handlers
are installed on input to prevent default behavior).