### PR TITLE
Sometimes onContextMenu doesn't work for views (in Windows)

### DIFF
--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -306,6 +306,10 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         }
     }
 
+    protected _isButton(viewProps: Types.ViewProps): boolean {
+        return super._isButton(viewProps) || !!viewProps.onContextMenu;
+    }
+
     private _onFocusableKeyDown = (e: React.SyntheticEvent<any>): void => {
 
         let keyEvent = EventHelpers.toKeyboardEvent(e);


### PR DESCRIPTION
Views with specified onContextMenu (and no onPress nor onLongPress should be also considered buttons for mixin applying purposes on Windows.