### PR TITLE
Replaced onInput with onChange event for TextInput in web

### DIFF
--- a/src/web/TextInput.tsx
+++ b/src/web/TextInput.tsx
@@ -94,7 +94,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
                     maxLength={ this.props.maxLength }
                     placeholder={ this.props.placeholder }
 
-                    onInput={ this._onInput }
+                    onChange={ this._onInputChanged }
                     onKeyDown={ this._onKeyDown }
                     onKeyUp={ this._checkSelectionChanged }
                     onFocus={ this.props.onFocus }
@@ -123,7 +123,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
                     maxLength={ this.props.maxLength }
                     placeholder={ this.props.placeholder }
 
-                    onInput={ this._onInput }
+                    onChange= { this._onInputChanged }
                     onKeyDown={ this._onKeyDown }
                     onKeyUp={ this._checkSelectionChanged }
                     onFocus={ this.props.onFocus }
@@ -193,8 +193,8 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
         this._checkSelectionChanged();
     }
 
-    private _onInput = (e: React.FormEvent<any>) => {
-        if (!e.defaultPrevented) {
+    private _onInputChanged = (event: React.ChangeEvent<HTMLElement>) => {
+        if (!event.defaultPrevented) {
             if (this._mountedComponent) {
                 // Has the input value changed?
                 const value = this._mountedComponent.value || '';


### PR DESCRIPTION
Fixing TextInput warning  when running on web:

> Failed form propType: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`."

Since ReactJS is [already](https://github.com/facebook/react/pull/4003/files) superseding onInput vs onChange it is safe to subscribe to onChange event as well.