### PR TITLE
backport: fix TextInput reference for focus control on windows

### DIFF
--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -35,9 +35,7 @@ interface Selection {
 export class TextInput extends React.Component<Types.TextInputProps, TextInputState> {
     private _selectionToSet: Selection | undefined;
     private _selection: Selection = { start: 0, end: 0 };
-    private _mountedComponent: RN.ReactNativeBaseComponent<any, any>|null = null;
-
-    protected _textInputRef: RN.TextInput|null = null;
+    protected _mountedComponent: RN.ReactNativeBaseComponent<any, any>|null = null;
 
     constructor(props: Types.TextInputProps) {
         super(props);

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -48,9 +48,9 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
     }
 
     updateNativeTabIndex(): void {
-        if (this._textInputRef) {
+        if (this._mountedComponent) {
             let tabIndex: number | undefined = this.getTabIndex();
-            this._textInputRef.setNativeProps({
+            this._mountedComponent.setNativeProps({
                 tabIndex: tabIndex,
                 value: this.state.inputValue // mandatory for some reason
             });


### PR DESCRIPTION
backport of: https://github.com/Microsoft/reactxp/pull/568