### PR TITLE
Fix focus management for cacheable popups on RN Windows

### DIFF
--- a/src/common/PopupContainerViewBase.tsx
+++ b/src/common/PopupContainerViewBase.tsx
@@ -12,13 +12,14 @@
 import React = require('react');
 import PropTypes = require('prop-types');
 import Types = require('./Types');
+import FocusManagerBase from './utils/FocusManager';
 
 export interface PopupContainerViewBaseProps extends Types.CommonProps {
     hidden?: boolean;
 }
 
 export interface PopupContainerViewContext {
-    focusManager?: any;
+    focusManager?: FocusManagerBase;
 }
 
 export interface PopupComponent {

--- a/src/common/PopupContainerViewBase.tsx
+++ b/src/common/PopupContainerViewBase.tsx
@@ -1,29 +1,24 @@
 /**
-* PopupContainer.tsx
+* PopupContainerViewBase.tsx
 *
 * Copyright (c) Microsoft Corporation. All rights reserved.
 * Licensed under the MIT license.
 *
 * Common parent of all components rendered into a popup. Calls onShow and onHide
 * callbacks when the popup is hidden (i.e. "closed" but still rendered as hidden)
-* and re-shown.
+* and re-shown. Abstract class to be overriden per platform.
 */
 
-import _ = require('./utils/lodashMini');
 import React = require('react');
 import PropTypes = require('prop-types');
-import FocusManager from './utils/FocusManager';
-import Types = require('../common/Types');
+import Types = require('./Types');
 
-export interface PopupContainerProps extends Types.CommonProps {
-    style: React.CSSProperties;
-    onMouseEnter?: (e: any) => void;
-    onMouseLeave?: (e: any) => void;
+export interface PopupContainerViewBaseProps extends Types.CommonProps {
     hidden?: boolean;
 }
 
-export interface PopupContainerContext {
-    focusManager?: FocusManager;
+export interface PopupContainerViewContext {
+    focusManager?: any;
 }
 
 export interface PopupComponent {
@@ -31,7 +26,7 @@ export interface PopupComponent {
     onHide: () => void;
 }
 
-export class PopupContainer extends React.Component<PopupContainerProps, {}> {
+export abstract class PopupContainerViewBase<P extends PopupContainerViewBaseProps, S> extends React.Component<P, S> {
     static contextTypes: React.ValidationMap<any> = {
         focusManager: PropTypes.object
     };
@@ -42,31 +37,15 @@ export class PopupContainer extends React.Component<PopupContainerProps, {}> {
 
     private _popupComponentStack: PopupComponent[] = [];
 
-    constructor(props: PopupContainerProps, context: PopupContainerContext) {
+    constructor(props: P, context: PopupContainerViewContext) {
         super(props, context);
     }
 
     getChildContext() {
         return {
             focusManager: this.context.focusManager,
-            popupContainer: this as PopupContainer
+            popupContainer: this as PopupContainerViewBase<P, S>
         };
-    }
-
-    render() {
-        let style = _.clone(this.props.style);
-        if (this.props.hidden) {
-            style.visibility = 'hidden';
-        }
-        return (
-            <div
-                style={ style }
-                onMouseEnter={ this.props.onMouseEnter }
-                onMouseLeave={ this.props.onMouseLeave }
-            >
-                { this.props.children }
-            </div>
-        );
     }
 
     public registerPopupComponent(onShow: () => void, onHide: () => void): PopupComponent {
@@ -83,10 +62,10 @@ export class PopupContainer extends React.Component<PopupContainerProps, {}> {
     }
 
     public isHidden(): boolean {
-        return this.props.hidden || false;
+        return !!this.props.hidden;
     }
 
-    componentDidUpdate(prevProps: PopupContainerProps) {
+    componentDidUpdate(prevProps: P, prevState: S) {
         if (prevProps.hidden && !this.props.hidden) {
             // call onShow on all registered components (iterate front to back)
             for (let i = 0; i < this._popupComponentStack.length; i++) {
@@ -101,6 +80,7 @@ export class PopupContainer extends React.Component<PopupContainerProps, {}> {
         }
     }
 
+    abstract render(): JSX.Element;
 }
 
-export default PopupContainer;
+export default PopupContainerViewBase;

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -1,5 +1,5 @@
 ﻿/**
-* PopupContainerView.ts
+* PopupContainerView.tsx
 *
 * Copyright (c) Microsoft Corporation. All rights reserved.
 * Licensed under the MIT license.
@@ -16,6 +16,7 @@ import RN = require('react-native');
 
 import International from './International';
 import Types = require('../common/Types');
+import { PopupContainerViewBase, PopupContainerViewBaseProps, PopupContainerViewContext } from '../common/PopupContainerViewBase';
 
 // Width of the "alley" around popups so they don't get too close to the boundary of the screen boundary.
 const ALLEY_WIDTH = 2;
@@ -24,11 +25,10 @@ const ALLEY_WIDTH = 2;
 // attempting a different position?
 const MIN_ANCHOR_OFFSET = 16;
 
-export interface PopupContainerViewProps extends Types.CommonProps {
+export interface PopupContainerViewProps extends PopupContainerViewBaseProps {
     popupOptions: Types.PopupOptions;
     anchorHandle?: number;
     onDismissPopup?: () => void;
-    hidden: boolean;
 }
 
 export interface PopupContainerViewState {
@@ -54,13 +54,13 @@ export interface PopupContainerViewState {
     constrainedPopupHeight: number;
 }
 
-export class PopupContainerView extends React.Component<PopupContainerViewProps, PopupContainerViewState> {
+export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, PopupContainerViewState> {
     private _mountedComponent: RN.View|null = null;
     private _viewHandle: number | null = null;
     private _respositionPopupTimer: number|undefined;
 
-    constructor(props: PopupContainerViewProps) {
-        super(props);
+    constructor(props: PopupContainerViewProps, context: PopupContainerViewContext) {
+        super(props, context);
         this.state = this._getInitialState();
     }
 
@@ -86,6 +86,8 @@ export class PopupContainerView extends React.Component<PopupContainerViewProps,
     }
 
     componentDidUpdate(prevProps: PopupContainerViewProps, prevState: PopupContainerViewState) {
+        super.componentDidUpdate(prevProps, prevState);
+
         if (this.props.popupOptions && !this.props.hidden) {
             this._recalcPosition();
 

--- a/src/web/PopupContainerView.tsx
+++ b/src/web/PopupContainerView.tsx
@@ -13,8 +13,8 @@ import { PopupContainerViewBase, PopupContainerViewBaseProps, PopupContainerView
 
 export interface PopupContainerViewProps extends PopupContainerViewBaseProps {
     style: React.CSSProperties;
-    onMouseEnter?: (e: any) => void;
-    onMouseLeave?: (e: any) => void;
+    onMouseEnter?: (e: React.MouseEvent<HTMLDivElement>) => void;
+    onMouseLeave?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, {}> {

--- a/src/web/PopupContainerView.tsx
+++ b/src/web/PopupContainerView.tsx
@@ -1,0 +1,42 @@
+/**
+* PopupContainerView.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* Common parent of all components rendered into a popup, web version.
+*/
+
+import _ = require('./utils/lodashMini');
+import React = require('react');
+import { PopupContainerViewBase, PopupContainerViewBaseProps, PopupContainerViewContext } from '../common/PopupContainerViewBase';
+
+export interface PopupContainerViewProps extends PopupContainerViewBaseProps {
+    style: React.CSSProperties;
+    onMouseEnter?: (e: any) => void;
+    onMouseLeave?: (e: any) => void;
+}
+
+export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, {}> {
+    constructor(props: PopupContainerViewProps, context: PopupContainerViewContext) {
+        super(props, context);
+    }
+
+    render() {
+        let style = _.clone(this.props.style);
+        if (this.props.hidden) {
+            style.visibility = 'hidden';
+        }
+        return (
+            <div
+                style={ style }
+                onMouseEnter={ this.props.onMouseEnter }
+                onMouseLeave={ this.props.onMouseLeave }
+            >
+                { this.props.children }
+            </div>
+        );
+    }
+}
+
+export default PopupContainerView;

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -20,7 +20,7 @@ import ModalContainer from './ModalContainer';
 import Types = require('../common/Types');
 import FocusManager from './utils/FocusManager';
 import UserInterface from './UserInterface';
-import PopupContainer from './PopupContainer';
+import PopupContainerView from './PopupContainerView';
 
 export class PopupDescriptor {
     constructor(public popupId: string, public popupOptions: Types.PopupOptions) {}
@@ -251,7 +251,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                 this.state.constrainedPopupWidth, this.state.constrainedPopupHeight)
             );
         return (
-            <PopupContainer
+            <PopupContainerView
                 key={ key }
                 style={ popupContainerStyle }
                 hidden={ hidden }
@@ -260,7 +260,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                 onMouseLeave={ e => this._onMouseLeave(e) }
             >
                 { renderedPopup }
-            </PopupContainer>
+            </PopupContainerView>
         );
     }
 
@@ -302,7 +302,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         );
     }
 
-    protected _onMount = (component: PopupContainer|null) => {
+    protected _onMount = (component: PopupContainerView|null) => {
         this._mountedComponent = component ? ReactDOM.findDOMNode(component) as HTMLElement : undefined;
     }
 

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -240,7 +240,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
         return ReactDOM.findDOMNode(this) as HTMLElement;
     }
 
-    private isHidden(): boolean {
+    private _isHidden(): boolean {
         return !!this._popupContainer && this._popupContainer.isHidden();
     }
 
@@ -252,7 +252,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
             return;
         }
 
-        if (!this.isHidden()) {
+        if (!this._isHidden()) {
             if (restricted) {
                 this._focusManager.restrictFocusWithin();
             } else {
@@ -270,7 +270,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
             return;
         }
 
-        if (!this.isHidden()) {
+        if (!this._isHidden()) {
             if (limited && !this._isFocusLimited) {
                 this._focusManager.limitFocusWithin(this.props.limitFocusWithin!!!);
             } else if (!limited && this._isFocusLimited) {
@@ -399,7 +399,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
 
         // If we are mounted as visible, do our initialization now. If we are hidden, it will
         // be done later when the popup is shown.
-        if (!this.isHidden()) {
+        if (!this._isHidden()) {
             this.enableFocusManager();
         }
 

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -18,7 +18,8 @@ import restyleForInlineText = require('./utils/restyleForInlineText');
 import Styles from './Styles';
 import Types = require('../common/Types');
 import ViewBase from './ViewBase';
-import { PopupContainer, PopupComponent } from './PopupContainer';
+import PopupContainerView from './PopupContainerView';
+import { PopupComponent } from '../common/PopupContainerViewBase';
 import { FocusManager, applyFocusableComponentMixin } from './utils/FocusManager';
 
 const _styles = {
@@ -71,7 +72,7 @@ if (typeof document !== 'undefined') {
 export interface ViewContext {
     isRxParentAText?: boolean;
     focusManager?: FocusManager;
-    popupContainer?: PopupContainer;
+    popupContainer?: PopupContainerView;
 }
 
 export class View extends ViewBase<Types.ViewProps, {}> {
@@ -97,7 +98,7 @@ export class View extends ViewBase<Types.ViewProps, {}> {
     private _resizeDetectorAnimationFrame: number|undefined;
     private _resizeDetectorNodes: { grow?: HTMLElement, shrink?: HTMLElement } = {};
 
-    private _popupContainer: PopupContainer|undefined;
+    private _popupContainer: PopupContainerView|undefined;
     private _popupToken: PopupComponent|undefined;
 
     constructor(props: Types.ViewProps, context: ViewContext) {

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -120,7 +120,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
         // If we are mounted as visible, do our initialization now. If we are hidden, it will
         // be done later when the popup is shown.
-        if (!this.isHidden()) {
+        if (!this._isHidden()) {
             this.enableFocusManager();
         }
 
@@ -312,7 +312,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         return childContext;
     }
 
-    private isHidden(): boolean {
+    private _isHidden(): boolean {
         return !!this._popupContainer && this._popupContainer.isHidden();
     }
 
@@ -322,7 +322,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
             return;
         }
 
-        if (!this.isHidden()) {
+        if (!this._isHidden()) {
             if (restricted) {
                 this._focusManager.restrictFocusWithin();
             } else {
@@ -338,7 +338,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
             return;
         }
 
-        if (!this.isHidden()) {
+        if (!this._isHidden()) {
             if (limited && !this._isFocusLimited) {
                 this._focusManager.limitFocusWithin(this.props.limitFocusWithin!!!);
             } else if (!limited && this._isFocusLimited) {


### PR DESCRIPTION
Just like web, Windows views rendered into a cacheable popup must be aware of the popup
hiding and re-showing in order to properly un-restrict and re-restrict focus to the
right components. The implementation is identical to that used on web, i.e. FocusManager
is released and re-initialized on hide and re-show, respectively, in addition to doing
it on unmount and mount.