### PR TITLE
Platform select() method - make it easier to get platform specific va…

### DIFF
--- a/docs/docs/apis/platform.md
+++ b/docs/docs/apis/platform.md
@@ -18,5 +18,8 @@ type PlatformType = 'web' | 'ios' | 'android' | 'windows';
 ``` javascript
 // Returns the platform type
 getType(): Types.PlatformType;
+
+// Returns the value in `specifics` for the current platform type.
+select<T>(specifics: { [ platform in Types.PlatformType | 'default' ]?: T }): T | undefined;
 ```
 

--- a/samples/RXPTest/src/Tests/PlatformTest.tsx
+++ b/samples/RXPTest/src/Tests/PlatformTest.tsx
@@ -42,30 +42,13 @@ class PlatformView extends RX.Component<RX.CommonProps, PlatformState> {
     }
 
     render() {
-        let platformTypeText = '';
-        switch (this.state.platformType) {
-            case 'web':
-                platformTypeText = 'Browser (web)';
-                break;
-
-            case 'ios':
-                platformTypeText = 'iOS';
-                break;
-
-            case 'android':
-                platformTypeText = 'Android';
-                break;
-
-            case 'windows':
-                platformTypeText = 'Windows (UWP)';
-                break;
-
-            default:
-                if (this.state.platformType) {
-                    platformTypeText = 'Unknown (' + this.state.platformType + ')';
-                }
-                break;
-        }
+        const platformTypeText = RX.Platform.select({
+            'web': 'Browser (web)',
+            'ios': 'iOS',
+            'android': 'Android',
+            'windows': 'Windows (UWP)',
+            'default': `Unknown (${JSON.stringify(this.state.platformType)})`
+        });
 
         return (
             <RX.View style={ _styles.container}>

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -183,6 +183,7 @@ export abstract class Network {
 
 export abstract class Platform {
     abstract getType(): Types.PlatformType;
+    abstract select<T>(specifics: { [ platform in Types.PlatformType | 'default' ]?: T }): T | undefined;
 }
 
 export abstract class Input {

--- a/src/native-common/Platform.ts
+++ b/src/native-common/Platform.ts
@@ -16,6 +16,11 @@ export class Platform extends RX.Platform {
     getType(): Types.PlatformType {
         return RN.Platform.OS;
     }
+
+    select<T>(specifics: { [ platform in Types.PlatformType | 'default' ]?: T }): T | undefined {
+        const platformType = this.getType();
+        return platformType in specifics ? specifics[platformType] : specifics.default;
+    }
 }
 
 export default new Platform();

--- a/src/web/Platform.ts
+++ b/src/web/Platform.ts
@@ -14,6 +14,11 @@ export class Platform extends RX.Platform {
     getType(): Types.PlatformType {
         return 'web';
     }
+
+    select<T>(specifics: { [ platform in Types.PlatformType | 'default' ]?: T }): T | undefined {
+        const platformType = this.getType();
+        return platformType in specifics ? specifics[platformType] : specifics.default;
+    }
 }
 
 export default new Platform();


### PR DESCRIPTION
…lues.

This is an API in React Native that I also thinks adds value here.

Note:  I added test code, but it won't run in the current config because the test app points to an old RXP version that doesn't have this.  Feels like we should have a solution here.  Maybe change the RXPTest `package.json` to point to the reactxp dependency to the dist parent folder? 