### PR TITLE
Use white-space:pre for the aria-live region

### DIFF
--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -147,8 +147,8 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                 } else {
 
                     // Additionally, alternate between announcement text directly under the aria-live element and
-                    // nested in a div to work around issues with some browsers. Chrome on Windows is known to
-                    // not fire accessibility events reliably without this, for example.
+                    // nested in a div to work around issues with some readers. NVDA on Windows is known to
+                    // not announce aria-live reliably without this, for example.
                     this.setState({
                         announcementText: announcement,
                         announcementTextInNestedDiv: !this.state.announcementTextInNestedDiv

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -84,7 +84,7 @@ const _rightClickButtonCode = 2;
 const _isMac = (typeof navigator !== 'undefined') && (typeof navigator.platform === 'string') && (navigator.platform.indexOf('Mac') >= 0);
 
 const _styles = {
-    liveRegionContainer: Styles.createViewStyle({
+    liveRegionContainer: Styles.combine({
         position: 'absolute',
         overflow: 'hidden',
         opacity: 0,
@@ -92,8 +92,9 @@ const _styles = {
         bottom: 0,
         left: 0,
         right: 0,
-        height: 30
-    })
+        height: 30,
+        whiteSpace: 'pre'
+    }),
 };
 
 const KEY_CODE_TAB = 9;


### PR DESCRIPTION
Announcing the same text repeatedly with announceForAccessibility() is done
through triggering DOM updates by appending (and removing) a space character
to the text. This does not work reliably if the region is not marked as
preformatted.

For example Chrome trims leading and trailing whitespace from the text
at this callstack if not marked as preformatted:

blink_core!blink::TextIteratorTextNodeHandler::HandleTextNodeInRange+0x5f7
blink_core!blink::TextIteratorAlgorithm<blink::EditingAlgorithm<blink::NodeTraversal> >::HandleTextNode+0x270
blink_core!blink::TextIteratorAlgorithm<blink::EditingAlgorithm<blink::NodeTraversal> >::Advance+0x865
blink_core!blink::TextIteratorAlgorithm<blink::EditingAlgorithm<blink::NodeTraversal> >::TextIteratorAlgorithm+0x6e3
blink_core!blink::CreatePlainText<blink::EditingAlgorithm<blink::NodeTraversal> >+0xf5
blink_core!blink::PlainText+0x25
blink_core!blink::LayoutText::PlainText+0x96
blink_modules!blink::AXLayoutObject::TextAlternative+0x1c9
blink_modules!blink::AXObject::GetName+0x119
blink_modules!blink::WebAXObject::GetName+0xc7
content!content::BlinkAXTreeSource::SerializeNode+0x41b

The DOM update then does not result in a change to the text and no accessibility
event is fired by the browser.