### PR TITLE
Ramyasen/reactxp disabledopacity override

### DIFF
--- a/docs/docs/components/button.md
+++ b/docs/docs/components/button.md
@@ -34,6 +34,9 @@ delayLongPress: number = 1000;
 // If disabled, touch and mouse input events are ignored
 disabled: boolean = false;
 
+// By default, opacity of a disabled element is 0.5. This value be overriden with this property
+disabledOpacity: number = undefined;
+
 // Called when VoiceOver is on and the user double tapped to
 // activate a control
 onAccessibilityTapIOS: (e: SyntheticEvent) => void; // iOS Only

--- a/docs/docs/components/button.md
+++ b/docs/docs/components/button.md
@@ -34,7 +34,7 @@ delayLongPress: number = 1000;
 // If disabled, touch and mouse input events are ignored
 disabled: boolean = false;
 
-// By default, opacity of a disabled element is 0.5. This value be overriden with this property
+// By default, opacity of a disabled element is 0.5. This value can be overriden with this property
 disabledOpacity: number = undefined;
 
 // Called when VoiceOver is on and the user double tapped to

--- a/samples/RXPTest/src/Tests/ButtonTest.tsx
+++ b/samples/RXPTest/src/Tests/ButtonTest.tsx
@@ -116,12 +116,33 @@ class ButtonView extends RX.Component<RX.CommonProps, ButtonViewState> {
                 <RX.View style={ _styles.explainTextContainer } key={ 'explanation2' }>
                     <RX.Text style={ _styles.explainText }>
                         { 'This button should be disabled and respond to no clicks, presses, or hovers. ' + 
-                          'The mouse pointer should not turn into a pointer.' }
+                          'The mouse pointer should not turn into a pointer.' + 
+                          'The opacity of the disabled button should be its default value of 0.5' }
                     </RX.Text>
                 </RX.View>
                 <RX.Button
                     style={ _styles.button2 }
                     disabled={ true }
+                    onPress={ () => {
+                        // no-op
+                    } }
+                >
+                    <RX.Text style={ _styles.button2Text }>
+                        { 'Disabled Button' }
+                    </RX.Text>
+                </RX.Button>
+
+                <RX.View style={ _styles.explainTextContainer } key={ 'explanation2' }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'This button should be disabled and respond to no clicks, presses, or hovers. ' + 
+                          'The mouse pointer should not turn into a pointer.' + 
+                          'The opacity of the disabled button should be 0.3' }
+                    </RX.Text>
+                </RX.View>
+                <RX.Button
+                    style={ _styles.button2 }
+                    disabled={ true }
+                    disabledOpacity={ 0.3 }
                     onPress={ () => {
                         // no-op
                     } }

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -457,6 +457,7 @@ export interface CommonStyledProps<T> extends CommonProps {
 export interface ButtonProps extends CommonStyledProps<ButtonStyleRuleSet>, CommonAccessibilityProps {
     title?: string;
     disabled?: boolean;
+    disabledOpacity?: number;
     delayLongPress?: number;
 
     onAccessibilityTapIOS?: Function; // iOS-only prop, call when a button is double tapped in accessibility mode

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -130,7 +130,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         const opacityStyle = !this.props.disableTouchOpacityAnimation && this._opacityAnimatedStyle;
         let disabledStyle = this.props.disabled && _styles.disabled;
 
-        if (this.props.disabled && this.props.disabledOpacity) {
+        if (this.props.disabled && this.props.disabledOpacity !== undefined) {
             disabledStyle = Styles.createButtonStyle({
                 opacity: this.props.disabledOpacity
             }, false);

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -128,11 +128,18 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
             _defaultAccessibilityTrait);
 
         const opacityStyle = !this.props.disableTouchOpacityAnimation && this._opacityAnimatedStyle;
+        let disabledStyle = this.props.disabled && _styles.disabled;
+
+        if (this.props.disabled && this.props.disabledOpacity) {
+            disabledStyle = Styles.createButtonStyle({
+                opacity: this.props.disabledOpacity
+            }, false);
+        }
 
         let internalProps: RN.ViewProps = {
             ref: this._onButtonRef,
             style: Styles.combine([_styles.defaultButton, this.props.style, opacityStyle,
-                this.props.disabled && _styles.disabled]),
+                disabledStyle]),
             accessibilityLabel: this.props.accessibilityLabel || this.props.title,
             accessibilityTraits: accessibilityTrait,
             accessibilityComponentType: accessibilityComponentType,

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -33,9 +33,6 @@ const _styles = {
         borderColor: 'transparent',
         textAlign: 'left',
         borderWidth: '0'
-    },
-    disabled: {
-        opacity: 0.5
     }
 };
 
@@ -157,7 +154,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         }
 
         if (this.props.disabled) {
-            buttonStyleMutations.opacity = 0.5;
+            buttonStyleMutations.opacity = this.props.disabledOpacity || 0.5;
         }
 
         // Default to 'pointer' cursor for enabled buttons unless otherwise specified.

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -154,7 +154,7 @@ export class Button extends React.Component<Types.ButtonProps, {}> {
         }
 
         if (this.props.disabled) {
-            buttonStyleMutations.opacity = this.props.disabledOpacity || 0.5;
+            buttonStyleMutations.opacity = this.props.disabledOpacity !== undefined ? this.props.disabledOpacity : 0.5;
         }
 
         // Default to 'pointer' cursor for enabled buttons unless otherwise specified.


### PR DESCRIPTION
Currently there is no way to override the disabled opacity value of a button. There are requirements where this is needed. 
In code using react xp, we can have a workaround. We can override opacity and in the on press handler - we simply return. 

This is a cleaner way of doing it. 