### PR TITLE
[Windows] Add onContextMenu callback to GestureView

### DIFF
--- a/docs/docs/components/gestureview.md
+++ b/docs/docs/components/gestureview.md
@@ -27,6 +27,7 @@ onPanVertical: (gestureState: PanGestureState) => void = undefined;
 onPanHorizontal: (gestureState: PanGestureState) => void = undefined;
 onTap: (gestureState: TapGestureState) => void = undefined;
 onDoubleTap: (gestureState: TapGestureState) => void = undefined;
+onContextMenu: (gestureState: TapGestureState) => void = undefined;
 
 // We can set vertical or horizontal as preferred
 preferredPan: PreferredPanGesture = undefined; // Horizontal or vertical

--- a/samples/RXPTest/src/Tests/GestureViewTest.tsx
+++ b/samples/RXPTest/src/Tests/GestureViewTest.tsx
@@ -1,5 +1,5 @@
 /*
-* Tests the functionality of a GestureView component 
+* Tests the functionality of a GestureView component
 * through user interaction.
 */
 
@@ -38,10 +38,12 @@ const _styles = {
 };
 
 const _colors = ['red', 'green', 'blue'];
+const _shades = ['#000', '#333', '#666', '#999', '#CCC', '#FFF'];
 
 interface GestureViewState {
     test1ColorIndex?: number;
     test2ColorIndex?: number;
+    test4ColorIndex?: number;
 }
 
 class GestureViewView extends RX.Component<RX.CommonProps, GestureViewState> {
@@ -51,7 +53,7 @@ class GestureViewView extends RX.Component<RX.CommonProps, GestureViewState> {
     private _test1AnimatedStyle = RX.Styles.createAnimatedViewStyle({
         transform: [{
             scale: this._test1ScaleValue
-        }, { 
+        }, {
             rotate: this._test1RotateValue.interpolate({
                 inputRange: [0, 360],
                 outputRange: ['0deg', '360deg']
@@ -79,12 +81,23 @@ class GestureViewView extends RX.Component<RX.CommonProps, GestureViewState> {
         }]
     });
 
+    private _test4HorizontalOffset = new RX.Animated.Value(0);
+    private _test4VerticalOffset = new RX.Animated.Value(0);
+    private _test4AnimatedStyle = RX.Styles.createAnimatedViewStyle({
+        transform: [{
+            translateX: this._test4HorizontalOffset
+        }, {
+            translateY: this._test4VerticalOffset
+        }]
+    });
+
     constructor(props: RX.CommonProps) {
         super(props);
 
         this.state = {
             test1ColorIndex: 0,
-            test2ColorIndex: 1
+            test2ColorIndex: 1,
+            test4ColorIndex: 2
         };
     }
 
@@ -96,6 +109,10 @@ class GestureViewView extends RX.Component<RX.CommonProps, GestureViewState> {
 
         let test2ColorStyle = RX.Styles.createViewStyle({
             backgroundColor: _colors[this.state.test2ColorIndex]
+        }, false);
+
+        let test4ColorStyle = RX.Styles.createViewStyle({
+            backgroundColor: _shades[this.state.test4ColorIndex]
         }, false);
 
         return (
@@ -152,6 +169,23 @@ class GestureViewView extends RX.Component<RX.CommonProps, GestureViewState> {
                 >
                     <RX.Animated.View
                         style={ [_styles.smallBox, this._test3AnimatedStyle] }
+                    />
+                </RX.GestureView>
+
+                <RX.View style={ _styles.explainTextContainer } key={ 'explanation4' }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'Desktop platforms: Left click will make the box lighter. ' +
+                          'Right click (context menu) will make the box darker.' }
+                    </RX.Text>
+                </RX.View>
+                <RX.GestureView
+                    style={ _styles.gestureView }
+                    onTap={ state => this._onTapTest4(state) }
+                    onContextMenuGesture={ e => this._onContextMenu4(e) }
+                    mouseOverCursor={ RX.Types.GestureMouseCursor.Pointer }
+                >
+                    <RX.Animated.View
+                        style={ [_styles.smallBox, test4ColorStyle, this._test4AnimatedStyle] }
                     />
                 </RX.GestureView>
             </RX.View>
@@ -222,6 +256,19 @@ class GestureViewView extends RX.Component<RX.CommonProps, GestureViewState> {
             this._test3VerticalOffset.setValue(state.pageY - state.initialPageY);
         }
     }
+
+    private _onTapTest4(gestureState: RX.Types.TapGestureState) {
+        // Change the color.
+        this.setState({
+            test4ColorIndex: (this.state.test4ColorIndex + 1) % _shades.length
+        });
+    }
+
+    private _onContextMenu4(gestureState: RX.Types.TapGestureState) {
+        this.setState({
+            test4ColorIndex: (this.state.test4ColorIndex - 1) % _shades.length
+        });
+    }
 }
 
 class GestureViewTest implements Test {
@@ -230,7 +277,7 @@ class GestureViewTest implements Test {
     getPath(): string {
         return 'Components/GestureView';
     }
-    
+
     getTestType(): TestType {
         return TestType.Interactive;
     }

--- a/samples/RXPTest/src/Tests/GestureViewTest.tsx
+++ b/samples/RXPTest/src/Tests/GestureViewTest.tsx
@@ -181,7 +181,7 @@ class GestureViewView extends RX.Component<RX.CommonProps, GestureViewState> {
                 <RX.GestureView
                     style={ _styles.gestureView }
                     onTap={ state => this._onTapTest4(state) }
-                    onContextMenuGesture={ e => this._onContextMenu4(e) }
+                    onContextMenu={ e => this._onContextMenu4(e) }
                     mouseOverCursor={ RX.Types.GestureMouseCursor.Pointer }
                 >
                     <RX.Animated.View
@@ -260,13 +260,13 @@ class GestureViewView extends RX.Component<RX.CommonProps, GestureViewState> {
     private _onTapTest4(gestureState: RX.Types.TapGestureState) {
         // Change the color.
         this.setState({
-            test4ColorIndex: (this.state.test4ColorIndex + 1) % _shades.length
+            test4ColorIndex: Math.min(this.state.test4ColorIndex + 1, _shades.length - 1)
         });
     }
 
     private _onContextMenu4(gestureState: RX.Types.TapGestureState) {
         this.setState({
-            test4ColorIndex: (this.state.test4ColorIndex - 1) % _shades.length
+            test4ColorIndex: Math.max(this.state.test4ColorIndex - 1, 0)
         });
     }
 }

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -703,7 +703,7 @@ export interface TapGestureState extends GestureState {
     clientY: number;
     pageX: number;
     pageY: number;
-    isRightButton?: boolean; // UWP only, for desktop context menu
+    button: MouseButton;
 }
 
 export enum GestureMouseCursor {
@@ -1149,9 +1149,15 @@ export interface ClipboardEvent extends SyntheticEvent {
 
 export type FocusEvent = SyntheticEvent;
 
+export enum MouseButton {
+    Primary,
+    Auxiliary,
+    Secondary
+}
+
 export interface MouseEvent extends SyntheticEvent {
     altKey: boolean;
-    button: number;
+    button: MouseButton;
     clientX: number;
     clientY: number;
     ctrlKey: boolean;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1149,15 +1149,9 @@ export interface ClipboardEvent extends SyntheticEvent {
 
 export type FocusEvent = SyntheticEvent;
 
-export enum MouseButton {
-    Primary,
-    Auxiliary,
-    Secondary
-}
-
 export interface MouseEvent extends SyntheticEvent {
     altKey: boolean;
-    button: MouseButton;
+    button: number;
     clientX: number;
     clientY: number;
     ctrlKey: boolean;
@@ -1204,9 +1198,6 @@ export interface TouchEvent extends SyntheticEvent {
     pageX?: number;
     pageY?: number;
     touches: TouchList;
-    button?: number; // Mac, web native events
-    isRightButton?: boolean; // UWP only
-    isMiddleButton?: boolean;
 }
 
 export interface WheelEvent extends SyntheticEvent {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -703,7 +703,6 @@ export interface TapGestureState extends GestureState {
     clientY: number;
     pageX: number;
     pageY: number;
-    button: MouseButton;
 }
 
 export enum GestureMouseCursor {
@@ -733,6 +732,7 @@ export interface GestureViewProps extends CommonStyledProps<ViewStyleRuleSet>, C
     onPanHorizontal?: (gestureState: PanGestureState) => void;
     onTap?: (gestureState: TapGestureState) => void;
     onDoubleTap?: (gestureState: TapGestureState) => void;
+    onContextMenuGesture?: (gestureState: TapGestureState) => void;
 
     // We can set vertical or horizontal as preferred
     preferredPan?: PreferredPanGesture;
@@ -1205,6 +1205,7 @@ export interface TouchEvent extends SyntheticEvent {
     pageY?: number;
     touches: TouchList;
     isRightButton?: boolean; // UWP only
+    isMiddleButton?: boolean;
 }
 
 export interface WheelEvent extends SyntheticEvent {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -703,6 +703,7 @@ export interface TapGestureState extends GestureState {
     clientY: number;
     pageX: number;
     pageY: number;
+    isRightButton?: boolean; // UWP only, for desktop context menu
 }
 
 export enum GestureMouseCursor {
@@ -1197,6 +1198,7 @@ export interface TouchEvent extends SyntheticEvent {
     pageX?: number;
     pageY?: number;
     touches: TouchList;
+    isRightButton?: boolean; // UWP only
 }
 
 export interface WheelEvent extends SyntheticEvent {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1204,6 +1204,7 @@ export interface TouchEvent extends SyntheticEvent {
     pageX?: number;
     pageY?: number;
     touches: TouchList;
+    button?: number; // Mac, web native events
     isRightButton?: boolean; // UWP only
     isMiddleButton?: boolean;
 }

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -732,7 +732,7 @@ export interface GestureViewProps extends CommonStyledProps<ViewStyleRuleSet>, C
     onPanHorizontal?: (gestureState: PanGestureState) => void;
     onTap?: (gestureState: TapGestureState) => void;
     onDoubleTap?: (gestureState: TapGestureState) => void;
-    onContextMenuGesture?: (gestureState: TapGestureState) => void;
+    onContextMenu?: (gestureState: TapGestureState) => void;
 
     // We can set vertical or horizontal as preferred
     preferredPan?: PreferredPanGesture;

--- a/src/native-common/GestureView.tsx
+++ b/src/native-common/GestureView.tsx
@@ -500,7 +500,7 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
         return panEvent;
     }
 
-    private _sendTapEvent(e: Types.TouchEvent) {
+    protected _sendTapEvent(e: Types.TouchEvent) {
         if (this.props.onTap) {
             const tapEvent: Types.TapGestureState = {
                 pageX: e.pageX!!!,

--- a/src/native-common/GestureView.tsx
+++ b/src/native-common/GestureView.tsx
@@ -64,7 +64,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
 
                 this._lastGestureStartEvent = event;
                 // If we're trying to detect a tap, set this as the responder immediately.
-                if (this.props.onTap || this.props.onDoubleTap || this.props.onContextMenuGesture) {
+                if (this.props.onTap || this.props.onDoubleTap || this.props.onContextMenu) {
                     return true;
                 }
                 return false;
@@ -505,7 +505,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         const button = EventHelpers.toMouseButton(e);
         if (button === 2) {
             // Always handle secondary button, even if context menu is not set - it shouldn't trigger onTap.
-            if (this.props.onContextMenuGesture) {
+            if (this.props.onContextMenu) {
                 const tapEvent: Types.TapGestureState = {
                     pageX: e.pageX!!!,
                     pageY: e.pageY!!!,
@@ -514,7 +514,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
                     timeStamp: e.timeStamp
                 };
 
-                this.props.onContextMenuGesture(tapEvent);
+                this.props.onContextMenu(tapEvent);
             }
         } else if (this.props.onTap) {
             const tapEvent: Types.TapGestureState = {

--- a/src/native-common/GestureView.tsx
+++ b/src/native-common/GestureView.tsx
@@ -503,8 +503,8 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
 
     private _sendTapEvent(e: Types.TouchEvent) {
         const button = EventHelpers.toMouseButton(e);
-        if (button === Types.MouseButton.Secondary) {
-            // always handle secondary button, even if context menu is not set - it shouldn't trigger onTap
+        if (button === 2) {
+            // Always handle secondary button, even if context menu is not set - it shouldn't trigger onTap.
             if (this.props.onContextMenuGesture) {
                 const tapEvent: Types.TapGestureState = {
                     pageX: e.pageX!!!,
@@ -530,11 +530,11 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
     }
 
     private _sendDoubleTapEvent(e: Types.TouchEvent) {
-        // if user did a double click with different mouse buttons, eg. left (50ms) right
-        // both clicks need to be registered as separate events
+        // If user did a double click with different mouse buttons, eg. left (50ms) right
+        // both clicks need to be registered as separate events.
         const lastButton = EventHelpers.toMouseButton(this._lastTapEvent!!!);
         const button = EventHelpers.toMouseButton(e);
-        if (lastButton !== button || button === Types.MouseButton.Secondary) {
+        if (lastButton !== button || button === 2) {
             this._sendTapEvent(this._lastTapEvent!!!);
             this._sendTapEvent(e);
             return;

--- a/src/native-common/GestureView.tsx
+++ b/src/native-common/GestureView.tsx
@@ -15,6 +15,7 @@ import React = require('react');
 import RN = require('react-native');
 
 import AccessibilityUtil from './AccessibilityUtil';
+import EventHelpers from './utils/EventHelpers';
 
 import Types = require('../common/Types');
 import UserInterface from './UserInterface';
@@ -500,14 +501,15 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
         return panEvent;
     }
 
-    protected _sendTapEvent(e: Types.TouchEvent) {
+    private _sendTapEvent(e: Types.TouchEvent) {
         if (this.props.onTap) {
             const tapEvent: Types.TapGestureState = {
                 pageX: e.pageX!!!,
                 pageY: e.pageY!!!,
                 clientX: e.locationX!!!,
                 clientY: e.locationY!!!,
-                timeStamp: e.timeStamp
+                timeStamp: e.timeStamp,
+                button: EventHelpers.toMouseButton(e)
             };
 
             this.props.onTap(tapEvent);
@@ -521,7 +523,8 @@ export abstract class GestureView extends ViewBase<Types.GestureViewProps, {}> {
                 pageY: e.pageY!!!,
                 clientX: e.locationX!!!,
                 clientY: e.locationY!!!,
-                timeStamp: e.timeStamp
+                timeStamp: e.timeStamp,
+                button: EventHelpers.toMouseButton(e)
             };
 
             this.props.onDoubleTap(tapEvent);

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -140,7 +140,7 @@ export class EventHelpers {
         // reuses events, so we're not allowed to modify the original.
         // Instead, we'll clone it.
         let mouseEvent = _.clone(e as Types.MouseEvent);
-        
+
         const nativeEvent = e.nativeEvent;
 
         // We keep pageX/Y and clientX/Y coordinates in sync, similar to the React web behavior
@@ -153,13 +153,7 @@ export class EventHelpers {
             mouseEvent.clientY = mouseEvent.pageY = nativeEvent.pageY;
         }
 
-        if (!!nativeEvent.IsRightButton) {
-            mouseEvent.button = 2;
-        } else if (!!nativeEvent.IsMiddleButton) {
-            mouseEvent.button = 1;
-        } else {
-            mouseEvent.button = 0;
-        }
+        mouseEvent.button = this.toMouseButton(e);
 
         if (nativeEvent.shiftKey) {
             mouseEvent.shiftKey = nativeEvent.shiftKey;
@@ -189,8 +183,22 @@ export class EventHelpers {
         return mouseEvent;
     }
 
+    toMouseButton(e: Types.SyntheticEvent): number {
+        if (this.isRightMouseButton(e)) {
+            return Types.MouseButton.Secondary;
+        } else if (this.isMiddleMouseButton(e)) {
+            return Types.MouseButton.Auxiliary;
+        }
+
+        return Types.MouseButton.Primary;
+    }
+
     isRightMouseButton(e: Types.SyntheticEvent): boolean {
-        return !!e.nativeEvent.isRightButton;
+        return !!e.nativeEvent.isRightButton || !!e.nativeEvent.IsRightButton;
+    }
+
+    isMiddleMouseButton(e: Types.SyntheticEvent): boolean {
+        return !!e.nativeEvent.isMiddleButton || !!e.nativeEvent.IsMiddleButton;
     }
 }
 

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -184,15 +184,16 @@ export class EventHelpers {
     }
 
     toMouseButton(e: Types.TouchEvent): number {
-        if (e.button !== undefined) {
-            return e.button;
-        } else if (e.isRightButton) {
-            return Types.MouseButton.Secondary;
-        } else if (e.isMiddleButton) {
-            return Types.MouseButton.Auxiliary;
+        const nativeEvent = e as any;
+        if (nativeEvent.button !== undefined) {
+            return nativeEvent.button;
+        } else if (nativeEvent.isRightButton) {
+            return 2;
+        } else if (nativeEvent.isMiddleButton) {
+            return 1;
         }
 
-        return Types.MouseButton.Primary;
+        return 0;
     }
 
     isRightMouseButton(e: Types.SyntheticEvent): boolean {

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -153,7 +153,7 @@ export class EventHelpers {
             mouseEvent.clientY = mouseEvent.pageY = nativeEvent.pageY;
         }
 
-        mouseEvent.button = this.toMouseButton(e);
+        mouseEvent.button = this.toMouseButton(e.nativeEvent as Types.TouchEvent);
 
         if (nativeEvent.shiftKey) {
             mouseEvent.shiftKey = nativeEvent.shiftKey;
@@ -183,10 +183,10 @@ export class EventHelpers {
         return mouseEvent;
     }
 
-    toMouseButton(e: Types.SyntheticEvent): number {
-        if (this.isRightMouseButton(e)) {
+    toMouseButton(e: Types.TouchEvent): number {
+        if (e.isRightButton) {
             return Types.MouseButton.Secondary;
-        } else if (this.isMiddleMouseButton(e)) {
+        } else if (e.isMiddleButton) {
             return Types.MouseButton.Auxiliary;
         }
 
@@ -194,11 +194,7 @@ export class EventHelpers {
     }
 
     isRightMouseButton(e: Types.SyntheticEvent): boolean {
-        return !!e.nativeEvent.isRightButton || !!e.nativeEvent.IsRightButton;
-    }
-
-    isMiddleMouseButton(e: Types.SyntheticEvent): boolean {
-        return !!e.nativeEvent.isMiddleButton || !!e.nativeEvent.IsMiddleButton;
+        return !!e.nativeEvent.isRightButton;
     }
 }
 

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -184,7 +184,9 @@ export class EventHelpers {
     }
 
     toMouseButton(e: Types.TouchEvent): number {
-        if (e.isRightButton) {
+        if (e.button !== undefined) {
+            return e.button;
+        } else if (e.isRightButton) {
             return Types.MouseButton.Secondary;
         } else if (e.isMiddleButton) {
             return Types.MouseButton.Auxiliary;

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -98,7 +98,7 @@ export class EventHelpers {
                     case 'ArrowDown':
                         keyCode = 20;
                         break;
-                    
+
                     case 'Number0':
                         keyCode = 48;
                         break;
@@ -237,9 +237,9 @@ export class EventHelpers {
         const nativeEvent = e as any;
         if (nativeEvent.button !== undefined) {
             return nativeEvent.button;
-        } else if (nativeEvent.isRightButton) {
+        } else if (nativeEvent.isRightButton || nativeEvent.IsRightButton) {
             return 2;
-        } else if (nativeEvent.isMiddleButton) {
+        } else if (nativeEvent.isMiddleButton || nativeEvent.IsMiddleButton) {
             return 1;
         }
 

--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -346,7 +346,8 @@ export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
                     pageY: e.pageY,
                     clientX: e.clientX - clientRect.left,
                     clientY: e.clientY - clientRect.top,
-                    timeStamp: e.timeStamp
+                    timeStamp: e.timeStamp,
+                    button: e.button
                 };
 
                 this.props.onTap(tapEvent);
@@ -364,7 +365,8 @@ export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
                     pageY: e.pageY,
                     clientX: e.clientX - clientRect.left,
                     clientY: e.clientY - clientRect.top,
-                    timeStamp: e.timeStamp
+                    timeStamp: e.timeStamp,
+                    button: e.button
                 };
 
                 this.props.onDoubleTap(tapEvent);

--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -78,6 +78,7 @@ export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
                 role={ ariaRole }
                 aria-label={ this.props.accessibilityLabel }
                 aria-hidden={ isAriaHidden }
+                onContextMenu={ this.props.onContextMenuGesture ? this._sendContextMenuEvent : undefined }
             >
                 { this.props.children }
             </div>
@@ -180,6 +181,25 @@ export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
             // timer so we can determine whether the current tap is a single or double.
             this._reportDelayedTap();
             this._startDoubleTapTimer(e);
+        }
+    }
+
+    private _sendContextMenuEvent = (e: React.MouseEvent<any>) => {
+        if (this.props.onContextMenuGesture) {
+            const clientRect = this._getGestureViewClientRect();
+
+            if (clientRect) {
+                const tapEvent: Types.TapGestureState = {
+                    pageX: e.pageX,
+                    pageY: e.pageY,
+                    clientX: e.clientX - clientRect.left,
+                    clientY: e.clientY - clientRect.top,
+                    timeStamp: e.timeStamp
+                };
+
+                this.props.onContextMenuGesture(tapEvent);
+                e.preventDefault();
+            }
         }
     }
 
@@ -346,8 +366,7 @@ export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
                     pageY: e.pageY,
                     clientX: e.clientX - clientRect.left,
                     clientY: e.clientY - clientRect.top,
-                    timeStamp: e.timeStamp,
-                    button: e.button
+                    timeStamp: e.timeStamp
                 };
 
                 this.props.onTap(tapEvent);
@@ -365,8 +384,7 @@ export class GestureView extends RX.ViewBase<Types.GestureViewProps, {}> {
                     pageY: e.pageY,
                     clientX: e.clientX - clientRect.left,
                     clientY: e.clientY - clientRect.top,
-                    timeStamp: e.timeStamp,
-                    button: e.button
+                    timeStamp: e.timeStamp
                 };
 
                 this.props.onDoubleTap(tapEvent);

--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -77,7 +77,7 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
                 role={ ariaRole }
                 aria-label={ this.props.accessibilityLabel }
                 aria-hidden={ isAriaHidden }
-                onContextMenu={ this.props.onContextMenuGesture ? this._sendContextMenuEvent : undefined }
+                onContextMenu={ this.props.onContextMenu ? this._sendContextMenuEvent : undefined }
             >
                 { this.props.children }
             </div>
@@ -184,7 +184,10 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
     }
 
     private _sendContextMenuEvent = (e: React.MouseEvent<any>) => {
-        if (this.props.onContextMenuGesture) {
+        if (this.props.onContextMenu) {
+            e.preventDefault();
+            e.stopPropagation();
+
             const clientRect = this._getGestureViewClientRect();
 
             if (clientRect) {
@@ -196,8 +199,7 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
                     timeStamp: e.timeStamp
                 };
 
-                this.props.onContextMenuGesture(tapEvent);
-                e.preventDefault();
+                this.props.onContextMenu(tapEvent);
             }
         }
     }

--- a/src/windows/GestureView.tsx
+++ b/src/windows/GestureView.tsx
@@ -18,7 +18,7 @@ export class GestureView extends BaseGestureView {
         super(props);
     }
 
-    protected _getPreferredPanRatio(): number { 
+    protected _getPreferredPanRatio(): number {
         return _preferredPanRatio;
     }
 
@@ -36,6 +36,21 @@ export class GestureView extends BaseGestureView {
         }
 
         return timestamp.valueOf();
+    }
+
+    protected _sendTapEvent(e: Types.TouchEvent) {
+        if (this.props.onTap) {
+            const tapEvent: Types.TapGestureState = {
+                pageX: e.pageX!!!,
+                pageY: e.pageY!!!,
+                clientX: e.locationX!!!,
+                clientY: e.locationY!!!,
+                timeStamp: e.timeStamp,
+                isRightButton: e.isRightButton
+            };
+
+            this.props.onTap(tapEvent);
+        }
     }
 }
 

--- a/src/windows/GestureView.tsx
+++ b/src/windows/GestureView.tsx
@@ -37,21 +37,6 @@ export class GestureView extends BaseGestureView {
 
         return timestamp.valueOf();
     }
-
-    protected _sendTapEvent(e: Types.TouchEvent) {
-        if (this.props.onTap) {
-            const tapEvent: Types.TapGestureState = {
-                pageX: e.pageX!!!,
-                pageY: e.pageY!!!,
-                clientX: e.locationX!!!,
-                clientY: e.locationY!!!,
-                timeStamp: e.timeStamp,
-                isRightButton: e.isRightButton
-            };
-
-            this.props.onTap(tapEvent);
-        }
-    }
 }
 
 export default GestureView;

--- a/src/windows/GestureView.tsx
+++ b/src/windows/GestureView.tsx
@@ -18,7 +18,7 @@ export class GestureView extends BaseGestureView {
         super(props);
     }
 
-    protected _getPreferredPanRatio(): number {
+    protected _getPreferredPanRatio(): number { 
         return _preferredPanRatio;
     }
 


### PR DESCRIPTION
When using RX.GestureView as an interaction handler, it's impossible to detect right mouse button clicks right now in UWP. This info is already propagated from native code in the event received by RX, but it's hidden by GestureView. This PR passes the information further so that user can detect right clicks.