### PR TITLE
Add Image.prefetchAndGetCachedPath

### DIFF
--- a/docs/docs/components/image.md
+++ b/docs/docs/components/image.md
@@ -61,4 +61,19 @@ getNativeHeight(): number;
 getNativeWidth(): number;
 ```
 
+## Static Methods
+```javascript
+// Prefetches a remote image and stores it in a cache. This can decrease the
+// amount of time it takes when you later want to show the image because the
+// image only has to be fetched from the local cache rather than over the
+// network.
+prefetch(url: string): Promise<boolean>;
 
+// Like `prefetch` but returns the path to the cached image on disk. Due to
+// the nature of caches, there's no guarantee how long the returned path will
+// exist. Only use this method if you're okay with that limitation.
+//
+// Windows-only. On other platforms the effect is the same as `prefetch`
+// but the return value is always `undefined`.
+prefetchAndGetCachedPath(url: string): Promise<string|undefined>;
+```

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -140,6 +140,7 @@ export interface ImageConstructor {
     new (props: Types.ImageProps): Image;
 
     prefetch(url: string): SyncTasks.Promise<boolean>;
+    prefetchAndGetCachedPath(url: string): SyncTasks.Promise<string|undefined>;
 }
 
 export abstract class Image extends React.Component<Types.ImageProps, any> {

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -46,6 +46,24 @@ export class Image extends React.Component<Types.ImageProps, {}> implements Reac
         return defer.promise();
     }
 
+    static prefetchAndGetCachedPath(url: string): SyncTasks.Promise<string|undefined> {
+        if (RN.Image.prefetchAndGetCachedPath) {
+            const defer = SyncTasks.Defer<string>();
+
+            RN.Image.prefetchAndGetCachedPath(url).then((cachedImagePath: string) => {
+                defer.resolve(cachedImagePath);
+            }).catch((error: any) => {
+                defer.reject(error);
+            });
+
+            return defer.promise();
+        } else {
+            return Image.prefetch(url).then((value) => {
+                return undefined;
+            });
+        }
+    }
+
     protected _mountedComponent: RN.ReactNativeBaseComponent<any, any>|null = null;
     private _nativeImageWidth: number|undefined;
     private _nativeImageHeight: number|undefined;

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -497,6 +497,7 @@ declare module 'react-native' {
 
     class Image extends ReactNativeBaseComponent<ImageProperties, {}> {
         static prefetch(url: string): Promise<boolean>;
+        static prefetchAndGetCachedPath(url: string): Promise<string|undefined>;
     }
     class ActivityIndicator extends ReactNativeBaseComponent<ActivityIndicatorProps, {}> { }
     class Text extends ReactNativeBaseComponent<TextProps, {}> { }

--- a/src/web/Image.tsx
+++ b/src/web/Image.tsx
@@ -154,6 +154,12 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         return defer.promise();
     }
 
+    static prefetchAndGetCachedPath(url: string): SyncTasks.Promise<string|undefined> {
+        return Image.prefetch(url).then((value) => {
+            return undefined;
+        });
+    }
+
     private _isMounted = false;
     private _nativeImageWidth: number|undefined;
     private _nativeImageHeight: number|undefined;


### PR DESCRIPTION
When prefetching an image, enables consumers to find out where on disk the image gets cached to. Useful if you need a local file path for an image rather than a URL and if you're okay with there being no guarantees around how long the local path will exist.

`RX.Image.prefetchAndGetCachedPath` is currently only interesting on Windows. On other platforms, it has the same effect as `RX.Image.prefetch`.

We've only invested in implementing this on Windows so far because, in our app, this API is needed for a Windows-specific scenario which requires calling a native API which accepts an image as a local file path but not as a URL. We can extend this API to other platforms in the future if needed.

React Native Windows added support for `prefetchAndGetCachedPath` in this commit: https://github.com/Microsoft/react-native-windows/commit/e0c0d820d5a932d9063be47537c47688ee6357e9