### PR TITLE
Create correct Animated.TextInput for windows

### DIFF
--- a/src/windows/ReactXP.ts
+++ b/src/windows/ReactXP.ts
@@ -127,7 +127,8 @@ module ReactXP {
 
     const windowsAnimatedClasses =  {
         ...CommonAnimatedClasses,
-        View: RN.Animated.createAnimatedComponent(ViewImpl)
+        View: RN.Animated.createAnimatedComponent(ViewImpl),
+        TextInput:  RN.Animated.createAnimatedComponent(TextInputImpl)
     };
 
     export const Animated = makeAnimated(windowsAnimatedClasses, true);


### PR DESCRIPTION
Added the missing animated TextInput for the windows flavor.
I was afraid there was a bigger issue/regression, but things look better.