### PR TITLE
Pass 'animated' param to setBarStyle on iOS

### DIFF
--- a/src/ios/StatusBar.ts
+++ b/src/ios/StatusBar.ts
@@ -19,7 +19,7 @@ export class StatusBar extends RX.StatusBar {
     }
 
     setBarStyle(style: 'default' | 'light-content' | 'dark-content', animated: boolean): void {
-        RN.StatusBar.setBarStyle(style, true);
+        RN.StatusBar.setBarStyle(style, animated);
     }
 
     setHidden(hidden: boolean, showHideTransition: 'fade' | 'slide'): void {


### PR DESCRIPTION
Looks like this is unintentionally always set to true