### PR TITLE
Use zero-sized PopupContainerView for RN hidden popups

### DIFF
--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -129,7 +129,9 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
             alignItems: 'flex-start',
             alignSelf: 'flex-start',
             opacity: this.state.isMeasuringPopup ? 0 : 1,
-            overflow: 'visible'
+            overflow: 'visible',
+            width: this.props.hidden ? 0 : undefined,
+            height: this.props.hidden ? 0 : undefined
         };
 
         return (


### PR DESCRIPTION
Passing 0 for size to renderPopup() is not enough to make the popup reliably
render as hidden. The bug reproduces as "ghost" components showing on the screen
when a regular popup is shown and a cacheable popup is rendered as hidden.