### PR TITLE
Always take View ref in PopupContainerView

### DIFF
--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -137,7 +137,7 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
         return (
             <RN.View
                 style={ style }
-                ref={ this.props.hidden ? undefined : this._onMount }
+                ref={ this._onMount }
             >
                 { popupView }
             </RN.View>


### PR DESCRIPTION
The old code was likely an attempt at optimizing out the measurement/position logic for
hidden popups. It's not only unnecessary (the code is under if !this.props.hidden already)
but also wrong because if a hidden popup happens to get unmounted, _mountedComponent will
not be updated and we'll end up calling setState on an unmounted component.