### PR TITLE
Fix popup API reentrancy issues

### DIFF
--- a/docs/docs/apis/popup.md
+++ b/docs/docs/apis/popup.md
@@ -47,7 +47,8 @@ interface PopupOptions {
     // with button and chevron icon.
     getElementTriggeringPopup?: () => React.Component<any, any>;
 
-    // Called when the popup is dismissed.
+    // Called when the popup is dismissed. Popup.isDisplayed() will return
+    // false for the popup being dismissed when this callback runs.
     onDismiss?: () => void;
 
     // Prioritized order of positions. Popup is positioned

--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -102,10 +102,6 @@ export class FrontLayerViewManager {
         const index = this._findIndexOfPopup(popupId);
         if (index >= 0) {
             const popupContext = this._overlayStack[index] as PopupStackContext;
-            if (popupContext.popupOptions.onDismiss) {
-                popupContext.popupOptions.onDismiss();
-            }
-
             if (popupContext.popupOptions.cacheable) {
                 // The popup is transitioning from active to cached.
                 this._cachedPopups.push(popupContext);
@@ -113,6 +109,11 @@ export class FrontLayerViewManager {
             }
 
             this._overlayStack.splice(index, 1);
+
+            if (popupContext.popupOptions.onDismiss) {
+                popupContext.popupOptions.onDismiss();
+            }
+
             this.event_changed.fire();
         }
     }


### PR DESCRIPTION
The onDismiss() callback may attempt to invoke popup API; a common case is
calling Popup.dismiss() on the very same popup from within the callback.
This used to work before #534 as long as the callback implemented its own
reentrancy check. After #534 we crash in FrontLayerViewManager.dismissPopup
accessing the cacheable field on the already-nulled-out _activePopupOptions.

Fixed in this commit by always calling onDismiss() last, after the state has
been mutated.