### PR TITLE
Change Linking.getInitialUrl() to return null, not undefined

### DIFF
--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -110,7 +110,7 @@ export abstract class Popup {
 
 export abstract class Linking {
     // Incoming deep links
-    abstract getInitialUrl(): SyncTasks.Promise<string|undefined>;
+    abstract getInitialUrl(): SyncTasks.Promise<string|null>;
     deepLinkRequestEvent = new SubscribableEvent<(url: string) => void>();
 
     // Outgoing deep links

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1308,7 +1308,7 @@ export enum LinkingErrorCode {
 
 export interface LinkingErrorInfo {
     code: LinkingErrorCode;
-    url: string;
+    url: string | null;
     description?: string;
 }
 

--- a/src/native-common/Linking.ts
+++ b/src/native-common/Linking.ts
@@ -50,7 +50,7 @@ export class Linking extends CommonLinking {
         return defer.promise();
     }
 
-    getInitialUrl(): SyncTasks.Promise<string> {
+    getInitialUrl(): SyncTasks.Promise<string|null> {
         let defer = SyncTasks.Defer<string>();
 
         RN.Linking.getInitialURL().then(url => {
@@ -58,7 +58,7 @@ export class Linking extends CommonLinking {
         }).catch(error => {
             defer.reject({
                 code: Types.LinkingErrorCode.InitialUrlNotFound,
-                url: '',
+                url: null,
                 description: error
             } as Types.LinkingErrorInfo);
         });

--- a/src/web/Linking.ts
+++ b/src/web/Linking.ts
@@ -47,8 +47,8 @@ export class Linking extends CommonLinking {
         return SyncTasks.Resolved<void>();
     }
 
-    getInitialUrl(): SyncTasks.Promise<string|undefined> {
-        return SyncTasks.Resolved(undefined);
+    getInitialUrl(): SyncTasks.Promise<string|null> {
+        return SyncTasks.Resolved(null);
     }
 }
 


### PR DESCRIPTION
`null` is returned by [the RN implementations](https://facebook.github.io/react-native/docs/linking.html#getinitialurl) when an initial url can't be found, not `undefined`.  