### PR TITLE
Fixed import from RNSvgPackage to SvgPackage

### DIFF
--- a/samples/hello-world-js/android/app/src/main/java/com/rxphelloworld/MainApplication.java
+++ b/samples/hello-world-js/android/app/src/main/java/com/rxphelloworld/MainApplication.java
@@ -4,7 +4,7 @@ import android.app.Application;
 
 import com.facebook.react.ReactApplication;
 import com.brentvatne.react.ReactVideoPackage;
-import com.horcrux.svg.RNSvgPackage;
+import com.horcrux.svg.SvgPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -26,7 +26,7 @@ public class MainApplication extends Application implements ReactApplication {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
             new ReactVideoPackage(),
-            new RNSvgPackage()
+            new SvgPackage()
       );
     }
   };


### PR DESCRIPTION
The Android hello-world-js sample would not compile because RNSvgPackage has been updated to SvgPackage. This change was not made in the hello-world-js sample, so this PR makes this change.