### PR TITLE
Making sure first additions to aria live regions also get announced in Mac

### DIFF
--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -359,7 +359,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                     style={ _styles.liveRegionContainer as any }
                     aria-live={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Polite) }
                     aria-atomic={ 'true' }
-                    aria-relevant={ 'text' }
+                    aria-relevant={ 'additions text' }
                 >
                     { announcement }
                 </div>


### PR DESCRIPTION
Issue: In Mac, whenever we recreate a rootview (like when we open a popup), the aria live div gets recreated. On Mac, the first announcement that happens after the creation is ignored. It starts announcing only after the first suggestion when text changes. 

Making sure we add aria-relvant with "additions" too so that we dont miss the first announcement. 