### PR TITLE
Remove useless css properties

### DIFF
--- a/src/web/Link.tsx
+++ b/src/web/Link.tsx
@@ -17,22 +17,18 @@ const _styles = {
     defaultStyle: {
         position: 'relative',
         display: 'inline',
-        flexDirection: 'column',
         flexGrow: 0,
         flexShrink: 0,
         overflow: 'hidden',
-        alignItems: 'stretch',
         overflowWrap: 'break-word',
         msHyphens: 'auto'
     },
     ellipsis: {
         position: 'relative',
         display: 'inline',
-        flexDirection: 'column',
         flexGrow: 0,
         flexShrink: 0,
         overflow: 'hidden',
-        alignItems: 'stretch',
 
         whiteSpace: 'pre',
         textOverflow: 'ellipsis'


### PR DESCRIPTION
`flex-direction/align-items` are useless for Link component because these properties have to be used with `display: flex/inline-flex` but not with `display: inline`

> Flex items do not have properties `flex-direction/align-items` - 
[a-guide-to-flexbox]( https://css-tricks.com/snippets/css/a-guide-to-flexbox/), [flex-items](https://drafts.csswg.org/css-flexbox-1/#flex-items.)

> LinkProps does not provide a way to set `display` property. https://github.com/Microsoft/reactxp/blob/master/src/common/Types.ts#L313, https://github.com/Microsoft/reactxp/blob/master/src/common/Types.ts#L263.