### PR TITLE
Updated RN for Windows projects dependencies.

### DIFF
--- a/extensions/navigation/package.json
+++ b/extensions/navigation/package.json
@@ -28,7 +28,7 @@
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-native": "^0.51.0",
-    "react-native-windows": "^0.51.0-rc.1"
+    "react-native-windows": "^0.51.0"
   },
   "devDependencies": {
     "typescript": "2.7.2",

--- a/extensions/video/package.json
+++ b/extensions/video/package.json
@@ -17,7 +17,7 @@
   "peerDependencies": {
     "react-dom": "16.2.0",
     "react-native": "^0.51.0",
-    "react-native-windows": "^0.51.0-rc.1"
+    "react-native-windows": "^0.51.0"
   },
   "devDependencies": {
     "typescript": "2.7.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-native": "^0.53.3",
-    "react-native-windows": "^0.51.0-rc.1"
+    "react-native-windows": "^0.53.0"
   },
   "devDependencies": {
     "typescript": "2.7.2",

--- a/samples/ImageList/package.json
+++ b/samples/ImageList/package.json
@@ -23,7 +23,7 @@
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-native": "^0.53.0",
-    "react-native-windows": "^0.51.0-rc.1",
+    "react-native-windows": "^0.53.0",
     "reactxp": "^1.0.0",
     "reactxp-imagesvg": "^0.2.9",
     "reactxp-navigation": "^1.0.16",

--- a/samples/RXPTest/package.json
+++ b/samples/RXPTest/package.json
@@ -27,7 +27,7 @@
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-native": "^0.53.3",
-    "react-native-windows": "^0.51.0-rc.1",
+    "react-native-windows": "^0.53.0",
     "reactxp": "^1.0.0"
   }
 }

--- a/samples/TodoList/package.json
+++ b/samples/TodoList/package.json
@@ -25,7 +25,7 @@
     "react-dom": "16.2.0",
     "react-native": "^0.51.0",
     "react-native-sqlite-storage": "^3.3.1",
-    "react-native-windows": "^0.51.0-rc.1",
+    "react-native-windows": "^0.53.0",
     "reactxp": "^1.0.0",
     "reactxp-imagesvg": "^0.2.8",
     "reactxp-navigation": "^1.0.15",

--- a/samples/hello-world-js/package.json
+++ b/samples/hello-world-js/package.json
@@ -19,7 +19,7 @@
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-native": "^0.53.0",
-    "react-native-windows": "^0.51.0-rc.1",
+    "react-native-windows": "^0.53.0",
     "reactxp": "^1.0.0",
     "reactxp-imagesvg": "^0.2.9",
     "reactxp-navigation": "^1.0.16",

--- a/samples/hello-world/package.json
+++ b/samples/hello-world/package.json
@@ -23,7 +23,7 @@
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-native": "^0.53.0",
-    "react-native-windows": "^0.51.0-rc.1",
+    "react-native-windows": "^0.53.0",
     "reactxp": "^1.0.0",
     "reactxp-imagesvg": "^0.2.9",
     "reactxp-navigation": "^1.0.16",


### PR DESCRIPTION
Moved to 0.53, consistent with RN (0.53) and React (16.2.0)
I kept 0.51 for the 2 extensions due to the associated RN peer dependencies. Not sure whether those were left to 0.51 on purpose.