### PR TITLE
Construct full RX.Types.MouseEvent objects for the onPress/onLongPress handlers if possible

### DIFF
--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -228,7 +228,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
                 }
             } else {
                 if (this.props.onPress) {
-                    this.props.onPress(e);
+                    this.props.onPress(EventHelpers.toMouseEvent(e));
                 }
             }
         }
@@ -236,7 +236,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
 
     touchableHandleLongPress = (e: Types.SyntheticEvent) => {
         if (!this.props.disabled && !EventHelpers.isRightMouseButton(e) && this.props.onLongPress) {
-            this.props.onLongPress(e);
+            this.props.onLongPress(EventHelpers.toMouseEvent(e));
         }
     }
 

--- a/src/native-common/Link.tsx
+++ b/src/native-common/Link.tsx
@@ -58,7 +58,7 @@ export class Link extends React.Component<Types.LinkProps, {}> {
         }
 
         if (this.props.onPress) {
-            this.props.onPress(e, this.props.url);
+            this.props.onPress(EventHelpers.toMouseEvent(e), this.props.url);
             return;
         }
 
@@ -72,7 +72,7 @@ export class Link extends React.Component<Types.LinkProps, {}> {
 
     protected _onLongPress = (e: RX.Types.SyntheticEvent) => {
         if (!EventHelpers.isRightMouseButton(e) && this.props.onLongPress) {
-            this.props.onLongPress(e, this.props.url);
+            this.props.onLongPress(EventHelpers.toMouseEvent(e), this.props.url);
         }
     }
 }

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -75,7 +75,7 @@ export class Text extends React.Component<Types.TextProps, {}> implements React.
             }
         } else {
             if (this.props.onPress) {
-                this.props.onPress(e);
+                this.props.onPress(EventHelpers.toMouseEvent(e));
             }
         }
     }

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -408,7 +408,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
             }
         } else {
             if (this.props.onPress) {
-                this.props.onPress(e);
+                this.props.onPress(EventHelpers.toMouseEvent(e));
             }
         }
     }
@@ -416,7 +416,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
     touchableHandleLongPress(e: Types.SyntheticEvent): void {
         if (!EventHelpers.isRightMouseButton(e)) {
             if (this.props.onLongPress) {
-                this.props.onLongPress(e);
+                this.props.onLongPress(EventHelpers.toMouseEvent(e));
             }
         }
     }


### PR DESCRIPTION
We can provide MouseEvent objects when the RN source is touch/mouse related. 
Apps seem to care about "keyboard modifiers" and force their way through the API type constraints in the web implementation, so I'm trying to bring RN(UWP) in sync with that behavior.

The API cannot guarantee more than SyntheticEvent since we can have keyboard simulated clicks, narrator accessibility taps, etc. involved.