### PR TITLE
If properties are NOT equal clone the element

### DIFF
--- a/src/native-common/RootView.tsx
+++ b/src/native-common/RootView.tsx
@@ -155,7 +155,7 @@ class RootViewUsingStore extends BaseRootView<BaseRootViewProps> {
     private _getStateFromStore(): RootViewState {
         let mainView = MainViewStore.getMainView();
 
-        if (mainView && _.isEqual(mainView.props, this._mainViewProps)) {
+        if (mainView && !_.isEqual(mainView.props, this._mainViewProps)) {
             mainView = React.cloneElement(mainView, this._mainViewProps);
         }
 


### PR DESCRIPTION
I think the logic got reverted some time ago, we need to cloneElement when the props are different