### PR TITLE
Upgrade typescript to 2.7.2, enable strictPropertyInitialization checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-native-windows": "^0.51.0-rc.1"
   },
   "devDependencies": {
-    "typescript": "2.6.2",
+    "typescript": "2.7.2",
     "tslint": "5.8.0",
     "tslint-microsoft-contrib": "5.0.0"
   },

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -53,7 +53,7 @@ export abstract class FocusManager {
     protected static _resetFocusTimer: number | undefined;
 
     private _parent: FocusManager|undefined;
-    private _isFocusLimited: boolean;
+    private _isFocusLimited = false;
     private _prevFocusedComponent: StoredFocusableComponent|undefined;
     private _myFocusableComponentIds: { [id: string]: boolean } = {};
 

--- a/src/macos/Accessibility.ts
+++ b/src/macos/Accessibility.ts
@@ -22,7 +22,7 @@ const RetryTimeout = 3000; // 3 seconds
 export class Accessibility extends NativeAccessibility {
     // Queue of pending announcements.
     private _announcementQueue: string[] = [];
-    private _retryTimestamp: number;
+    private _retryTimestamp = NaN;
 
     constructor() {
         super();

--- a/src/native-common/AccessibilityUtil.ts
+++ b/src/native-common/AccessibilityUtil.ts
@@ -56,15 +56,15 @@ const componentTypeMap: { [key: string]: string } = {
 };
 
 export class AccessibilityUtil extends CommonAccessibilityUtil {
-    // Handle to accessibility platform helper instance that gets initialized during ReactXP initialization using the setter. 
-    private _instance: AccessibilityPlatformUtil;
+    // Handle to accessibility platform helper instance that gets initialized during ReactXP initialization using the setter.
+    private _instance!: AccessibilityPlatformUtil;
 
     setAccessibilityPlatformUtil(instance: AccessibilityPlatformUtil) {
-        this._instance = instance; 
+        this._instance = instance;
     }
 
-    // Converts an AccessibilityTrait to a string, but the returned value is only needed for iOS and UWP. Other platforms ignore it. 
-    // Presence of an AccessibilityTrait.None can make an element non-accessible on Android. 
+    // Converts an AccessibilityTrait to a string, but the returned value is only needed for iOS and UWP. Other platforms ignore it.
+    // Presence of an AccessibilityTrait.None can make an element non-accessible on Android.
     // We use the override traits if they are present, else use the default trait.
     // If ensureDefaultTrait is true, ensure the return result contains the defaultTrait.
     accessibilityTraitToString(overrideTraits: Types.AccessibilityTrait | Types.AccessibilityTrait[] | undefined,
@@ -110,7 +110,7 @@ export class AccessibilityUtil extends CommonAccessibilityUtil {
         return undefined;
     }
 
-    // Platform specific accessibility APIs. 
+    // Platform specific accessibility APIs.
     setAccessibilityFocus(component: React.Component<any, any>): void {
         this._instance.setAccessibilityFocus(component);
     }

--- a/src/native-common/Animated.tsx
+++ b/src/native-common/Animated.tsx
@@ -36,7 +36,7 @@ export const CommonAnimatedClasses: AnimatedClasses = {
 let animatedClasses: AnimatedClasses = CommonAnimatedClasses;
 
 class AnimatedWrapper<P, T> extends RX.AnimatedComponent<P, T> {
-    protected _mountedComponent: RN.ReactNativeBaseComponent<any, any> | null;
+    protected _mountedComponent: RN.ReactNativeBaseComponent<any, any> | null | undefined;
 
     setNativeProps(props: P) {
         if (this._mountedComponent && this._mountedComponent.setNativeProps) {

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -72,13 +72,14 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
     private _mixin_componentDidMount = RN.Touchable.Mixin.componentDidMount || noop;
     private _mixin_componentWillUnmount = RN.Touchable.Mixin.componentWillUnmount || noop;
 
-    touchableGetInitialState: () => RN.Touchable.State;
-    touchableHandleStartShouldSetResponder: () => boolean;
-    touchableHandleResponderTerminationRequest: () => boolean;
-    touchableHandleResponderGrant: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderMove: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderRelease: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderTerminate: (e: React.SyntheticEvent<any>) => void;
+    // These are provided by mixin applied in the constructor
+    touchableGetInitialState!: () => RN.Touchable.State;
+    touchableHandleStartShouldSetResponder!: () => boolean;
+    touchableHandleResponderTerminationRequest!: () => boolean;
+    touchableHandleResponderGrant!: (e: React.SyntheticEvent<any>) => void;
+    touchableHandleResponderMove!: (e: React.SyntheticEvent<any>) => void;
+    touchableHandleResponderRelease!: (e: React.SyntheticEvent<any>) => void;
+    touchableHandleResponderTerminate!: (e: React.SyntheticEvent<any>) => void;
 
     private _isMounted = false;
     protected _isMouseOver = false;

--- a/src/native-common/GestureView.tsx
+++ b/src/native-common/GestureView.tsx
@@ -40,7 +40,7 @@ const _defaultImportantForAccessibility = Types.ImportantForAccessibility.Yes;
 
 export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
     private _panResponder: RN.PanResponderInstance;
-    private _doubleTapTimer: any = null;
+    private _doubleTapTimer: number | undefined;
 
     // State for tracking move gestures (pinch/zoom or pan)
     private _pendingGestureType: GestureType = GestureType.None;
@@ -55,21 +55,7 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
     constructor(props: Types.GestureViewProps) {
         super(props);
 
-        this._setUpPanResponder();
-    }
-
-    componentWillUnmount() {
-        // Dispose of timer before the component goes away.
-        this._cancelDoubleTapTimer();
-    }
-
-    // Get preferred pan ratio for platform.
-    protected abstract _getPreferredPanRatio(): number;
-
-    // Returns the timestamp for the touch event in milliseconds.
-    protected abstract _getEventTimestamp(e: Types.TouchEvent): number;
-
-    private _setUpPanResponder(): void {
+        // Setup Pan Responder
         this._panResponder = RN.PanResponder.create({
             onStartShouldSetPanResponder: (e, gestureState) => {
                 const event = (e as any).nativeEvent as Types.TouchEvent;
@@ -126,7 +112,7 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
                     this._pendingGestureType = this._detectMoveGesture(event, gestureState);
                     initializeFromEvent = true;
                 }
-                
+
                 if (this._pendingGestureType === GestureType.MultiTouch) {
                     this._setPendingGestureState(this._sendMultiTouchEvents(event, gestureState,
                         initializeFromEvent, false));
@@ -143,6 +129,17 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
             onPanResponderTerminationRequest: (e, gestureState) => this.props.releaseOnRequest
         });
     }
+
+    componentWillUnmount() {
+        // Dispose of timer before the component goes away.
+        this._cancelDoubleTapTimer();
+    }
+
+    // Get preferred pan ratio for platform.
+    protected abstract _getPreferredPanRatio(): number;
+
+    // Returns the timestamp for the touch event in milliseconds.
+    protected abstract _getEventTimestamp(e: Types.TouchEvent): number;
 
     private _onPanResponderEnd(e: RN.GestureResponderEvent, gestureState: RN.PanResponderGestureState) {
         const event = (e as any).nativeEvent as Types.TouchEvent;
@@ -239,7 +236,7 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
 
         this._doubleTapTimer = setTimeout(() => {
             this._reportDelayedTap();
-            this._doubleTapTimer = null;
+            this._doubleTapTimer = undefined;
         }, _doubleTapDurationThreshold);
     }
 
@@ -247,7 +244,7 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
     private _cancelDoubleTapTimer() {
         if (this._doubleTapTimer) {
             clearTimeout(this._doubleTapTimer);
-            this._doubleTapTimer = null;
+            this._doubleTapTimer = undefined;
         }
     }
 
@@ -446,17 +443,17 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
 
         assert.ok(this._lastGestureStartEvent, 'Gesture start event must not be null.');
 
-        let initialPageX = this._lastGestureStartEvent 
-            ? this._lastGestureStartEvent.pageX!!! 
+        let initialPageX = this._lastGestureStartEvent
+            ? this._lastGestureStartEvent.pageX!!!
             : initializeFromEvent ? pageX : state.initialPageX;
-        let initialPageY = this._lastGestureStartEvent 
-            ? this._lastGestureStartEvent.pageY!!! 
+        let initialPageY = this._lastGestureStartEvent
+            ? this._lastGestureStartEvent.pageY!!!
             : initializeFromEvent ? pageY : state.initialPageY;
-        let initialClientX = this._lastGestureStartEvent 
+        let initialClientX = this._lastGestureStartEvent
             ? this._lastGestureStartEvent.locationX!!!
             : initializeFromEvent ? clientX : state.initialClientX;
-        let initialClientY = this._lastGestureStartEvent 
-            ? this._lastGestureStartEvent.locationY!!! 
+        let initialClientY = this._lastGestureStartEvent
+            ? this._lastGestureStartEvent.locationY!!!
             : initializeFromEvent ? clientY : state.initialClientY;
 
         let velocityX = initializeFromEvent ? 0 : gestureState.vx;

--- a/src/native-common/UserInterface.tsx
+++ b/src/native-common/UserInterface.tsx
@@ -19,13 +19,13 @@ import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
 
 export class UserInterface extends RX.UserInterface {
-    private _touchLatencyThresholhdMs: number;
+    private _touchLatencyThresholhdMs: number|undefined;
 
     constructor() {
         super();
         RN.Dimensions.addEventListener('change', (event) => {
             this.contentSizeMultiplierChangedEvent.fire(event.window.fontScale);
-        });        
+        });
     }
 
     measureLayoutRelativeToWindow(component: React.Component<any, any>):

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -119,16 +119,17 @@ function _childrenEdited(prevChildrenKeys: ChildKey[], nextChildrenKeys: ChildKe
 export class View extends ViewBase<Types.ViewProps, {}> {
     protected _internalProps: any = {};
 
-    touchableGetInitialState: () => RN.Touchable.State;
-    touchableHandleStartShouldSetResponder: () => boolean;
-    touchableHandleResponderTerminationRequest: () => boolean;
-    touchableHandleResponderGrant: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderMove: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderRelease: (e: React.SyntheticEvent<any>) => void;
-    touchableHandleResponderTerminate: (e: React.SyntheticEvent<any>) => void;
+    // Assigned when mixin is applied
+    touchableGetInitialState!: () => RN.Touchable.State;
+    touchableHandleStartShouldSetResponder!: () => boolean;
+    touchableHandleResponderTerminationRequest!: () => boolean;
+    touchableHandleResponderGrant!: (e: React.SyntheticEvent<any>) => void;
+    touchableHandleResponderMove!: (e: React.SyntheticEvent<any>) => void;
+    touchableHandleResponderRelease!: (e: React.SyntheticEvent<any>) => void;
+    touchableHandleResponderTerminate!: (e: React.SyntheticEvent<any>) => void;
 
     private _mixinIsApplied = false;
-    private _childrenKeys: ChildKey[];
+    private _childrenKeys: ChildKey[]|undefined;
 
     private _mixin_componentDidMount?: () => void;
     private _mixin_componentWillUnmount?: () => void;
@@ -178,7 +179,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
             ' Only callback refs are supported when using child animations on a `View`'
         );
 
-        let prevChildrenKeys = this._childrenKeys;
+        let prevChildrenKeys = this._childrenKeys || [];
         let nextChildrenKeys = extractChildrenKeys(nextProps.children);
         this._childrenKeys = nextChildrenKeys;
         if (_childrenEdited(prevChildrenKeys, nextChildrenKeys)) {

--- a/src/web/App.ts
+++ b/src/web/App.ts
@@ -39,6 +39,8 @@ export class App extends RX.App {
                     this.activationStateChangedEvent.fire(this._activationState);
                 }
             });
+        } else {
+            this._activationState = Types.AppActivationState.Active;
         }
     }
 

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -61,7 +61,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         hasRxButtonAscendant: PropTypes.bool
     };
 
-    private _lastMouseDownEvent: Types.SyntheticEvent;
+    private _lastMouseDownEvent: Types.SyntheticEvent|undefined;
     private _ignoreClick = false;
     private _longPressTimer: number|undefined;
     private _isMouseOver = false;
@@ -184,10 +184,15 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
             this._lastMouseDownEvent = e;
             e.persist();
 
+            // In the unlikely event we get 2 mouse down events, clear existing timer
+            if (this._longPressTimer) {
+                window.clearTimeout(this._longPressTimer);
+            }
             this._longPressTimer = window.setTimeout(() => {
                 this._longPressTimer = undefined;
                 if (this.props.onLongPress) {
-                    this.props.onLongPress(this._lastMouseDownEvent);
+                    // lastMouseDownEvent can never be undefined at this point
+                    this.props.onLongPress(this._lastMouseDownEvent!!!);
                     this._ignoreClick = true;
                 }
             }, _longPressTime);

--- a/src/web/CustomScrollbar.ts
+++ b/src/web/CustomScrollbar.ts
@@ -159,9 +159,10 @@ export class Scrollbar {
     private _container: HTMLElement;
     private _verticalBar: IScrollbarInfo = {};
     private _horizontalBar: IScrollbarInfo = {};
-    private _viewport: HTMLElement;
+    // Viewport will always be initialized before it's used
+    private _viewport!: HTMLElement;
     private _dragging = false;
-    private _dragIsVertical: boolean;
+    private _dragIsVertical = false;
     private _scrollingVisible = false;
     private _hasHorizontal = false;
     private _hasVertical = true;
@@ -334,14 +335,14 @@ export class Scrollbar {
 
         if (this._hasVertical) {
             const eventOffsetY = e.pageY - target.getBoundingClientRect().top;
-            const halfHeight = this._verticalBar.slider!!!.offsetHeight / 2; 
+            const halfHeight = this._verticalBar.slider!!!.offsetHeight / 2;
             const offsetY = (eventOffsetY - this._verticalBar.slider!!!.offsetTop - halfHeight) * this._verticalBar.slider2Scroll!!!;
             this._viewport.scrollTop = offsetY + this._viewport.scrollTop;
         }
-        
+
         if (this._hasHorizontal) {
             const eventOffsetX = e.pageX - target.getBoundingClientRect().left;
-            const halfWidth = this._horizontalBar.slider!!!.offsetWidth / 2; 
+            const halfWidth = this._horizontalBar.slider!!!.offsetWidth / 2;
             const offsetX = (eventOffsetX - this._horizontalBar.slider!!!.offsetLeft - halfWidth) * this._horizontalBar.slider2Scroll!!!;
             this._viewport.scrollLeft = offsetX + this._viewport.scrollLeft;
         }

--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -46,23 +46,19 @@ let _idCounter = 1;
 
 export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
 
-    private _id: number;
+    private _id = _idCounter++;
 
-    private _container: HTMLElement;
+    private _container: HTMLElement|null|   undefined;
     // State for tracking double taps
     private _doubleTapTimer: number|undefined;
     private _lastTapEvent: React.MouseEvent<any>|undefined;
 
-    private _responder: MouseResponderSubscription;
+    private _responder: MouseResponderSubscription|undefined;
 
     // private _pendingGestureState: Types.PanGestureState = null;
     private _pendingGestureType = GestureType.None;
     private _gestureTypeLocked = false;
     private _skipNextTap = false;
-
-    componentWillMount() {
-        this._id = _idCounter++;
-    }
 
     componentWillUnmount() {
         // Dispose of timer before the component goes away.
@@ -88,12 +84,12 @@ export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
         );
     }
 
-    private _createMouseResponder() {
+    private _createMouseResponder(container: HTMLElement) {
         this._disposeMouseResponder();
 
         this._responder = MouseResponder.create({
             id: this._id,
-            target: this._container,
+            target: container,
             shouldBecomeFirstResponder: (event: MouseEvent) => {
                 if (!this.props.onPan && !this.props.onPanHorizontal && !this.props.onPanVertical) {
                     return false;
@@ -134,12 +130,12 @@ export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
         }
     }
 
-    private _setContainerRef = (container: any) => {
+    private _setContainerRef = (container: HTMLElement|null) => {
         // safe since div refs resolve into HTMLElement and not react element.
-        this._container = container as HTMLElement;
+        this._container = container;
 
         if (container) {
-            this._createMouseResponder();
+            this._createMouseResponder(container);
         } else {
             this._disposeMouseResponder();
         }

--- a/src/web/Image.tsx
+++ b/src/web/Image.tsx
@@ -117,7 +117,8 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         isRxParentAText: PropTypes.bool
     };
 
-    context: ImageContext;
+    // Provided by super, just re-typing here
+    context!: ImageContext;
 
     static childContextTypes: React.ValidationMap<any> = {
         isRxParentAText: PropTypes.bool.isRequired

--- a/src/web/ScrollView.tsx
+++ b/src/web/ScrollView.tsx
@@ -95,8 +95,8 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
                 overflowY: 'scroll',
                 paddingRight: 30 - nativeScrollbarWidth,
                 marginRight: -30,
-                // Fixes a bug for Chrome beta where the parent flexbox (customScrollContainer) doesn't 
-                // recognize that its child got populated with items. Smallest default width gives an 
+                // Fixes a bug for Chrome beta where the parent flexbox (customScrollContainer) doesn't
+                // recognize that its child got populated with items. Smallest default width gives an
                 // indication that content will exist here.
                 minHeight: 0
             };
@@ -107,8 +107,8 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
                 overflowX: 'scroll',
                 paddingBottom: 30 - nativeScrollbarWidth,
                 marginBottom: -30,
-                // Fixes a bug for Chrome beta where the parent flexbox (customScrollContainer) doesn't 
-                // recognize that its child got populated with items. Smallest default width gives an 
+                // Fixes a bug for Chrome beta where the parent flexbox (customScrollContainer) doesn't
+                // recognize that its child got populated with items. Smallest default width gives an
                 // indication that content will exist here.
                 minWidth: 0
             };
@@ -118,7 +118,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
     }
 
     private _mounted = false;
-    private _customScrollbar: CustomScrollbar;
+    private _customScrollbar: CustomScrollbar | undefined;
     private _customScrollbarEnabled = true;
     private _dragging = false;
 
@@ -151,13 +151,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
         super.componentDidMount();
         this._mounted = true;
 
-        if (this._customScrollbarEnabled) {
-            let element = ReactDOM.findDOMNode(this) as HTMLElement;
-            if (element) {
-                this._customScrollbar = new CustomScrollbar(element);
-                this._customScrollbar.init({ horizontal: this.props.horizontal, vertical: this.props.vertical });
-            }
-        }
+        this.createCustomScrollbarsIfNeeded();
     }
 
     componentWillReceiveProps(newProps: Types.ScrollViewProps) {
@@ -169,8 +163,9 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
         super.componentWillUnmount();
         this._mounted = false;
 
-        if (this._customScrollbarEnabled) {
+        if (this._customScrollbar) {
             this._customScrollbar.dispose();
+            this._customScrollbar = undefined;
         }
     }
 
@@ -184,7 +179,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
             return;
         }
 
-        if (this._customScrollbarEnabled) {
+        if (this._customScrollbarEnabled && this._customScrollbar) {
             this._customScrollbar.update();
         }
 
@@ -211,6 +206,19 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, {}> implements R
 
     private _onPropsChange(props: Types.ScrollViewProps) {
         this._customScrollbarEnabled = ScrollViewConfig.useCustomScrollbars();
+
+        // If we're turning on custom scrollbars, we need to create the scrollbar when this prop
+        this.createCustomScrollbarsIfNeeded();
+    }
+
+    private createCustomScrollbarsIfNeeded() {
+        if (this._mounted && this._customScrollbarEnabled && !this._customScrollbar) {
+            let element = ReactDOM.findDOMNode(this) as HTMLElement;
+            if (element) {
+                this._customScrollbar = new CustomScrollbar(element);
+                this._customScrollbar.init({ horizontal: this.props.horizontal, vertical: this.props.vertical });
+            }
+        }
     }
 
     private _getContainerStyle(): Types.ScrollViewStyleRuleSet {

--- a/src/web/UserPresence.ts
+++ b/src/web/UserPresence.ts
@@ -29,8 +29,10 @@ export class UserPresence extends RX.UserPresence {
             ifvisible.on('idle', this._handleIdle.bind(this));
             ifvisible.on('focus', this._handleFocus.bind(this));
             ifvisible.on('blur', this._handleBlur.bind(this));
-            
+
             window.addEventListener('blur', this._handleWindowBlur.bind(this));
+        } else {
+            this._isPresent = false;
         }
     }
 

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -77,15 +77,16 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         isRxParentAText: PropTypes.bool,
         focusManager: PropTypes.object
     };
-    context: ViewContext;
+    // Context is provided by super - just re-typing here
+    context!: ViewContext;
 
     static childContextTypes: React.ValidationMap<any> = {
         isRxParentAText: PropTypes.bool.isRequired,
         focusManager: PropTypes.object
     };
 
-    private _focusManager: FocusManager;
-    private _isFocusLimited: boolean;
+    private _focusManager: FocusManager|undefined;
+    private _isFocusLimited = false;
 
     private _resizeDetectorAnimationFrame: number|undefined;
     private _resizeDetectorNodes: { grow?: HTMLElement, shrink?: HTMLElement } = {};

--- a/src/web/listAnimations/MonitorListEdits.tsx
+++ b/src/web/listAnimations/MonitorListEdits.tsx
@@ -143,10 +143,11 @@ export class MonitorListEdits extends React.Component<MonitorListEditsProps, {}>
     } = {};
 
     private _isMounted = false;
-    private _childrenKeys: ChildKey[]; // Updated in componentWillUpdate
-    private _childrenMap: ChildrenMap; // Updated in componentWillUpdate
+    // These are assigned in component will mount - will get value before used
+    private _childrenKeys!: ChildKey[]; // Updated in componentWillUpdate
+    private _childrenMap!: ChildrenMap; // Updated in componentWillUpdate
     // Extracted to don't leak it, shouldn't be a problem as js is singlethreaded
-    private _childrenToRender: JSX.Element[];
+    private _childrenToRender!: JSX.Element[];
 
     private _phase: ComponentPhaseEnum = ComponentPhaseEnum.rest;
     private _willAnimatePhaseInfo: IWillAnimatePhaseInfo|undefined;

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -32,7 +32,9 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     static contextTypes: React.ValidationMap<any> = {
         isRxParentAText: PropTypes.bool
     };
-    context: LinkContext;
+
+    // Will be assiged by super - just re-typing here
+    context!: LinkContext;
 
     private _focusableElement : RNW.FocusableWindows<RN.TextProps> | null = null;
 

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -37,23 +37,24 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         isRxParentAText: PropTypes.bool,
         focusManager: PropTypes.object
     };
-    context: ViewContext;
+    // Context is provided by super - just re-typing here
+    context!: ViewContext;
 
     static childContextTypes: React.ValidationMap<any> = {
         isRxParentAText: PropTypes.bool.isRequired,
         focusManager: PropTypes.object
     };
 
-    private _onKeyDown: (e: React.SyntheticEvent<any>) => void;
-    private _onMouseEnter: (e: React.SyntheticEvent<any>) => void;
-    private _onMouseLeave: (e: React.SyntheticEvent<any>) => void;
-    private _onMouseOver: (e: React.SyntheticEvent<any>) => void;
-    private _onMouseMove: (e: React.SyntheticEvent<any>) => void;
+    private _onKeyDown: ((e: React.SyntheticEvent<any>) => void) | undefined;
+    private _onMouseEnter: ((e: React.SyntheticEvent<any>) => void) | undefined;
+    private _onMouseLeave: ((e: React.SyntheticEvent<any>) => void) | undefined;
+    private _onMouseOver: ((e: React.SyntheticEvent<any>) => void) | undefined;
+    private _onMouseMove: ((e: React.SyntheticEvent<any>) => void) | undefined;
 
     private _focusableElement : RNW.FocusableWindows<RN.ViewProps> | null = null;
 
-    private _focusManager: FocusManager;
-    private _isFocusLimited: boolean;
+    private _focusManager: FocusManager|undefined;
+    private _isFocusLimited = false;
 
     constructor(props: Types.ViewProps, context: ViewContext) {
         super(props);
@@ -222,7 +223,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
             let PotentiallyAnimatedFocusableView = this._isButton(this.props) ? FocusableAnimatedView : FocusableView;
             return (
-                <PotentiallyAnimatedFocusableView 
+                <PotentiallyAnimatedFocusableView
                     { ...focusableViewProps }
                 />
             );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "noImplicitThis": true,
         "noUnusedLocals": true,
         "strictNullChecks": true,
+        "strictPropertyInitialization": true,
         "forceConsistentCasingInFileNames": true,
         "outDir": "dist/",
         "lib": [


### PR DESCRIPTION
Strict initialization checks validate that every value that does not list ```undefined``` will be assigned in the constructor. Fixed a bunch of places where properties could be undefined but their types didn't reflect that