### PR TITLE
Fix measureInWindow() callback signature

### DIFF
--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -194,7 +194,7 @@ export class FrontLayerViewManager {
             if (activePopupContext.popupOptions.onAnchorPressed) {
                 RN.NativeModules.UIManager.measureInWindow(
                     activePopupContext.anchorHandle,
-                    (x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
+                    (x: number, y: number, width: number, height: number) => {
                         const touchEvent = e.nativeEvent as any;
                         let anchorRect: ClientRect = { left: x, top: y, right: x + width,
                                 bottom: y + height, width: width, height: height };

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -150,7 +150,7 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
         assert.ok(!!this.props.anchorHandle);
         RN.NativeModules.UIManager.measureInWindow(
             this.props.anchorHandle,
-            (x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
+            (x: number, y: number, width: number, height: number) => {
                 if (!this._mountedComponent) {
                     return;
                 }
@@ -163,7 +163,7 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
 
                 RN.NativeModules.UIManager.measureInWindow(
                     this._viewHandle,
-                    (x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
+                    (x: number, y: number, width: number, height: number) => {
                         let popupRect: ClientRect = {
                             left: x, top: y, right: x + width, bottom: y + height,
                             width: width, height: height

--- a/src/native-common/UserInterface.tsx
+++ b/src/native-common/UserInterface.tsx
@@ -36,7 +36,7 @@ export class UserInterface extends RX.UserInterface {
 
         assert.ok(!!nodeHandle);
         RN.NativeModules.UIManager.measureInWindow(
-            nodeHandle, (x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
+            nodeHandle, (x: number, y: number, width: number, height: number) => {
                 deferred.resolve({
                     x: x,
                     y: y,


### PR DESCRIPTION
Unlike measure(), measureInWindow() is supposed to return only x, y,
width, height.

https://facebook.github.io/react-native/docs/direct-manipulation.html#measureinwindowcallback