### PR TITLE
Bump RXPTest reactxp dependency

### DIFF
--- a/samples/RXPTest/package.json
+++ b/samples/RXPTest/package.json
@@ -28,6 +28,6 @@
     "react-dom": "16.2.0",
     "react-native": "^0.53.3",
     "react-native-windows": "^0.51.0-rc.1",
-    "reactxp": "^1.0.0"
+    "reactxp": "^1.1.0-rc.2"
   }
 }


### PR DESCRIPTION
Fix

```
ERROR in [at-loader] ./src/Tests/PopupTest.tsx:291:13 
    TS2345: Argument of type '{ dismissIfShown: true; cacheable: boolean; getAnchor: () => Button; getElementTriggeringPopup: (...' is not assignable to parameter of type 'PopupOptions'.
  Object literal may only specify known properties, and 'cacheable' does not exist in type 'PopupOptions'.
```