### PR TITLE
[Windows] fix textInput focusability after focus restriction

### DIFF
--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -44,7 +44,7 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
 
     getTabIndex(): number | undefined {
         // Focus Manager may override this
-        return this.props.tabIndex;
+        return this.props.tabIndex || 0;
     }
 
     updateNativeTabIndex(): void {
@@ -52,7 +52,8 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
             let tabIndex: number | undefined = this.getTabIndex();
             this._mountedComponent.setNativeProps({
                 tabIndex: tabIndex,
-                value: this.state.inputValue // mandatory for some reason
+                value: this.state.inputValue, // mandatory for some reason
+                isTabStop: this.props.editable && tabIndex >= 0
             });
         }
     }


### PR DESCRIPTION
Intent of this change is to fix existing integration with FocusManager focus restriction logic. 

What can (and does) happen is following:
1. We apply focus restriction on TextInput applying mixin to getTabIndex which returns -1 and call updateNativeTabIndex
2. Something triggers render on the component
3. We set value (-1) from getTabIndex to tabIndex prop of RN.TextInput, this can also change isTabStop prop inside RNW
4. Focus restriction ends, removes mixin and calls updateNativeTabIndex
5. We call setNativeProps with original tabIndex value (if it was undefined nothing changes) leaving component with tabIndex = -1 and isTabStop = false which means non focusable

Currently this invalid state is fixed only when the component renders again (and recalculates isTabStop prop there based on restored getTabIndex mixin)

Also it would be better to move coupling logic between tabIndex and isTabStop inside RNW native code (if possible) so it would be transparent for both nativeProps update and generic props update.