### PR TITLE
Avoid triggering sync layout on web

### DIFF
--- a/src/web/CustomScrollbar.ts
+++ b/src/web/CustomScrollbar.ts
@@ -513,6 +513,7 @@ export class Scrollbar {
 
         // Defer remaining init work to avoid triggering sync layout
         this._asyncInitTimer = window.setTimeout(() => {
+            this._asyncInitTimer = undefined;
             this._tryLtrOverride();
             this.update();
         }, 0);

--- a/src/web/ViewBase.tsx
+++ b/src/web/ViewBase.tsx
@@ -113,32 +113,32 @@ export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase
             return SyncTasks.Resolved<void>();
         }
 
-        const container = this._getContainer();
-        if (!container) {
-            return SyncTasks.Resolved<void>();
-        }
+        const deferred = SyncTasks.Defer<void>();
+        ViewBase._reportLayoutChange(() => {
+            if (!this._isMounted || !this.props.onLayout) {
+                deferred.resolve(void 0);
+                return;
+            }
+            const container = this._getContainer();
+            if (!container) {
+                deferred.resolve(void 0);
+                return;
+            }
 
-        const newX = container.offsetLeft;
-        const newY = container.offsetTop;
-        const marginTop = !container.style.marginTop ? 0 : parseInt(container.style.marginTop, 10) || 0;
-        const marginBottom = !container.style.marginBottom ? 0 : parseInt(container.style.marginBottom, 10) || 0;
-        const marginRight = !container.style.marginRight ? 0 : parseInt(container.style.marginRight, 10) || 0;
-        const marginLeft = !container.style.marginLeft ? 0 : parseInt(container.style.marginLeft, 10) || 0;
-        const newWidth = container.offsetWidth + marginRight + marginLeft;
-        const newHeight = container.offsetHeight + marginTop + marginBottom;
+            const newX = container.offsetLeft;
+            const newY = container.offsetTop;
+            const marginTop = !container.style.marginTop ? 0 : parseInt(container.style.marginTop, 10) || 0;
+            const marginBottom = !container.style.marginBottom ? 0 : parseInt(container.style.marginBottom, 10) || 0;
+            const marginRight = !container.style.marginRight ? 0 : parseInt(container.style.marginRight, 10) || 0;
+            const marginLeft = !container.style.marginLeft ? 0 : parseInt(container.style.marginLeft, 10) || 0;
+            const newWidth = container.offsetWidth + marginRight + marginLeft;
+            const newHeight = container.offsetHeight + marginTop + marginBottom;
 
-        if (this._lastX !== newX || this._lastY !== newY || this._lastWidth !== newWidth || this._lastHeight !== newHeight) {
-            this._lastX = newX;
-            this._lastY = newY;
-            this._lastWidth = newWidth;
-            this._lastHeight = newHeight;
-
-            const deferred = SyncTasks.Defer<void>();
-            ViewBase._reportLayoutChange(() => {
-                if (!this._isMounted || !this.props.onLayout) {
-                    deferred.resolve(void 0);
-                    return;
-                }
+            if (this._lastX !== newX || this._lastY !== newY || this._lastWidth !== newWidth || this._lastHeight !== newHeight) {
+                this._lastX = newX;
+                this._lastY = newY;
+                this._lastWidth = newWidth;
+                this._lastHeight = newHeight;
 
                 this.props.onLayout({
                     x: newX,
@@ -147,11 +147,9 @@ export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase
                     height: this._lastHeight
                 });
                 deferred.resolve(void 0);
-            });
-            return deferred.promise();
-        }
-
-        return SyncTasks.Resolved<void>();
+            }
+        });
+        return deferred.promise();
     }
 
     private _checkViewCheckerBuild() {

--- a/src/web/ViewBase.tsx
+++ b/src/web/ViewBase.tsx
@@ -10,6 +10,7 @@
 import _ = require('./utils/lodashMini');
 import ReactDOM = require('react-dom');
 
+import { default as FrontLayerViewManager } from './FrontLayerViewManager';
 import AppConfig from '../common/AppConfig';
 import RX = require('../common/Interfaces');
 import SyncTasks = require('synctasks');
@@ -30,6 +31,7 @@ export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase
     abstract render(): JSX.Element;
     protected abstract _getContainer(): HTMLElement|null;
     private _isMounted = false;
+    private _isPopupDisplayed = false;
 
     // Sets the activation state so we can stop our periodic timer
     // when the app is in the background.
@@ -199,9 +201,20 @@ export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase
     }
 
     componentDidUpdate() {
+        const isPopupDisplayed = FrontLayerViewManager.isPopupDisplayed();
         if (this.props.onLayout) {
-            this._checkAndReportLayout();
+            if (isPopupDisplayed && !this._isPopupDisplayed) {
+                // A popup was just added to DOM. Checking layout now would stall script
+                // execution because the browser would have to do a reflow. Avoid that
+                // by deferring the work.
+                setTimeout(() => {
+                    this._checkAndReportLayout();
+                }, 0);
+            } else {
+                this._checkAndReportLayout();
+            }
         }
+        this._isPopupDisplayed = isPopupDisplayed;
     }
 
     private static _onResize() {

--- a/src/web/ViewBase.tsx
+++ b/src/web/ViewBase.tsx
@@ -113,32 +113,32 @@ export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase
             return SyncTasks.Resolved<void>();
         }
 
-        const deferred = SyncTasks.Defer<void>();
-        ViewBase._reportLayoutChange(() => {
-            if (!this._isMounted || !this.props.onLayout) {
-                deferred.resolve(void 0);
-                return;
-            }
-            const container = this._getContainer();
-            if (!container) {
-                deferred.resolve(void 0);
-                return;
-            }
+        const container = this._getContainer();
+        if (!container) {
+            return SyncTasks.Resolved<void>();
+        }
 
-            const newX = container.offsetLeft;
-            const newY = container.offsetTop;
-            const marginTop = !container.style.marginTop ? 0 : parseInt(container.style.marginTop, 10) || 0;
-            const marginBottom = !container.style.marginBottom ? 0 : parseInt(container.style.marginBottom, 10) || 0;
-            const marginRight = !container.style.marginRight ? 0 : parseInt(container.style.marginRight, 10) || 0;
-            const marginLeft = !container.style.marginLeft ? 0 : parseInt(container.style.marginLeft, 10) || 0;
-            const newWidth = container.offsetWidth + marginRight + marginLeft;
-            const newHeight = container.offsetHeight + marginTop + marginBottom;
+        const newX = container.offsetLeft;
+        const newY = container.offsetTop;
+        const marginTop = !container.style.marginTop ? 0 : parseInt(container.style.marginTop, 10) || 0;
+        const marginBottom = !container.style.marginBottom ? 0 : parseInt(container.style.marginBottom, 10) || 0;
+        const marginRight = !container.style.marginRight ? 0 : parseInt(container.style.marginRight, 10) || 0;
+        const marginLeft = !container.style.marginLeft ? 0 : parseInt(container.style.marginLeft, 10) || 0;
+        const newWidth = container.offsetWidth + marginRight + marginLeft;
+        const newHeight = container.offsetHeight + marginTop + marginBottom;
 
-            if (this._lastX !== newX || this._lastY !== newY || this._lastWidth !== newWidth || this._lastHeight !== newHeight) {
-                this._lastX = newX;
-                this._lastY = newY;
-                this._lastWidth = newWidth;
-                this._lastHeight = newHeight;
+        if (this._lastX !== newX || this._lastY !== newY || this._lastWidth !== newWidth || this._lastHeight !== newHeight) {
+            this._lastX = newX;
+            this._lastY = newY;
+            this._lastWidth = newWidth;
+            this._lastHeight = newHeight;
+
+            const deferred = SyncTasks.Defer<void>();
+            ViewBase._reportLayoutChange(() => {
+                if (!this._isMounted || !this.props.onLayout) {
+                    deferred.resolve(void 0);
+                    return;
+                }
 
                 this.props.onLayout({
                     x: newX,
@@ -147,9 +147,11 @@ export abstract class ViewBase<P extends Types.ViewProps, S> extends RX.ViewBase
                     height: this._lastHeight
                 });
                 deferred.resolve(void 0);
-            }
-        });
-        return deferred.promise();
+            });
+            return deferred.promise();
+        }
+
+        return SyncTasks.Resolved<void>();
     }
 
     private _checkViewCheckerBuild() {

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -161,10 +161,15 @@ export class FocusManager extends FocusManagerBase {
             // back again.
             // Defer the work to avoid triggering sync layout.
             FocusManager._resetFocusTimer = setTimeout(() => {
+                FocusManager._resetFocusTimer = undefined;
                 const prevTabIndex = FocusManager._setTabIndex(document.body, 0);
+                const activeElement = document.activeElement;
                 document.body.focus();
                 document.body.blur();
                 FocusManager._setTabIndex(document.body, prevTabIndex);
+                if (activeElement instanceof HTMLElement) {
+                    activeElement.focus();
+                }
             }, 0);
         }
     }

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -31,6 +31,8 @@ import { applyFocusableComponentMixin, FocusableComponentStateCallback } from  '
 export { applyFocusableComponentMixin, FocusableComponentStateCallback };
 
 export class FocusManager extends FocusManagerBase {
+    private static _setTabIndexTimer: number|undefined;
+    private static _setTabIndexElement: HTMLElement|undefined;
 
     constructor(parent: FocusManager | undefined) {
         super(parent);
@@ -157,10 +159,13 @@ export class FocusManager extends FocusManagerBase {
             // In order to avoid losing this first Tab press, we're making <body>
             // focusable, focusing it, removing the focus and making it unfocusable
             // back again.
-            const prevTabIndex = FocusManager._setTabIndex(document.body, 0);
-            document.body.focus();
-            document.body.blur();
-            FocusManager._setTabIndex(document.body, prevTabIndex);
+            // Defer the work to avoid triggering sync layout.
+            FocusManager._resetFocusTimer = setTimeout(() => {
+                const prevTabIndex = FocusManager._setTabIndex(document.body, 0);
+                document.body.focus();
+                document.body.blur();
+                FocusManager._setTabIndex(document.body, prevTabIndex);
+            }, 0);
         }
     }
 
@@ -194,14 +199,35 @@ export class FocusManager extends FocusManagerBase {
     }
 
     private static _setTabIndex(element: HTMLElement, value: number|undefined): number|undefined {
-        const prev = element.hasAttribute(ATTR_NAME_TAB_INDEX) ? element.tabIndex : undefined;
+        // If a tabIndex assignment is pending for this element, cancel it now.
+        if (FocusManager._setTabIndexTimer && element === FocusManager._setTabIndexElement) {
+            clearTimeout(FocusManager._setTabIndexTimer);
+            FocusManager._setTabIndexTimer = undefined;
+        }
 
+        const prev = element.hasAttribute(ATTR_NAME_TAB_INDEX) ? element.tabIndex : undefined;
         if (value === undefined) {
             if (prev !== undefined) {
                 element.removeAttribute(ATTR_NAME_TAB_INDEX);
             }
-        } else {
-            element.tabIndex = value;
+        } else if (value !== prev) {
+            // Setting tabIndex to -1 on the active element would trigger sync layout. Defer it.
+            if (value === -1 && element === document.activeElement) {
+                // If a tabIndex assignment is pending for another element, run it now as we know
+                // that it's not active anymore.
+                if (FocusManager._setTabIndexTimer) {
+                    FocusManager._setTabIndexElement!!!.tabIndex = -1;
+                    clearTimeout(FocusManager._setTabIndexTimer);
+                    FocusManager._setTabIndexTimer = undefined;
+                }
+
+                FocusManager._setTabIndexElement = element;
+                FocusManager._setTabIndexTimer = setTimeout(() => {
+                    element.tabIndex = value;
+                }, 0);
+            } else {
+                element.tabIndex = value;
+            }
         }
 
         return prev;


### PR DESCRIPTION
Displaying a popup triggers synchronous layout (aka "recalculate style", "forced reflow") at multiple places. This is a collection of tweaks to avoid some of these and make popups faster to appear.

Time spent in layout went down from ~220 ms to ~150 ms when showing the emoticon picker in S4L Electron. This translated to the popup showing onClick handler taking ~80 ms (or ~20%) less time overall.

The remaining offender, not addressed in this PR, is RootView._recalcPosition() which heavily depends on measuring various elements. I'm open to suggestions on how tackle this one. As noted in the commit messages, my web-fu is weak :)