### PR TITLE
Fixed keyboard handler in RX.Link, it was defferring to base class on…

### DIFF
--- a/src/typings/react-native-windows.d.ts
+++ b/src/typings/react-native-windows.d.ts
@@ -31,6 +31,7 @@ declare module 'react-native-windows' {
         onKeyDown?: Function;
         onKeyUp?: Function;
         componentRef?: Function;
+        onAccessibilityTap?: Function;
     };
 
     interface FocusableWindows<P> extends RN.ReactNativeBaseComponent<FocusableWindowsProps<P>, {}>{

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -66,7 +66,8 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
                 handledKeyUpKeys: UP_KEYCODES,
                 onKeyDown: this._onKeyDown,
                 onKeyUp: this._onKeyUp,
-                onFocus: this._onFocus
+                onFocus: this._onFocus,
+                onAccessibilityTap: this._onPress
             };
 
             return (
@@ -103,24 +104,20 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
     }
 
     private _onKeyDown = (e: React.SyntheticEvent<any>): void => {
-        if (this.props.onPress) {
-            let keyEvent = EventHelpers.toKeyboardEvent(e);
-            let key = keyEvent.keyCode;
-            // ENTER triggers press on key down
-            if (key === KEY_CODE_ENTER) {
-                // Defer to base class
-                this._onPress(keyEvent);
-            }
+        let keyEvent = EventHelpers.toKeyboardEvent(e);
+        let key = keyEvent.keyCode;
+        // ENTER triggers press on key down
+        if (key === KEY_CODE_ENTER) {
+            // Defer to base class
+            this._onPress(keyEvent);
         }
     }
 
     private _onKeyUp = (e: React.SyntheticEvent<any>): void => {
-        if (this.props.onPress) {
-            let keyEvent = EventHelpers.toKeyboardEvent(e);
-            if (keyEvent.keyCode === KEY_CODE_SPACE) {
-                 // Defer to base class
-                this._onPress(keyEvent);
-            }
+        let keyEvent = EventHelpers.toKeyboardEvent(e);
+        if (keyEvent.keyCode === KEY_CODE_SPACE) {
+            // Defer to base class
+            this._onPress(keyEvent);
         }
     }
 

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -224,7 +224,8 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
                 onKeyDown: this._onFocusableKeyDown,
                 onKeyUp: this._onFocusableKeyUp,
                 onFocus: this._onFocus,
-                onBlur: this._onBlur
+                onBlur: this._onBlur,
+                onAccessibilityTap: this._internalProps.onPress
             };
 
             let PotentiallyAnimatedFocusableView = this._isButton(this.props) ? FocusableAnimatedView : FocusableView;


### PR DESCRIPTION
…ly when onPress was defined, and that was wrong. (#564)

Also made sure we pass onAccessibilityTap to all "focusable" controls.

(cherry picked from commit 54b8a016057ce14afb69fb917cc2d7394d176b2a)