### PR TITLE
Make ReactNative 'unknown' state map to active

### DIFF
--- a/src/native-common/App.ts
+++ b/src/native-common/App.ts
@@ -14,12 +14,14 @@ import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
 
 const _rnStateToRxState: {[key: string]: Types.AppActivationState} = {
+    'unknown': Types.AppActivationState.Active,
     'active': Types.AppActivationState.Active,
     'background': Types.AppActivationState.Background,
     'inactive': Types.AppActivationState.Inactive,
     'extension': Types.AppActivationState.Extension,
     // uninitialized means in Background on android since last change I did
     'uninitialized': Types.AppActivationState.Background
+
 };
 
 export class App extends RX.App {
@@ -43,7 +45,7 @@ export class App extends RX.App {
     }
 
     getActivationState(): Types.AppActivationState {
-        return _rnStateToRxState[RN.AppState.currentState];
+        return _rnStateToRxState[RN.AppState.currentState] || Types.AppActivationState.Active;
     }
 
     protected getRootViewFactory(): RN.ComponentProvider {


### PR DESCRIPTION
Ensure that getActivationState can never return undefined (which would happen if another state was introduced) by using the same fallback that exists when firing the app state change event

Relates to #532