### PR TITLE
Implement hidden scroll indicators in web/ScrollView

### DIFF
--- a/samples/RXPTest/src/Tests/ScrollViewBasicTest.tsx
+++ b/samples/RXPTest/src/Tests/ScrollViewBasicTest.tsx
@@ -59,12 +59,28 @@ const _styles = {
         borderWidth: 1,
         borderColor: '#eee',
         justifyContent: 'center'
+    }),
+    button: RX.Styles.createButtonStyle({
+        backgroundColor: '#ddd',
+        borderWidth: 1,
+        margin: 16,
+        paddingHorizontal: 12,
+        paddingVertical: 6,
+        borderRadius: 8,
+        borderColor: 'black'
+    }),
+    buttonText: RX.Styles.createTextStyle({
+        fontSize: CommonStyles.buttonFontSize,
+        marginHorizontal: 12,
+        color: CommonStyles.buttonTextColor
     })
 };
 
 const _colors = ['red', 'green', 'blue'];
 
 interface ScrollViewState {
+    horizontalIndicator: boolean;
+    verticalIndicator: boolean;
 }
 
 class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
@@ -72,6 +88,8 @@ class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
         super(props);
 
         this.state = {
+            horizontalIndicator: true,
+            verticalIndicator: true
         };
     }
 
@@ -103,9 +121,32 @@ class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
                 <RX.View style={ _styles.explainTextContainer } key={ 'explanation1' }>
                     <RX.Text style={ _styles.explainText }>
                         { 'Scroll view with both vertical and horizontal scrolling. ' +
-                          'Bouncing (iOS) and over-scroll (Android) are disabled. ' }
+                          'Bouncing (iOS) and over-scroll (Android) are disabled. ' +
+                          'Press buttons to toggle scroll indicators.' }
                     </RX.Text>
                 </RX.View>
+
+                <RX.Button
+                    style={ _styles.button }
+                    onPress={ () => {
+                        this.setState({ horizontalIndicator: !this.state.horizontalIndicator })
+                    } }
+                >
+                    <RX.Text style={ _styles.buttonText }>
+                        { 'Horizontal indicator: ' + (this.state.horizontalIndicator ? 'On' : 'Off') }
+                    </RX.Text>
+                </RX.Button>
+                <RX.Button
+                    style={ _styles.button }
+                    onPress={ () => {
+                        this.setState({ verticalIndicator: !this.state.verticalIndicator })
+                    } }
+                >
+                    <RX.Text style={ _styles.buttonText }>
+                        { 'Vertical indicator: ' + (this.state.verticalIndicator ? 'On' : 'Off') }
+                    </RX.Text>
+                </RX.Button>
+
                 <RX.View style={ _styles.scrollViewContainer }>
                     <RX.ScrollView
                         style={ _styles.scrollView1 }
@@ -113,6 +154,8 @@ class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
                         horizontal={ true }
                         bounces={ false }
                         overScrollMode={ 'never' }
+                        showsHorizontalScrollIndicator={ this.state.horizontalIndicator }
+                        showsVerticalScrollIndicator={ this.state.verticalIndicator }
                     >
                         <RX.View style={ _styles.numberGrid }>
                             { numberBoxes }

--- a/samples/RXPTest/src/index.tsx
+++ b/samples/RXPTest/src/index.tsx
@@ -2,4 +2,5 @@ import RX = require('reactxp');
 import App = require('./App');
 
 RX.App.initialize(true, true);
+RX.UserInterface.useCustomScrollbars(true);
 RX.UserInterface.setMainView(<App />);

--- a/src/web/CustomScrollbar.ts
+++ b/src/web/CustomScrollbar.ts
@@ -30,6 +30,7 @@ interface IScrollbarInfo {
 export interface ScrollbarOptions {
     horizontal?: boolean;
     vertical?: boolean;
+    hiddenScrollbar?: boolean;
 }
 
 var _nativeSrollBarWidth: number = -1;
@@ -166,6 +167,7 @@ export class Scrollbar {
     private _scrollingVisible = false;
     private _hasHorizontal = false;
     private _hasVertical = true;
+    private _hasHiddenScrollbar = false;
     private _stopDragCallback = this._stopDrag.bind(this);
     private _startDragVCallback = this._startDrag.bind(this, true);
     private _startDragHCallback = this._startDrag.bind(this, false);
@@ -433,7 +435,7 @@ export class Scrollbar {
     }
 
     private _calcNewBarSize(bar: IScrollbarInfo, newSize: number, newScrollSize: number, hasBoth: boolean) {
-        if (hasBoth) {
+        if (hasBoth || this._hasHiddenScrollbar) {
             newSize -= SCROLLER_NEGATIVE_MARGIN;
             newScrollSize -= SCROLLER_NEGATIVE_MARGIN - Scrollbar.getNativeScrollbarWidth();
         }
@@ -501,12 +503,16 @@ export class Scrollbar {
 
     init(options?: ScrollbarOptions) {
         if (options) {
-            this._hasHorizontal = options.horizontal!!!;
+            this._hasHorizontal = !!options.horizontal;
 
             // Only if vertical is explicitly false as opposed to null, set it to false (default is true)
             if (options.vertical === false) {
                 this._hasVertical = options.vertical;
             }
+
+            // Our container may be scrollable even if the corresponding scrollbar is hidden (i.e. vertical
+            // or horizontal is false). We have to take it into account when calculating scroll bar sizes.
+            this._hasHiddenScrollbar = !!options.hiddenScrollbar;
         }
         Scrollbar._installStyleSheet();
         this._addScrollbars();


### PR DESCRIPTION
Sometimes it's OK to leave it up to touch and the mouse wheel to do the scrolling
instead of cluttering the UI with scrollbars.

This commit makes the web ScrollView support the showsHorizontalScrollIndicator
and showsVerticalScrollIndicator props.