### PR TITLE
Making clipboard copy text to handle line breaks

### DIFF
--- a/src/web/Clipboard.ts
+++ b/src/web/Clipboard.ts
@@ -13,8 +13,8 @@ import SyncTasks = require('synctasks');
 export class Clipboard extends RX.Clipboard {
     public setText(text: string) {
         let node = Clipboard._createInvisibleNode();
-        // Replace carraige return /r with /r/n, so that pasting outside browser environment
-        // (eg in a native app) preserves this new line format
+        // Replace carriage return /r with /r/n, so that pasting outside browser environment
+        // (eg in a native app) preserves this new line
         text = text.replace(/(?:\\[r])+/g, '\r\n');
         node.innerHTML = text;
         document.body.appendChild(node);

--- a/src/web/Clipboard.ts
+++ b/src/web/Clipboard.ts
@@ -15,7 +15,7 @@ export class Clipboard extends RX.Clipboard {
         let node = Clipboard._createInvisibleNode();
         // Replace carriage return /r with /r/n, so that pasting outside browser environment
         // (eg in a native app) preserves this new line
-        text = text.replace(/(?:\\[r])+/g, '\r\n');
+        text = text.replace(/\r/g, '\r\n');
         node.innerHTML = text;
         document.body.appendChild(node);
         Clipboard._copyNode(node);


### PR DESCRIPTION
Currently when copying text from reactxp method for web - if text contains new lines (\r) and we paste it outside of a web environment - the new lines are not preserved and each newlins gets replaced by a space instead.

Fix: Replacing span element with a text area and using \r\n instead of only \r -> fixes the issue. The solution has been inspired by other sources online. 

The copy implementation works fine on mobile environments.   