### PR TITLE
Implement cacheable popups

### DIFF
--- a/docs/docs/apis/popup.md
+++ b/docs/docs/apis/popup.md
@@ -77,6 +77,11 @@ interface PopupOptions {
     // default behavior, in which case the popup must be dismissed explicitly.
     preventDismissOnPress?: boolean;
 
+    // The popup may be left in the DOM after it's dismissed. This is a performance optimization to
+    // make the popup appear faster when it's shown again, intended for popups that tend to be shown
+    // repeatedly. Note that this is only a hint, popups cannot be force-cached.
+    cacheable?: boolean;
+
     // Android & iOS only.
     // The id of the root view this popup is associated with.
     // Defaults to the view set by UserInterface.setMainView();

--- a/samples/RXPTest/src/Tests/PopupTest.tsx
+++ b/samples/RXPTest/src/Tests/PopupTest.tsx
@@ -68,6 +68,10 @@ const _styles = {
         left: 10,
         bottom: 10
     }),
+    popupAnchor4: RX.Styles.createViewStyle({
+        right: 10,
+        bottom: 10
+    }),
     anchorIndicator: RX.Styles.createViewStyle({
         position: 'absolute',
         height: _indicatorWidth,
@@ -80,6 +84,7 @@ const _styles = {
 const popup1Id = 'popup1';
 const popup2Id = 'popup2';
 const popup3Id = 'popup3';
+const popup4Id = 'popup4';
 
 interface PopupBoxProps extends RX.CommonProps {
     text: string;
@@ -144,6 +149,7 @@ class PopupView extends RX.Component<RX.CommonProps, RX.Stateless> {
     private _anchor1: RX.Button;
     private _anchor2: RX.Button;
     private _anchor3: RX.Button;
+    private _anchor4: RX.Button;
     
     componentWillUnmount() {
         RX.Popup.dismissAll();
@@ -190,6 +196,15 @@ class PopupView extends RX.Component<RX.CommonProps, RX.Stateless> {
                 >
                     <RX.Text style={ _styles.anchorText }>
                         { `3: isDisplayed = ${RX.Popup.isDisplayed(popup3Id)}` }
+                    </RX.Text>
+                </RX.Button>
+                <RX.Button
+                    style={ [_styles.popupAnchor, _styles.popupAnchor4] }
+                    ref={ (comp: RX.Button) => { this._anchor4 = comp; } }
+                    onPress={ this._showPopup4 }
+                >
+                    <RX.Text style={ _styles.anchorText }>
+                        { `4: isDisplayed = ${RX.Popup.isDisplayed(popup4Id)}` }
                     </RX.Text>
                 </RX.Button>
             </RX.View>
@@ -268,6 +283,33 @@ class PopupView extends RX.Component<RX.CommonProps, RX.Stateless> {
         }, popup3Id);
 
         RX.Popup.autoDismiss(popup3Id, 2000);
+    }
+
+    private _showPopup4 = () => {
+        RX.Popup.show({
+            dismissIfShown: true,
+            cacheable: true,
+            getAnchor: () => {
+                return this._anchor4;
+            },
+            getElementTriggeringPopup: () => {
+                return this._anchor3;
+            },
+            positionPriorities: ['left', 'top', 'bottom'],
+            renderPopup: (anchorPosition: RX.Types.PopupPosition, anchorOffset: number,
+                popupWidth: number, popupHeight: number) => {
+
+                return (
+                    <PopupBox
+                        text={ 'Cacheable popup\n(may be still rendered when dismissed)' }
+                        anchorOffset={ anchorOffset }
+                        anchorPosition={ anchorPosition }
+                        popupWidth={ popupWidth }
+                        popupHeight={ popupHeight }
+                    />
+                );
+            }
+        }, popup4Id);
     }
 }
 

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -972,6 +972,9 @@ export interface PopupOptions {
     // Called when the popup is dismissed.
     onDismiss?: () => void;
 
+    // Called before the popup is re-shown. Gives the popup a chance to reset itself to its initial state.
+    onReshow?: (oldOptions: PopupOptions) => void;
+
     // Prioritized order of positions. Popup is positioned
     // relative to the anchor such that it remains on screen.
     // Default is ['bottom', 'right', 'top', 'left'].
@@ -996,6 +999,10 @@ export interface PopupOptions {
     // outside of it. It will still close if the anchor is unmounted or if
     // dismiss is explicitly called.
     preventDismissOnPress?: boolean;
+
+    // The popup will be left in the DOM after it's dismissed and renderPopup can still be called.
+    // If the same popup (as determined by equal popupId) is shown, onReshow will be called.
+    hideOnDismiss?: boolean;
 
     // Android & iOS only.
     // The id of the root view this popup is associated with.

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -972,9 +972,6 @@ export interface PopupOptions {
     // Called when the popup is dismissed.
     onDismiss?: () => void;
 
-    // Called before the popup is re-shown. Gives the popup a chance to reset itself to its initial state.
-    onReshow?: (oldOptions: PopupOptions) => void;
-
     // Prioritized order of positions. Popup is positioned
     // relative to the anchor such that it remains on screen.
     // Default is ['bottom', 'right', 'top', 'left'].
@@ -1000,9 +997,10 @@ export interface PopupOptions {
     // dismiss is explicitly called.
     preventDismissOnPress?: boolean;
 
-    // The popup will be left in the DOM after it's dismissed and renderPopup can still be called.
-    // If the same popup (as determined by equal popupId) is shown, onReshow will be called.
-    hideOnDismiss?: boolean;
+    // The popup may be left in the DOM after it's dismissed. This is a performance optimization to
+    // make the popup appear faster when it's shown again, intended for popups that tend to be shown
+    // repeatedly. Note that this is only a hint, popups cannot be force-cached.
+    cacheable?: boolean;
 
     // Android & iOS only.
     // The id of the root view this popup is associated with.

--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -36,6 +36,7 @@ const _styles = {
 
 export class FrontLayerViewManager {
     private _overlayStack: (ModalStackContext | PopupStackContext)[] = [];
+    private _cachedPopups: PopupStackContext[] = [];
 
     event_changed = new SubscribableEvent<() => void>();
 
@@ -82,6 +83,11 @@ export class FrontLayerViewManager {
         if (index === -1) {
             const nodeHandle = RN.findNodeHandle(popupOptions.getAnchor());
             if (nodeHandle) {
+                if (popupOptions.cacheable) {
+                    // The popup is transitioning from cached to active.
+                    this._cachedPopups = this._cachedPopups.filter(popup => popup.popupId !== popupId);
+                }
+
                 this._overlayStack.push(new PopupStackContext(popupId, popupOptions, nodeHandle));
                 this.event_changed.fire();
                 return true;    
@@ -96,6 +102,11 @@ export class FrontLayerViewManager {
             const popupContext = this._overlayStack[index] as PopupStackContext;
             if (popupContext.popupOptions.onDismiss) {
                 popupContext.popupOptions.onDismiss();
+            }
+
+            if (popupContext.popupOptions.cacheable) {
+                // The popup is transitioning from active to cached.
+                this._cachedPopups.push(popupContext);
             }
 
             this._overlayStack.splice(index, 1);
@@ -147,39 +158,50 @@ export class FrontLayerViewManager {
         return !!(options === rootViewId || options && options.rootViewId === rootViewId);
     }
 
-    public getPopupLayerView(rootViewId?: string | null): React.ReactElement<any> | null {
+    private _renderPopup(context: PopupStackContext, hidden: boolean): JSX.Element {
+        const key = (context.popupOptions.cacheable ? 'CP:' : 'P:') + context.popupId;
+        return (
+            <ModalContainer
+                key={ key }
+                hidden={ hidden }>
+                <RN.TouchableWithoutFeedback
+                    onPressOut={ this._onBackgroundPressed }
+                    importantForAccessibility={ 'no' }
+                >
+                    <RN.View
+                        style={ _styles.fullScreenView }>
+                        <PopupContainerView
+                            popupOptions={ context.popupOptions }
+                            anchorHandle={ hidden ? undefined : context.anchorHandle }
+                            onDismissPopup={ hidden ? undefined : () => this.dismissPopup(context.popupId) }
+                            hidden={ hidden }
+                        />
+                    </RN.View>
+                </RN.TouchableWithoutFeedback>
+            </ModalContainer>
+        );
+    }
+
+    public getPopupLayerView(rootViewId?: string | null): JSX.Element[] | null {
         if (rootViewId === null) {
             // The Popup layer is only supported on root views that have set an id, or
             // the default root view (which has an undefined id)
             return null;
         }
 
+        let popupContainerViews: JSX.Element[] = [];
+
         const overlayContext =
             _.findLast(
                 this._overlayStack,
                 context => context instanceof PopupStackContext && context.popupOptions.rootViewId === rootViewId
             ) as PopupStackContext;
-
         if (overlayContext) {
-            return (
-                <ModalContainer>
-                    <RN.TouchableWithoutFeedback
-                        onPressOut={ this._onBackgroundPressed }
-                        importantForAccessibility={ 'no' }
-                    >
-                        <RN.View style={ _styles.fullScreenView }>
-                            <PopupContainerView
-                                activePopupOptions={ overlayContext.popupOptions }
-                                anchorHandle={ overlayContext.anchorHandle }
-                                onDismissPopup={ () => this.dismissPopup(overlayContext.popupId) }
-                            />
-                        </RN.View>
-                    </RN.TouchableWithoutFeedback>
-                </ModalContainer>
-            );
+            popupContainerViews.push(this._renderPopup(overlayContext, false));
         }
+        this._cachedPopups.map(context => popupContainerViews.push(this._renderPopup(context, true)));
 
-        return null;
+        return popupContainerViews;
     }
 
     private _onBackgroundPressed = (e: RN.SyntheticEvent<any>) => {

--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -34,6 +34,8 @@ const _styles = {
     }
 };
 
+const MAX_CACHED_POPUPS = 4;
+
 export class FrontLayerViewManager {
     private _overlayStack: (ModalStackContext | PopupStackContext)[] = [];
     private _cachedPopups: PopupStackContext[] = [];
@@ -107,6 +109,7 @@ export class FrontLayerViewManager {
             if (popupContext.popupOptions.cacheable) {
                 // The popup is transitioning from active to cached.
                 this._cachedPopups.push(popupContext);
+                this._cachedPopups = this._cachedPopups.slice(-MAX_CACHED_POPUPS);
             }
 
             this._overlayStack.splice(index, 1);

--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -13,7 +13,6 @@ import React = require('react');
 import RN = require('react-native');
 import SubscribableEvent from 'subscribableevent';
 
-import App from './App';
 import { ModalContainer } from '../native-common/ModalContainer';
 import PopupContainerView from './PopupContainerView';
 import Types = require('../common/Types');
@@ -42,12 +41,6 @@ export class FrontLayerViewManager {
     private _cachedPopups: PopupStackContext[] = [];
 
     event_changed = new SubscribableEvent<() => void>();
-
-    constructor() {
-        App.memoryWarningEvent.subscribe(() => {
-            this._cachedPopups = [];
-        });
-    }
 
     public showModal(modal: React.ReactElement<Types.ViewProps>, modalId: string, options?: Types.ModalOptions): void {
         const index = this._findIndexOfModal(modalId);
@@ -163,6 +156,10 @@ export class FrontLayerViewManager {
         return null;
     }
 
+    public releaseCachedPopups(): void {
+        this._cachedPopups = [];
+    }
+
     // Returns true if both are undefined, or if there are options and the rootViewIds are equal.
     private modalOptionsMatchesRootViewId(options?: Types.ModalOptions, rootViewId?: string): boolean {
         return !!(options === rootViewId || options && options.rootViewId === rootViewId);
@@ -177,7 +174,7 @@ export class FrontLayerViewManager {
                 anchorHandle={ hidden ? undefined : context.anchorHandle }
                 onDismissPopup={ hidden ? undefined : () => this.dismissPopup(context.popupId) }
                 hidden={ hidden }
-                />
+            />
         );
     }
 

--- a/src/native-common/ModalContainer.tsx
+++ b/src/native-common/ModalContainer.tsx
@@ -26,10 +26,15 @@ const _styles = {
         // On Android, we need to provide some color to prevent
         // removal of the view.
         backgroundColor: 'transparent'
+    },
+    hiddenContainer: {
+        width: 0,
+        height: 0
     }
 };
 
 export interface ModalContainerProps extends Types.CommonProps {
+    hidden?: boolean;
 }
 
 export class ModalContainer extends React.Component<ModalContainerProps, {}> {
@@ -39,7 +44,7 @@ export class ModalContainer extends React.Component<ModalContainerProps, {}> {
 
     render() {
         return (
-            <RN.View style={ _styles.defaultContainer }>
+            <RN.View style={ this.props.hidden ? _styles.hiddenContainer : _styles.defaultContainer }>
                 { this.props.children }
             </RN.View>
         );

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -25,9 +25,10 @@ const ALLEY_WIDTH = 2;
 const MIN_ANCHOR_OFFSET = 16;
 
 export interface PopupContainerViewProps extends Types.CommonProps {
-    activePopupOptions: Types.PopupOptions;
-    anchorHandle: number;
+    popupOptions: Types.PopupOptions;
+    anchorHandle?: number;
     onDismissPopup?: () => void;
+    hidden: boolean;
 }
 
 export interface PopupContainerViewState {
@@ -78,14 +79,14 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
     }
 
     componentWillReceiveProps(prevProps: PopupContainerViewProps) {
-        if (this.props.activePopupOptions !== prevProps.activePopupOptions) {
+        if (this.props.popupOptions !== prevProps.popupOptions) {
             // If the popup changes, reset our state.
             this.setState(this._getInitialState());
         }
     }
 
     componentDidUpdate(prevProps: PopupContainerViewProps, prevState: PopupContainerViewState) {
-        if (this.props.activePopupOptions) {
+        if (this.props.popupOptions && !this.props.hidden) {
             this._recalcPosition();
 
             if (!this._respositionPopupTimer) {
@@ -99,11 +100,8 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
     componentDidMount () {
         this._viewHandle = RN.findNodeHandle(this._mountedComponent);
 
-        if (this.props.activePopupOptions) {
+        if (this.props.popupOptions && !this.props.hidden) {
             this._recalcPosition();
-        }
-
-        if (this.props.activePopupOptions) {
             this._startRepositionPopupTimer();
         }
     }
@@ -113,9 +111,13 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
     }
 
     render() {
-        var popupView = this.props.activePopupOptions.renderPopup(
-            this.state.anchorPosition, this.state.anchorOffset,
-            this.state.constrainedPopupWidth, this.state.constrainedPopupHeight);
+        const popupView = (this.props.hidden ?
+            this.props.popupOptions.renderPopup('top', 0, 0, 0) :
+            this.props.popupOptions.renderPopup(
+                this.state.anchorPosition, this.state.anchorOffset,
+                this.state.constrainedPopupWidth,
+                this.state.constrainedPopupHeight)
+            );
         const isRTL = International.isRTL();
         const style = {
             position: 'absolute',
@@ -131,7 +133,7 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
         return (
             <RN.View
                 style={ style }
-                ref={ this._onMount }
+                ref={ this.props.hidden ? undefined : this._onMount }
             >
                 { popupView }
             </RN.View>
@@ -210,12 +212,12 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
                 return;
             }
 
-            let positionsToTry = this.props.activePopupOptions.positionPriorities;
+            let positionsToTry = this.props.popupOptions.positionPriorities;
             if (!positionsToTry || positionsToTry.length === 0) {
                 positionsToTry = ['bottom', 'right', 'top', 'left'];
             }
 
-            if (this.props.activePopupOptions.useInnerPositioning) {
+            if (this.props.popupOptions.useInnerPositioning) {
                 // If the popup is meant to be shown inside the anchor we need to recalculate
                 // the position differently.
                 this._recalcInnerPosition(anchorRect, newState);
@@ -344,7 +346,7 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
 
     private _recalcInnerPosition(anchorRect: ClientRect, newState: PopupContainerViewState) {
         // For inner popups we only accept the first position of the priorities since there should always be room for the bubble.
-        const pos = this.props.activePopupOptions.positionPriorities!!![0];
+        const pos = this.props.popupOptions.positionPriorities!!![0];
 
         switch (pos) {
             case 'top':

--- a/src/native-common/RootView.tsx
+++ b/src/native-common/RootView.tsx
@@ -14,6 +14,7 @@ import _ = require('./lodashMini');
 
 import Accessibility from './Accessibility';
 import AccessibilityUtil from './AccessibilityUtil';
+import App from './App';
 import AppConfig from '../common/AppConfig';
 import { default as FrontLayerViewManager } from './FrontLayerViewManager';
 import MainViewStore from './MainViewStore';
@@ -57,6 +58,7 @@ const _styles = {
 abstract class BaseRootView<P extends BaseRootViewProps> extends React.Component<P, RootViewState> {
     private _frontLayerViewChangedSubscription: SubscriptionToken|undefined;
     private _newAnnouncementEventChangedSubscription: SubscriptionToken|undefined;
+    private _memoryWarningEventSubscription: SubscriptionToken|undefined;
     protected _mainViewProps: {};
     protected _rootViewId?: string | null;
 
@@ -80,6 +82,11 @@ abstract class BaseRootView<P extends BaseRootViewProps> extends React.Component
                     announcementText: announcement
                 });
         });
+
+        this._memoryWarningEventSubscription = App.memoryWarningEvent.subscribe(() => {
+            FrontLayerViewManager.releaseCachedPopups();
+            this.forceUpdate();
+        });
     }
 
     componentWillUnmount(): void {
@@ -91,6 +98,11 @@ abstract class BaseRootView<P extends BaseRootViewProps> extends React.Component
         if (this._newAnnouncementEventChangedSubscription) {
             this._newAnnouncementEventChangedSubscription.unsubscribe();
             this._newAnnouncementEventChangedSubscription = undefined;
+        }
+
+        if (this._memoryWarningEventSubscription) {
+            this._memoryWarningEventSubscription.unsubscribe();
+            this._memoryWarningEventSubscription = undefined;
         }
     }
 

--- a/src/web/FrontLayerViewManager.tsx
+++ b/src/web/FrontLayerViewManager.tsx
@@ -91,9 +91,6 @@ export class FrontLayerViewManager {
 
         if (this._activePopupOptions && this._activePopupIsHidden && this._activePopupId === popupId) {
             // We are re-showing a previously hidden popup.
-            if (options.onReshow) {
-                options.onReshow(this._activePopupOptions);
-            }
         }
 
         if (this._popupShowDelayTimer) {
@@ -143,7 +140,7 @@ export class FrontLayerViewManager {
                 this._popupShowDelayTimer = undefined;
             }
 
-            if (this._activePopupOptions.hideOnDismiss) {
+            if (this._activePopupOptions.cacheable) {
                 this._activePopupIsHidden = true;
             } else {
                 this._activePopupOptions = undefined;

--- a/src/web/FrontLayerViewManager.tsx
+++ b/src/web/FrontLayerViewManager.tsx
@@ -14,6 +14,8 @@ import { RootView } from './RootView';
 
 import Types = require('../common/Types');
 
+const MAX_CACHED_POPUPS = 4;
+
 export class FrontLayerViewManager {
     private _mainView: React.ReactElement<any>|undefined;
     private _modalStack: { modal: React.ReactElement<Types.ViewProps>, id: string }[] = [];
@@ -96,6 +98,7 @@ export class FrontLayerViewManager {
         if (this._activePopupOptions && this._activePopupOptions.cacheable) {
             // Old popup is transitioning from active to cached.
             this._cachedPopups.push({ options: this._activePopupOptions, id: this._activePopupId!!! });
+            this._cachedPopups = this._cachedPopups.slice(-MAX_CACHED_POPUPS);
         }
 
         if (this._popupShowDelayTimer) {
@@ -147,6 +150,7 @@ export class FrontLayerViewManager {
             if (this._activePopupOptions.cacheable) {
                 // The popup is transitioning from active to cached.
                 this._cachedPopups.push({ options: this._activePopupOptions, id: this._activePopupId });
+                this._cachedPopups = this._cachedPopups.slice(-MAX_CACHED_POPUPS);
             }
 
             this._activePopupOptions = undefined;

--- a/src/web/PopupContainer.tsx
+++ b/src/web/PopupContainer.tsx
@@ -1,0 +1,104 @@
+/**
+* PopupContainer.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* Common parent of all components rendered into a popup. Calls onShow and onHide
+* callbacks when the popup is hidden (i.e. "closed" but still rendered as hidden)
+* and re-shown.
+*/
+
+import React = require('react');
+import PropTypes = require('prop-types');
+import FocusManager from './utils/FocusManager';
+
+export interface PopupContainerProps {
+    style: React.CSSProperties;
+    onMouseEnter?: (e: any) => void;
+    onMouseLeave?: (e: any) => void;
+    hidden?: boolean;
+}
+
+export interface PopupContainerContext {
+    focusManager?: FocusManager;
+}
+
+export interface PopupComponent {
+    onShow: () => void;
+    onHide: () => void;
+}
+
+export class PopupContainer extends React.Component<PopupContainerProps, {}> {
+    static contextTypes: React.ValidationMap<any> = {
+        focusManager: PropTypes.object
+    };
+    static childContextTypes: React.ValidationMap<any> = {
+        focusManager: PropTypes.object,
+        popupContainer: PropTypes.object
+    };
+
+    private _popupComponentStack: PopupComponent[] = [];
+
+    constructor(props: PopupContainerProps, context: PopupContainerContext) {
+        super(props, context);
+    }
+
+    getChildContext() {
+        return {
+            focusManager: this.context.focusManager,
+            popupContainer: this as PopupContainer
+        };
+    }
+
+    render() {
+        let style = this.props.style;
+        if (this.props.hidden) {
+            style['visibility'] = 'hidden';
+        }
+        return (
+            <div
+                style={ style }
+                onMouseEnter={ this.props.onMouseEnter }
+                onMouseLeave={ this.props.onMouseLeave }
+            >
+                { this.props.children }
+            </div>
+        );
+    }
+
+    public registerPopupComponent(onShow: () => void, onHide: () => void): PopupComponent {
+        const component = {
+            onShow,
+            onHide
+        };
+        this._popupComponentStack.push(component);
+        return component;
+    }
+
+    public unregisterPopupComponent(component: PopupComponent) {
+        this._popupComponentStack = this._popupComponentStack.filter(c => c !== component);
+    }
+
+    public isHidden(): boolean {
+        return this.props.hidden || false;
+    }
+
+    componentDidUpdate(prevProps: PopupContainerProps) {
+        if (prevProps.hidden && !this.props.hidden) {
+            // call onShow on all registered components (iterate front to back)
+            for (let i = 0; i < this._popupComponentStack.length; i++) {
+                this._popupComponentStack[i].onShow();
+            }
+        }
+        if (!prevProps.hidden && this.props.hidden) {
+            // call onHide on all registered components (iterate back to front)
+            for (let i = this._popupComponentStack.length - 1; i >= 0; i--) {
+                this._popupComponentStack[i].onHide();
+            }
+        }
+    }
+
+}
+
+export default PopupContainer;

--- a/src/web/PopupContainer.tsx
+++ b/src/web/PopupContainer.tsx
@@ -9,11 +9,13 @@
 * and re-shown.
 */
 
+import _ = require('./utils/lodashMini');
 import React = require('react');
 import PropTypes = require('prop-types');
 import FocusManager from './utils/FocusManager';
+import Types = require('../common/Types');
 
-export interface PopupContainerProps {
+export interface PopupContainerProps extends Types.CommonProps {
     style: React.CSSProperties;
     onMouseEnter?: (e: any) => void;
     onMouseLeave?: (e: any) => void;
@@ -52,9 +54,9 @@ export class PopupContainer extends React.Component<PopupContainerProps, {}> {
     }
 
     render() {
-        let style = this.props.style;
+        let style = _.clone(this.props.style);
         if (this.props.hidden) {
-            style['visibility'] = 'hidden';
+            style.visibility = 'hidden';
         }
         return (
             <div

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -32,6 +32,7 @@ export interface RootViewProps {
     autoDismiss?: boolean;
     autoDismissDelay?: number;
     onDismissPopup?: () => void;
+    popupIsHidden?: boolean;
     keyBoardFocusOutline?: string;
     mouseFocusOutline?: string;
 }
@@ -199,7 +200,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
     }
 
     componentDidUpdate(prevProps: RootViewProps, prevState: RootViewState) {
-        if (this.props.activePopupOptions) {
+        if (this.props.activePopupOptions && !this.props.popupIsHidden) {
             this._stopHidePopupTimer();
             this._recalcPosition();
 
@@ -228,7 +229,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
     }
 
     componentDidMount() {
-        if (this.props.activePopupOptions) {
+        if (this.props.activePopupOptions && !this.props.popupIsHidden) {
             this._recalcPosition();
         }
 
@@ -236,7 +237,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
             this._startHidePopupTimer();
         }
 
-        if (this.props.activePopupOptions) {
+        if (this.props.activePopupOptions && !this.props.popupIsHidden) {
             this._startRepositionPopupTimer();
         }
 
@@ -301,6 +302,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
             optionalPopup = (
                 <PopupContainer
                     style={ popupContainerStyle }
+                    hidden={ this.props.popupIsHidden }
                     ref={ this._onMount }
                     onMouseEnter={ e => this._onMouseEnter(e) }
                     onMouseLeave={ e => this._onMouseLeave(e) }
@@ -474,7 +476,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
     }
 
     private _onKeyUp = (e: KeyboardEvent) => {
-        if (this.props.activePopupOptions && (e.keyCode === KEY_CODE_ESC)) {
+        if (this.props.activePopupOptions && !this.props.popupIsHidden && (e.keyCode === KEY_CODE_ESC)) {
             if (e.stopPropagation) {
                 e.stopPropagation();
             }

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -23,6 +23,7 @@ import Styles from './Styles';
 import Types = require('../common/Types');
 import FocusManager from './utils/FocusManager';
 import UserInterface from './UserInterface';
+import PopupContainer from './PopupContainer';
 
 export interface RootViewProps {
     mainView?: React.ReactNode;
@@ -114,7 +115,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         focusManager: PropTypes.object
     };
 
-    private _mountedComponent: HTMLDivElement|null = null;
+    private _mountedComponent: Element|undefined;
     private _hidePopupTimer: number|undefined;
     private _respositionPopupTimer: number|undefined;
     private _clickHandlerInstalled = false;
@@ -298,7 +299,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
             }
 
             optionalPopup = (
-                <div
+                <PopupContainer
                     style={ popupContainerStyle }
                     ref={ this._onMount }
                     onMouseEnter={ e => this._onMouseEnter(e) }
@@ -307,7 +308,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                     { this.props.activePopupOptions.renderPopup(
                         this.state.anchorPosition, this.state.anchorOffset,
                         this.state.constrainedPopupWidth, this.state.constrainedPopupHeight) }
-                </div>
+                </PopupContainer>
             );
         }
 
@@ -344,8 +345,8 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         );
     }
 
-    protected _onMount = (component: HTMLDivElement|null) => {
-        this._mountedComponent = component;
+    protected _onMount = (component: PopupContainer|null) => {
+        this._mountedComponent = component ? ReactDOM.findDOMNode(component) : undefined;
     }
 
     private _tryClosePopup = (e: MouseEvent) => {


### PR DESCRIPTION
Popups that are lightweight, expected to be shown repeatedly, and easy to reset to
their initial state are good candidates for this feature. To elect to be "hideable",
a popup sets hideOnDismiss to true and optionally subscribes to onReshow().

When a hideable popup is dismissed, instead of removing it from the tree, it is still being
rendered, only with visibility: hidden. Then when the same popup is brought up again,
its onReshow() callback is called to give it a chance to reset its state, and visibility
goes back to its default value.

This massively improves the time required to bring up the popup as it saves a bunch of
work done by React when a new node subtree is introduced.

--

Picker popups (reactions, emoticons) in Skype are shown 10x faster when made hideable, with little impact on memory footprint. This is a web-only implementation for now. More platforms will be added if this approach proves useful.