### PR TITLE
Focus tweaks for UWP

### DIFF
--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -278,6 +278,9 @@ declare module 'react-native' {
         onMouseLeave?: Function;
         onMouseOver?: Function;
         onMouseMove?: Function;
+
+        // Windows
+        tabNavigation?: 'local' | 'cycle' | 'once';
     }
 
     interface ScrollViewProps extends ViewProps {

--- a/src/windows/ReactXP.ts
+++ b/src/windows/ReactXP.ts
@@ -41,7 +41,7 @@ import ScrollViewImpl from './ScrollView';
 import StatusBarImpl from './StatusBar';
 import StorageImpl from '../native-common/Storage';
 import StylesImpl from '../native-common/Styles';
-import TextImpl from '../native-common/Text';
+import TextImpl from './Text';
 import TextInputImpl from './TextInput';
 import UserInterfaceImpl from '../native-common/UserInterface';
 import UserPresenceImpl from '../native-common/UserPresence';
@@ -128,7 +128,8 @@ module ReactXP {
     const windowsAnimatedClasses =  {
         ...CommonAnimatedClasses,
         View: RN.Animated.createAnimatedComponent(ViewImpl),
-        TextInput:  RN.Animated.createAnimatedComponent(TextInputImpl)
+        TextInput:  RN.Animated.createAnimatedComponent(TextInputImpl),
+        Text:  RN.Animated.createAnimatedComponent(TextImpl)
     };
 
     export const Animated = makeAnimated(windowsAnimatedClasses, true);

--- a/src/windows/Text.tsx
+++ b/src/windows/Text.tsx
@@ -1,0 +1,18 @@
+/**
+* Text.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN Windows-specific implementation of the cross-platform Text abstraction.
+*/
+
+import { Text as TextBase } from '../native-common/Text';
+
+export class Text extends TextBase {
+    requestFocus() {
+        // UWP doesn't support casually focusing RN.Text elements. We override requestFocus in order to drop any focus requests
+    }
+}
+
+export default Text;

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -153,15 +153,15 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         // Base class does the bulk of _internalprops creation
         super._buildInternalProps(props);
 
-        // On Windows a view with importantForAccessibility='Yes' or 
+        // On Windows a view with importantForAccessibility='Yes' or
         // non-empty accessibilityLabel and importantForAccessibility='Auto' (or unspecified) will hide its children.
-        // However, a view that is also a group or a dialog should keep children visible to UI Automation. 
-        // The following condition checks and sets RNW importantForAccessibility property 
+        // However, a view that is also a group or a dialog should keep children visible to UI Automation.
+        // The following condition checks and sets RNW importantForAccessibility property
         // to 'yes-dont-hide-descendants' to keep view children visible.
         const hasGroup = this.hasTrait(Types.AccessibilityTrait.Group, props.accessibilityTraits);
         const hasDialog = this.hasTrait(Types.AccessibilityTrait.Dialog, props.accessibilityTraits);
         const i4aYes = props.importantForAccessibility === Types.ImportantForAccessibility.Yes;
-        const i4aAuto = (props.importantForAccessibility === Types.ImportantForAccessibility.Auto 
+        const i4aAuto = (props.importantForAccessibility === Types.ImportantForAccessibility.Auto
             || props.importantForAccessibility === undefined);
         const hasLabel = props.accessibilityLabel && props.accessibilityLabel.length > 0;
         if ((hasGroup || hasDialog) && (i4aYes || (i4aAuto && hasLabel))) {
@@ -300,11 +300,27 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         this._focusableElement = btn;
     }
 
+    requestFocus() {
+        if (!this._focusableElement) {
+            // Views with no tabIndex (even if -1) can't receive focus
+            if (AppConfig.isDevelopmentMode()) {
+                console.error('View: requestFocus called on a non focusable element');
+            }
+            return;
+        }
+
+        super.requestFocus();
+    }
+
     focus() {
         // Only forward to Button.
         // The other cases are RN.View based elements with no meaningful focus support
         if (this._focusableElement) {
             this._focusableElement.focus();
+        } else {
+            if (AppConfig.isDevelopmentMode()) {
+                console.error('View: focus called on a non focusable element');
+            }
         }
     }
 


### PR DESCRIPTION
1. RX.Text and RX.View (with no tasbIndex) are not keyboard focusable, so we should prevent them from participating in the race and being chosen as winners by focus arbitrator.
2. Added support for Windows only "tabNavigation" RN.View property that allows keeping focus confined within a restricted view regardless of the ability of FocusManager to control outside focusable controls.
