### PR TITLE
Ignore tabIndex=-1 in focusFirst().

### DIFF
--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -114,7 +114,7 @@ export class FocusManager extends FocusManagerBase {
                 storedComponent.limitedCount === 0 &&
                 storedComponent.limitedCountAccessible === 0)
             .map(storedComponent => ReactDOM.findDOMNode(storedComponent.component) as HTMLElement)
-            .filter(el => el && el.focus);
+            .filter(el => el && el.focus && (el.tabIndex !== -1));
 
         if (focusable.length) {
             focusable.sort((a, b) => {

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -114,7 +114,7 @@ export class FocusManager extends FocusManagerBase {
                 storedComponent.limitedCount === 0 &&
                 storedComponent.limitedCountAccessible === 0)
             .map(storedComponent => ReactDOM.findDOMNode(storedComponent.component) as HTMLElement)
-            .filter(el => el && el.focus && (el.tabIndex !== -1));
+            .filter(el => el && el.focus && ((el.tabIndex || 0) >= 0));
 
         if (focusable.length) {
             focusable.sort((a, b) => {


### PR DESCRIPTION
Elements with tabIndex=-1 should not be focused during the keyboard navigation using Tab and focusFirst() is used in the Tab navigation.