### PR TITLE
Change the UserPresence to set idle state on window.blur.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/react": "^16.0.9",
     "@types/react-dom": "^16.0.3",
     "assert": "^1.3.0",
-    "ifvisible.js": "^1.0.6",
+    "ifvisible": "^1.1.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.9",
     "rebound": "^0.0.13",

--- a/src/web/App.ts
+++ b/src/web/App.ts
@@ -13,7 +13,7 @@ import Types = require('../common/Types');
 // Hack to allow inline-require without importing node.d.ts
 declare var require: (path: string) => any;
 if (typeof(document) !== 'undefined') {
-    var ifvisible = require('ifvisible.js');
+    var ifvisible = require('ifvisible');
 }
 
 export class App extends RX.App {

--- a/src/web/UserPresence.ts
+++ b/src/web/UserPresence.ts
@@ -13,7 +13,7 @@ import RX = require('../common/Interfaces');
 // Hack to allow inline-require without importing node.d.ts
 declare var require: (path: string) => any;
 if (typeof(document) !== 'undefined') {
-    var ifvisible = require('ifvisible.js');
+    var ifvisible = require('ifvisible');
 }
 
 export class UserPresence extends RX.UserPresence {
@@ -29,9 +29,8 @@ export class UserPresence extends RX.UserPresence {
             ifvisible.on('idle', this._handleIdle.bind(this));
             ifvisible.on('focus', this._handleFocus.bind(this));
             ifvisible.on('blur', this._handleBlur.bind(this));
-
-            window.addEventListener('blur', this._handleBlur.bind(this));
-            window.addEventListener('focus', this._handleFocus.bind(this));
+            
+            window.addEventListener('blur', this._handleWindowBlur.bind(this));
         }
     }
 
@@ -66,6 +65,10 @@ export class UserPresence extends RX.UserPresence {
 
     private _handleBlur(): void {
         this._setUserPresent(false);
+    }
+
+    private _handleWindowBlur(): void {
+        ifvisible.idle();
     }
 }
 


### PR DESCRIPTION
Window getting focus was causing the UserPresence to report as active forever - since the ifvisible wakeup timer was never started.
Also changing the ifvisible package - the old one was not clearing the timers correctly which results in setting idle state at random times when the user is actually active.