### PR TITLE
Add onContextMenu to RX.Link

### DIFF
--- a/docs/docs/components/link.md
+++ b/docs/docs/components/link.md
@@ -37,6 +37,10 @@ onPress: (e: SyntheticEvent, url: string) => void = undefined;
 // within the bounds of the view and the press has not been canceled
 onLongPress: (e: SyntheticEvent, url:string) => void = undefined;
 
+// Event called when context menu is triggered, either by
+// right mouse button click or context menu key
+onContextMenu: (e: MouseEvent) => void = undefined;
+
 // Can the link be included in a text selection?
 selectable: boolean = false;
 

--- a/samples/RXPTest/src/Tests/LinkTest.tsx
+++ b/samples/RXPTest/src/Tests/LinkTest.tsx
@@ -70,7 +70,8 @@ class LinkView extends RX.Component<RX.CommonProps, LinkViewState> {
                 <RX.View style={ _styles.explainTextContainer } key={ 'explanation1' }>
                     <RX.Text style={ _styles.explainText }>
                         { 'Press on this link to test press callback. Hold to test long presses. ' +
-                          'Move mouse pointer to test hovering.' }
+                          'Right click to test context menu callback. ' +
+                          ' Move mouse pointer to test hovering.' }
                     </RX.Text>
                 </RX.View>
                 <RX.View style={ _styles.linkContainer }>
@@ -81,6 +82,7 @@ class LinkView extends RX.Component<RX.CommonProps, LinkViewState> {
                         onLongPress={ () => { this.setState({ test1Result: 'Long press detected' }); } }
                         onHoverStart={ () => { this.setState({ test1Hovering: true }); } }
                         onHoverEnd={ () => { this.setState({ test1Hovering: false }); } }
+                        onContextMenu={ () => { this.setState({ test1Result: 'Context menu detected' }); } }
                         allowFontScaling={ false }
                     >
                         { 'Press or hold' }

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -831,6 +831,7 @@ export interface LinkProps extends CommonStyledProps<LinkStyleRuleSet> {
     onLongPress?: (e: RX.Types.SyntheticEvent, url: string) => void;
     onHoverStart?: (e: SyntheticEvent) => void;
     onHoverEnd?: (e: SyntheticEvent) => void;
+    onContextMenu?: (e: MouseEvent) => void;
 }
 
 // TextInput

--- a/src/native-common/Link.tsx
+++ b/src/native-common/Link.tsx
@@ -54,6 +54,9 @@ export class Link extends React.Component<Types.LinkProps, Types.Stateless> {
 
     protected _onPress = (e: RX.Types.SyntheticEvent) => {
         if (EventHelpers.isRightMouseButton(e)) {
+            if (this.props.onContextMenu) {
+                this.props.onContextMenu(EventHelpers.toMouseEvent(e));
+            }
             return;
         }
 
@@ -71,6 +74,14 @@ export class Link extends React.Component<Types.LinkProps, Types.Stateless> {
     }
 
     protected _onLongPress = (e: RX.Types.SyntheticEvent) => {
+        // Right mouse button doesn't change behavior based on press length.
+        if (EventHelpers.isRightMouseButton(e)) {
+            if (this.props.onContextMenu) {
+                this.props.onContextMenu(EventHelpers.toMouseEvent(e));
+            }
+            return;
+        }
+
         if (!EventHelpers.isRightMouseButton(e) && this.props.onLongPress) {
             this.props.onLongPress(EventHelpers.toMouseEvent(e), this.props.url);
         }

--- a/src/web/Link.tsx
+++ b/src/web/Link.tsx
@@ -11,6 +11,7 @@ import React = require('react');
 
 import Styles from './Styles';
 import Types = require('../common/Types');
+import EventHelpers from '../native-common/utils/EventHelpers';
 import { applyFocusableComponentMixin } from './utils/FocusManager';
 
 const _styles = {
@@ -59,6 +60,7 @@ export class Link extends React.Component<Types.LinkProps, Types.Stateless> {
                 onMouseDown={ this._onMouseDown }
                 onMouseUp={ this._onMouseUp }
                 tabIndex={ this.props.tabIndex }
+                onContextMenu={ this.props.onContextMenu ? this._onContextMenu : undefined }
             >
                 { this.props.children }
             </a>
@@ -100,7 +102,11 @@ export class Link extends React.Component<Types.LinkProps, Types.Stateless> {
 
             this._longPressTimer = setTimeout(() => {
                 this._longPressTimer = undefined;
-                if (this.props.onLongPress) {
+
+                const mouseEvent = e as React.MouseEvent<any>;
+                // Ignore right mouse button for long press. Context menu will
+                // be always displayed on mouseUp no matter the press length.
+                if (this.props.onLongPress && mouseEvent.button !== 2) {
                     this.props.onLongPress(e, this.props.url);
                 }
             }, _longPressTime);
@@ -111,6 +117,14 @@ export class Link extends React.Component<Types.LinkProps, Types.Stateless> {
         if (this._longPressTimer) {
             clearTimeout(this._longPressTimer);
             this._longPressTimer = undefined;
+        }
+    }
+
+    private _onContextMenu = (e: Types.SyntheticEvent) => {
+        if (this.props.onContextMenu) {
+            e.stopPropagation();
+            e.preventDefault();
+            this.props.onContextMenu(EventHelpers.toMouseEvent(e));
         }
     }
 }


### PR DESCRIPTION
As with RX.GestureView #599, RX.Link in UWP receives press events even from right mouse button and doesn't propagate them to parents which implement onContextMenu. In order to support context menu, we need a delegate that can call context menu handler. 

Additionally, this PR unifies long press handling and ignores long presses with right mouse button; onContextMenu is always called onMouseUp instead.