### PR TITLE
Allow for Group view children to be visible to UI Automation.

### DIFF
--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -20,7 +20,6 @@ import EventHelpers from '../native-common/utils/EventHelpers';
 import { applyFocusableComponentMixin, FocusManagerFocusableComponent, FocusManager } from '../native-desktop/utils/FocusManager';
 import PopupContainerView from '../native-common/PopupContainerView';
 import { PopupComponent } from '../common/PopupContainerViewBase';
-import { AccessibilityTrait } from '../common/Types';
 
 const KEY_CODE_ENTER = 13;
 const KEY_CODE_SPACE = 32;
@@ -145,9 +144,11 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         // Base class does the bulk of _internalprops creation
         super._buildInternalProps(props);
 
-        // Group view descendants should be visible to UI automation.
-        if (((props && props.accessibilityTraits === AccessibilityTrait.Group) ||
-            (_.isArray(props.accessibilityTraits) && (props.accessibilityTraits.indexOf(AccessibilityTrait.Group) !== -1))) &&
+        // On Windows a view with importantForAccessibility='Yes' or non-empty accessibilityLabel will hide its children.
+        // However, a view that is also a group should keep children visible to UI Automation. The following condition checks
+        // and sets RNW importantForAccessibility property to 'yes-dont-hide-descendants' to keep view children visible.
+        if (((props.accessibilityTraits === Types.AccessibilityTrait.Group) ||
+            (_.isArray(props.accessibilityTraits) && (props.accessibilityTraits.indexOf(Types.AccessibilityTrait.Group) !== -1))) &&
             ((props.importantForAccessibility === Types.ImportantForAccessibility.Yes) ||
              (props.accessibilityLabel && props.accessibilityLabel.length > 0))) {
             this._internalProps.importantForAccessibility = 'yes-dont-hide-descendants';

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -150,7 +150,8 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         if (((props.accessibilityTraits === Types.AccessibilityTrait.Group) ||
             (_.isArray(props.accessibilityTraits) && (props.accessibilityTraits.indexOf(Types.AccessibilityTrait.Group) !== -1))) &&
             ((props.importantForAccessibility === Types.ImportantForAccessibility.Yes) ||
-             (props.accessibilityLabel && props.accessibilityLabel.length > 0))) {
+             (props.importantForAccessibility === Types.ImportantForAccessibility.Auto &&
+                props.accessibilityLabel && props.accessibilityLabel.length > 0))) {
             this._internalProps.importantForAccessibility = 'yes-dont-hide-descendants';
         }
 

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -7,6 +7,7 @@
 * Windows-specific implementation of View.
 */
 
+import _ = require('../native-common/lodashMini');
 import React = require('react');
 import RN = require('react-native');
 import RNW = require('react-native-windows');
@@ -19,6 +20,7 @@ import EventHelpers from '../native-common/utils/EventHelpers';
 import { applyFocusableComponentMixin, FocusManagerFocusableComponent, FocusManager } from '../native-desktop/utils/FocusManager';
 import PopupContainerView from '../native-common/PopupContainerView';
 import { PopupComponent } from '../common/PopupContainerViewBase';
+import { AccessibilityTrait } from '../common/Types';
 
 const KEY_CODE_ENTER = 13;
 const KEY_CODE_SPACE = 32;
@@ -142,6 +144,14 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     protected _buildInternalProps(props: Types.ViewProps) {
         // Base class does the bulk of _internalprops creation
         super._buildInternalProps(props);
+
+        // Group view descendants should be visible to UI automation.
+        if (((props && props.accessibilityTraits === AccessibilityTrait.Group) ||
+            (_.isArray(props.accessibilityTraits) && (props.accessibilityTraits.indexOf(AccessibilityTrait.Group) !== -1))) &&
+            ((props.importantForAccessibility === Types.ImportantForAccessibility.Yes) ||
+             (props.accessibilityLabel && props.accessibilityLabel.length > 0))) {
+            this._internalProps.importantForAccessibility = 'yes-dont-hide-descendants';
+        }
 
         if (props.onKeyPress) {
 


### PR DESCRIPTION
Currently any view that has ImportantForAccessibility='Yes' or an accessibility label set will hide its children from UI Automation. However there are some cases when these children must be visible (e.g. for Groups). This change adds functionality that overrides the importantForAccessibility flag to allow for this.