### PR TITLE
Fill pageX/Y & clientX/Y in MouseEvent events

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -460,7 +460,7 @@ export interface ButtonProps extends CommonStyledProps<ButtonStyleRuleSet>, Comm
     delayLongPress?: number;
 
     onAccessibilityTapIOS?: Function; // iOS-only prop, call when a button is double tapped in accessibility mode
-    onContextMenu?: (e: SyntheticEvent) => void;
+    onContextMenu?: (e: MouseEvent) => void;
     onPress?: (e: SyntheticEvent) => void;
     onPressIn?: (e: SyntheticEvent) => void;
     onPressOut?: (e: SyntheticEvent) => void;
@@ -553,7 +553,7 @@ export interface TextPropsShared extends CommonProps {
     onPress?: (e: SyntheticEvent) => void;
 
     id?: string; // Web only. Needed for accessibility.
-    onContextMenu?: (e: SyntheticEvent) => void;
+    onContextMenu?: (e: MouseEvent) => void;
 }
 
 export interface TextProps extends TextPropsShared {
@@ -625,7 +625,7 @@ export interface ViewPropsShared extends CommonProps, CommonAccessibilityProps {
 
 export interface ViewProps extends ViewPropsShared {
     style?:  StyleRuleSetRecursive<ViewStyleRuleSet>;
-    onContextMenu?: (e: SyntheticEvent) => void;
+    onContextMenu?: (e: MouseEvent) => void;
     onStartShouldSetResponder?: (e: SyntheticEvent) => boolean;
     onMoveShouldSetResponder?: (e: SyntheticEvent) => boolean;
     onStartShouldSetResponderCapture?: (e: SyntheticEvent) => boolean;

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -219,12 +219,12 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         }
     }
 
-    touchableHandlePress = (e: Types.MouseEvent) => {
+    touchableHandlePress = (e: Types.SyntheticEvent) => {
         UserInterface.evaluateTouchLatency(e);
         if (!this.props.disabled) {
             if (EventHelpers.isRightMouseButton(e)) {
                 if (this.props.onContextMenu) {
-                    this.props.onContextMenu(e);
+                    this.props.onContextMenu(EventHelpers.toMouseEvent(e));
                 }
             } else {
                 if (this.props.onPress) {
@@ -234,7 +234,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         }
     }
 
-    touchableHandleLongPress = (e: Types.MouseEvent) => {
+    touchableHandleLongPress = (e: Types.SyntheticEvent) => {
         if (!this.props.disabled && !EventHelpers.isRightMouseButton(e) && this.props.onLongPress) {
             this.props.onLongPress(e);
         }

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -71,7 +71,7 @@ export class Text extends React.Component<Types.TextProps, {}> implements React.
     private _onPress = (e: RN.SyntheticEvent<any>) => {
         if (EventHelpers.isRightMouseButton(e)) {
             if (this.props.onContextMenu) {
-                this.props.onContextMenu(e);
+                this.props.onContextMenu(EventHelpers.toMouseEvent(e));
             }
         } else {
             if (this.props.onPress) {

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -400,11 +400,11 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         );
     }
 
-    touchableHandlePress(e: Types.MouseEvent): void {
+    touchableHandlePress(e: Types.SyntheticEvent): void {
         UserInterface.evaluateTouchLatency(e);
         if (EventHelpers.isRightMouseButton(e)) {
             if (this.props.onContextMenu) {
-                this.props.onContextMenu(e);
+                this.props.onContextMenu(EventHelpers.toMouseEvent(e));
             }
         } else {
             if (this.props.onPress) {
@@ -413,7 +413,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         }
     }
 
-    touchableHandleLongPress(e: Types.MouseEvent): void {
+    touchableHandleLongPress(e: Types.SyntheticEvent): void {
         if (!EventHelpers.isRightMouseButton(e)) {
             if (this.props.onLongPress) {
                 this.props.onLongPress(e);

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -91,23 +91,25 @@ export class EventHelpers {
                 }
             }
 
-            // We need to add keyCode to the original event, but React Native
+            // We need to add keyCode and other properties to the original event, but React Native
             // reuses events, so we're not allowed to modify the original.
             // Instead, we'll clone it.
             keyEvent = _.clone(keyEvent);
             keyEvent.keyCode = keyCode;
 
-            if ((e.nativeEvent as any).shiftKey) {
-                keyEvent.shiftKey = (e.nativeEvent as any).shiftKey;
+            const nativeEvent = e.nativeEvent;
+
+            if (nativeEvent.shiftKey) {
+                keyEvent.shiftKey = nativeEvent.shiftKey;
             }
-            if ((e.nativeEvent as any).ctrlKey) {
-                keyEvent.ctrlKey = (e.nativeEvent as any).ctrlKey;
+            if (nativeEvent.ctrlKey) {
+                keyEvent.ctrlKey = nativeEvent.ctrlKey;
             }
-            if ((e.nativeEvent as any).altKey) {
-                keyEvent.altKey = (e.nativeEvent as any).altKey;
+            if (nativeEvent.altKey) {
+                keyEvent.altKey = nativeEvent.altKey;
             }
-            if ((e.nativeEvent as any).metaKey) {
-                keyEvent.metaKey = (e.nativeEvent as any).metaKey;
+            if (nativeEvent.metaKey) {
+                keyEvent.metaKey = nativeEvent.metaKey;
             }
 
             keyEvent.stopPropagation = () => {
@@ -134,8 +136,57 @@ export class EventHelpers {
 
     toMouseEvent(e: Types.SyntheticEvent): Types.MouseEvent {
 
-        // Nothing for now, this will have to be enhanced based on platform support.
-        return e as Types.MouseEvent;
+        // We need to add various properties to the original event, but React Native
+        // reuses events, so we're not allowed to modify the original.
+        // Instead, we'll clone it.
+        let mouseEvent = _.clone(e as Types.MouseEvent);
+        
+        const nativeEvent = e.nativeEvent;
+
+        // We keep pageX/Y and clientX/Y in coordinates in sync, similar to the React web behavior
+        // RN (UWP flavor for this type of event) also pass coordinates in the target view (locationX/Y) that we don't use here.
+        if (nativeEvent.pageX !== undefined) {
+            mouseEvent.clientX = mouseEvent.pageX = nativeEvent.pageX;
+        }
+
+        if (nativeEvent.pageY !== undefined) {
+            mouseEvent.clientY = mouseEvent.pageY = nativeEvent.pageY;
+        }
+
+        if (!!nativeEvent.IsRightButton) {
+            mouseEvent.button = 2;
+        } else if (!!nativeEvent.IsMiddleButton) {
+            mouseEvent.button = 1;
+        } else {
+            mouseEvent.button = 0;
+        }
+
+        if (nativeEvent.shiftKey) {
+            mouseEvent.shiftKey = nativeEvent.shiftKey;
+        }
+        if (nativeEvent.ctrlKey) {
+            mouseEvent.ctrlKey = nativeEvent.ctrlKey;
+        }
+        if (nativeEvent.altKey) {
+            mouseEvent.altKey = nativeEvent.altKey;
+        }
+        if (nativeEvent.metaKey) {
+            mouseEvent.metaKey = nativeEvent.metaKey;
+        }
+
+        mouseEvent.stopPropagation = () => {
+            if (e.stopPropagation) {
+                e.stopPropagation();
+            }
+        };
+
+        mouseEvent.preventDefault = () => {
+            if (e.preventDefault) {
+                e.preventDefault();
+            }
+        };
+
+        return mouseEvent;
     }
 
     isRightMouseButton(e: Types.SyntheticEvent): boolean {

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -143,7 +143,7 @@ export class EventHelpers {
         
         const nativeEvent = e.nativeEvent;
 
-        // We keep pageX/Y and clientX/Y in coordinates in sync, similar to the React web behavior
+        // We keep pageX/Y and clientX/Y coordinates in sync, similar to the React web behavior
         // RN (UWP flavor for this type of event) also pass coordinates in the target view (locationX/Y) that we don't use here.
         if (nativeEvent.pageX !== undefined) {
             mouseEvent.clientX = mouseEvent.pageX = nativeEvent.pageX;

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -169,7 +169,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         return combinedStyles;
     }
 
-    private _onContextMenu = (e: Types.SyntheticEvent) => {
+    private _onContextMenu = (e: React.MouseEvent<any>) => {
         if (this.props.onContextMenu) {
             this.props.onContextMenu(e);
         }


### PR DESCRIPTION
Fill pageX/Y & clientX/Y in MouseEvent events passed in various onMouse* handlers and onContextMenu (changed the signature on this a bit).