### PR TITLE
Right click support for UWP (#503)

### DIFF
--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -15,6 +15,7 @@ import PropTypes = require('prop-types');
 import AccessibilityUtil from './AccessibilityUtil';
 import Animated from './Animated';
 import AppConfig from '../common/AppConfig';
+import EventHelpers from './utils/EventHelpers';
 import Styles from './Styles';
 import Types = require('../common/Types');
 import { isEqual } from '../common/lodashMini';
@@ -215,13 +216,21 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
 
     touchableHandlePress = (e: Types.MouseEvent) => {
         UserInterface.evaluateTouchLatency(e);
-        if (!this.props.disabled && this.props.onPress) {
-            this.props.onPress(e);
+        if (!this.props.disabled) {
+            if (EventHelpers.isRightMouseButton(e)) {
+                if (this.props.onContextMenu) {
+                    this.props.onContextMenu(e);
+                }
+            } else {
+                if (this.props.onPress) {
+                    this.props.onPress(e);
+                }
+            }
         }
     }
 
     touchableHandleLongPress = (e: Types.MouseEvent) => {
-        if (!this.props.disabled && this.props.onLongPress) {
+        if (!this.props.disabled && !EventHelpers.isRightMouseButton(e) && this.props.onLongPress) {
             this.props.onLongPress(e);
         }
     }

--- a/src/native-common/Link.tsx
+++ b/src/native-common/Link.tsx
@@ -10,6 +10,7 @@
 import React = require('react');
 import RN = require('react-native');
 
+import EventHelpers from './utils/EventHelpers';
 import Linking from '../native-common/Linking';
 import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
@@ -52,6 +53,10 @@ export class Link extends React.Component<Types.LinkProps, {}> {
     }
 
     protected _onPress = (e: RX.Types.SyntheticEvent) => {
+        if (EventHelpers.isRightMouseButton(e)) {
+            return;
+        }
+
         if (this.props.onPress) {
             this.props.onPress(e, this.props.url);
             return;
@@ -66,7 +71,7 @@ export class Link extends React.Component<Types.LinkProps, {}> {
     }
 
     protected _onLongPress = (e: RX.Types.SyntheticEvent) => {
-        if (this.props.onLongPress) {
+        if (!EventHelpers.isRightMouseButton(e) && this.props.onLongPress) {
             this.props.onLongPress(e, this.props.url);
         }
     }

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -13,6 +13,7 @@ import React = require('react');
 import RN = require('react-native');
 
 import AccessibilityUtil from './AccessibilityUtil';
+import EventHelpers from './utils/EventHelpers';
 import Styles from './Styles';
 import Types = require('../common/Types');
 
@@ -41,6 +42,10 @@ export class Text extends React.Component<Types.TextProps, {}> implements React.
 
     render() {
         const importantForAccessibility = AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility);
+
+        // The presence of any of the onPress or onContextMenu makes the RN.Text a potential touch responder
+        const onPress = (this.props.onPress || this.props.onContextMenu) ? this._onPress : undefined;
+
         return (
             <RN.Text
                 style={ this._getStyles() }
@@ -49,7 +54,7 @@ export class Text extends React.Component<Types.TextProps, {}> implements React.
                 numberOfLines={ this.props.numberOfLines }
                 allowFontScaling={ this.props.allowFontScaling }
                 maxContentSizeMultiplier={ this.props.maxContentSizeMultiplier }
-                onPress={ this.props.onPress }
+                onPress={ onPress }
                 selectable={ this.props.selectable }
                 textBreakStrategy={ 'simple' }
                 ellipsizeMode={ this.props.ellipsizeMode }
@@ -61,6 +66,18 @@ export class Text extends React.Component<Types.TextProps, {}> implements React.
 
     protected _onMount = (component: RN.ReactNativeBaseComponent<any, any>|null) => {
         this._mountedComponent = component;
+    }
+
+    private _onPress = (e: RN.SyntheticEvent<any>) => {
+        if (EventHelpers.isRightMouseButton(e)) {
+            if (this.props.onContextMenu) {
+                this.props.onContextMenu(e);
+            }
+        } else {
+            if (this.props.onPress) {
+                this.props.onPress(e);
+            }
+        }
     }
 
     getChildContext() {

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -16,6 +16,7 @@ import RN = require('react-native');
 import AccessibilityUtil from './AccessibilityUtil';
 
 import Animated from './Animated';
+import EventHelpers from './utils/EventHelpers';
 import Styles from './Styles';
 import Types = require('../common/Types');
 import UserInterface from './UserInterface';
@@ -400,14 +401,22 @@ export class View extends ViewBase<Types.ViewProps, {}> {
 
     touchableHandlePress(e: Types.MouseEvent): void {
         UserInterface.evaluateTouchLatency(e);
-        if (this.props.onPress) {
-            this.props.onPress(e);
+        if (EventHelpers.isRightMouseButton(e)) {
+            if (this.props.onContextMenu) {
+                this.props.onContextMenu(e);
+            }
+        } else {
+            if (this.props.onPress) {
+                this.props.onPress(e);
+            }
         }
     }
 
     touchableHandleLongPress(e: Types.MouseEvent): void {
-        if (this.props.onLongPress) {
-            this.props.onLongPress(e);
+        if (!EventHelpers.isRightMouseButton(e)) {
+            if (this.props.onLongPress) {
+                this.props.onLongPress(e);
+            }
         }
     }
 

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -5,7 +5,7 @@
 * Licensed under the MIT license.
 */
 
-import _ = require('../../native-common/lodashMini');
+import _ = require('../lodashMini');
 import Types = require('../../common/Types');
 
 //
@@ -136,6 +136,10 @@ export class EventHelpers {
 
         // Nothing for now, this will have to be enhanced based on platform support.
         return e as Types.MouseEvent;
+    }
+
+    isRightMouseButton(e: Types.SyntheticEvent): boolean {
+        return !!e.nativeEvent.isRightButton;
     }
 }
 


### PR DESCRIPTION
* Treat right button related mouse events differently, to support "context menu" kind of scenarios.
* Backported to 0.51.x

(cherry picked from commit 8dbf6ce911d9856d218aa3809345134dbed60b04)