### PR TITLE
Add support for Text shadows

### DIFF
--- a/docs/docs/styles.md
+++ b/docs/docs/styles.md
@@ -169,6 +169,8 @@ borderTopLeftRadius: number = 0;
 
 **Shadows**
 ```javascript
+// NOTE: If applied to a Text element, these properties translate to text shadows, 
+// not a box shadow.
 shadowOffset: { height: number; width: number } = { 0, 0 };
 shadowRadius: number = 0;
 shadowColor: color = 'black';

--- a/samples/RXPTest/src/Tests/TextInputInteractiveTest.tsx
+++ b/samples/RXPTest/src/Tests/TextInputInteractiveTest.tsx
@@ -60,6 +60,17 @@ const _styles = {
         padding: 4,
         borderColor: '#999'
     }),
+    textInput7: RX.Styles.createTextInputStyle({
+        flex: 1,
+        maxWidth: 200,
+        borderWidth: 1,
+        fontSize: CommonStyles.generalFontSize,
+        padding: 4,
+        borderColor: '#999',
+        shadowColor: 'red',
+        shadowOffset: { width: 1, height: 4 },
+        shadowRadius: 5
+    }),
     eventHistoryScrollView: RX.Styles.createScrollViewStyle({
         margin: 12,
         padding: 8,
@@ -81,6 +92,7 @@ interface TextInputViewState {
     test2Input?: string;
     test6Input?: string;
     test6EventHistory?: string[];
+    test7Input?: string;
 }
 
 class TextInputView extends RX.Component<RX.CommonProps, TextInputViewState> {
@@ -91,7 +103,8 @@ class TextInputView extends RX.Component<RX.CommonProps, TextInputViewState> {
             test1Input: '',
             test2Input: '',
             test6Input: '',
-            test6EventHistory: []
+            test6EventHistory: [],
+            test7Input: ''
         };
     }
 
@@ -230,6 +243,22 @@ class TextInputView extends RX.Component<RX.CommonProps, TextInputViewState> {
                         }
                     </RX.Text>
                 </RX.ScrollView>
+
+                <RX.View style={ _styles.explainTextContainer } key={ 'explanation7' }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'The text entered in this input box will have a red shadow.' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={ _styles.resultContainer }>
+                    <RX.TextInput
+                        style={ _styles.textInput7 }
+                        value={ this.state.test7Input }
+                        onChangeText={ val => this.setState({ test7Input: val }) }
+                    />
+                    <RX.Text style={ _styles.resultText }>
+                        { this.state.test1Input }
+                    </RX.Text>
+                </RX.View>
 
                 <RX.View style={ _styles.placeholder }/>
 

--- a/samples/RXPTest/src/Tests/TextTest.tsx
+++ b/samples/RXPTest/src/Tests/TextTest.tsx
@@ -53,6 +53,12 @@ const _styles = {
     test7Text: RX.Styles.createTextStyle({
         fontSize: 16
     }),
+    test9Text: RX.Styles.createTextStyle({
+        fontSize: CommonStyles.generalFontSize,
+        shadowColor: 'red',
+        shadowOffset: { width: 1, height: 4 },
+        shadowRadius: 5
+    }),
     inlineImageContainer: RX.Styles.createViewStyle({
         height: 24,
         width: 20,
@@ -263,6 +269,17 @@ class TextView extends RX.Component<RX.CommonProps, TextViewState> {
                             { ' light bulb inlined within it. It is meant to demonstrate a' +
                               ' larger-than-normal line height.' }
                         </RX.Text>
+                    </RX.Text>
+                </RX.View>
+
+                <RX.View style={ _styles.explainTextContainer } key={ 'explanation9' }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'Text shadows can be applied with the shadow style props.' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={ _styles.resultContainer }>
+                    <RX.Text style={ _styles.test9Text }>
+                        { 'Text with a red shadow.' }
                     </RX.Text>
                 </RX.View>
             </RX.View>

--- a/samples/RXPTest/src/Tests/ViewBasicTest.tsx
+++ b/samples/RXPTest/src/Tests/ViewBasicTest.tsx
@@ -36,6 +36,15 @@ const _styles = {
         alignItems: 'center',
         justifyContent: 'center'
     }),
+    view4: RX.Styles.createViewStyle({
+        backgroundColor: 'green',
+        width: 50,
+        height: 50,
+        margin: 20,
+        shadowColor: 'red',
+        shadowOffset: { width: 1, height: 4 },
+        shadowRadius: 5
+    }),
     explainTextContainer: RX.Styles.createViewStyle({
         margin: 12
     }),
@@ -192,6 +201,16 @@ class BasicView extends RX.Component<RX.CommonProps, RX.Stateless> {
                 <RX.View style={ _styles.labelContainer }>
                     { accessibilityLabelAndImportantForAccessibilityTestUI(RX.Types.ImportantForAccessibility.No) }
                 </RX.View>
+
+                <RX.View
+                    style={ _styles.explainTextContainer }
+                    key={ 'explanation4' }
+                >
+                    <RX.Text style={ _styles.explainText }>
+                        { 'Box shadow can be applied with the shadow props.' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={ _styles.view4 } />
             </RX.View>
         );
     }

--- a/src/native-common/Styles.ts
+++ b/src/native-common/Styles.ts
@@ -36,6 +36,9 @@ type ReactNativeViewAndImageCommonStyle<Style extends Types.ViewAndImageCommonSt
     flexGrow?: number;
     flexShrink?: number;
     flexBasis?: number;
+    textShadowColor?: string;
+    textShadowOffset?: Types.ShadowOffset;
+    textShadowRadius?: number;
 };
 
 export class Styles extends RX.Styles {
@@ -105,7 +108,7 @@ export class Styles extends RX.Styles {
 
     // Creates opaque styles that can be used for Text
     createTextStyle(ruleSet: Types.TextStyle, cacheStyle: boolean = true): Types.TextStyleRuleSet {
-        return this._adaptStyles(ruleSet, cacheStyle);
+        return this._adaptStyles(ruleSet, cacheStyle, true);
     }
 
     // Creates opaque styles that can be used for Text
@@ -115,7 +118,7 @@ export class Styles extends RX.Styles {
 
     // Creates opaque styles that can be used for TextInput
     createTextInputStyle(ruleSet: Types.TextInputStyle, cacheStyle: boolean = true): Types.TextInputStyleRuleSet {
-        return this._adaptStyles(ruleSet, cacheStyle);
+        return this._adaptStyles(ruleSet, cacheStyle, true);
     }
 
     // Creates opaque styles that can be used for TextInput
@@ -148,7 +151,11 @@ export class Styles extends RX.Styles {
         return {};
     }
 
-    private _adaptStyles<S extends Types.ViewAndImageCommonStyle>(def: S, cacheStyle: boolean): Readonly<Types.StyleRuleSet<S>> {
+    private _adaptStyles<S extends Types.ViewAndImageCommonStyle>(
+        def: S, 
+        cacheStyle: boolean, 
+        isTextStyle = false
+    ): Readonly<Types.StyleRuleSet<S>> {
         let adaptedRuleSet = def as ReactNativeViewAndImageCommonStyle<S>;
         if (cacheStyle) {
             StyleLeakDetector.detectLeaks(def);
@@ -158,19 +165,33 @@ export class Styles extends RX.Styles {
             adaptedRuleSet = _.omit<S>(adaptedRuleSet, forbiddenProps) as ReactNativeViewAndImageCommonStyle<S>;
         }
 
-        // Convert text styling
-        let textStyle = adaptedRuleSet as Types.TextStyle;
-        if (textStyle.font) {
-            if (textStyle.font.fontFamily !== undefined) {
-                textStyle.fontFamily = textStyle.font.fontFamily;
+        if (isTextStyle) {
+            // Convert text styling
+            let textStyle = adaptedRuleSet as Types.TextStyle;
+            if (textStyle.font) {
+                if (textStyle.font.fontFamily !== undefined) {
+                    textStyle.fontFamily = textStyle.font.fontFamily;
+                }
+                if (textStyle.font.fontWeight !== undefined) {
+                    textStyle.fontWeight = textStyle.font.fontWeight;
+                }
+                if (textStyle.font.fontStyle !== undefined) {
+                    textStyle.fontStyle = textStyle.font.fontStyle;
+                }
+                delete textStyle.font;
             }
-            if (textStyle.font.fontWeight !== undefined) {
-                textStyle.fontWeight = textStyle.font.fontWeight;
+            if (textStyle.shadowColor !== undefined) {
+                adaptedRuleSet.textShadowColor = textStyle.shadowColor;
+                delete textStyle.shadowColor;
             }
-            if (textStyle.font.fontStyle !== undefined) {
-                textStyle.fontStyle = textStyle.font.fontStyle;
+            if (textStyle.shadowOffset !== undefined) {
+                adaptedRuleSet.textShadowOffset = textStyle.shadowOffset;
+                delete textStyle.shadowOffset;
             }
-            delete textStyle.font;
+            if (textStyle.shadowRadius !== undefined) {
+                adaptedRuleSet.textShadowRadius = textStyle.shadowRadius;
+                delete textStyle.shadowRadius;
+            }
         }
 
         if (def.flex !== undefined) {

--- a/src/native-common/Styles.ts
+++ b/src/native-common/Styles.ts
@@ -165,21 +165,22 @@ export class Styles extends RX.Styles {
             adaptedRuleSet = _.omit<S>(adaptedRuleSet, forbiddenProps) as ReactNativeViewAndImageCommonStyle<S>;
         }
 
-        if (isTextStyle) {
-            // Convert text styling
-            let textStyle = adaptedRuleSet as Types.TextStyle;
-            if (textStyle.font) {
-                if (textStyle.font.fontFamily !== undefined) {
-                    textStyle.fontFamily = textStyle.font.fontFamily;
-                }
-                if (textStyle.font.fontWeight !== undefined) {
-                    textStyle.fontWeight = textStyle.font.fontWeight;
-                }
-                if (textStyle.font.fontStyle !== undefined) {
-                    textStyle.fontStyle = textStyle.font.fontStyle;
-                }
-                delete textStyle.font;
+        // Convert text styling
+        let textStyle = adaptedRuleSet as Types.TextStyle;
+        if (textStyle.font) {
+            if (textStyle.font.fontFamily !== undefined) {
+                textStyle.fontFamily = textStyle.font.fontFamily;
             }
+            if (textStyle.font.fontWeight !== undefined) {
+                textStyle.fontWeight = textStyle.font.fontWeight;
+            }
+            if (textStyle.font.fontStyle !== undefined) {
+                textStyle.fontStyle = textStyle.font.fontStyle;
+            }
+            delete textStyle.font;
+        }
+
+        if (isTextStyle) {
             if (textStyle.shadowColor !== undefined) {
                 adaptedRuleSet.textShadowColor = textStyle.shadowColor;
                 delete textStyle.shadowColor;

--- a/src/web/Styles.ts
+++ b/src/web/Styles.ts
@@ -97,7 +97,7 @@ export class Styles extends RX.Styles {
 
     // Creates opaque styles that can be used for Text
     createTextStyle(ruleSet: Types.TextStyle, cacheStyle: boolean = true): Types.TextStyleRuleSet {
-        return this._adaptStyles(ruleSet, cacheStyle);
+        return this._adaptStyles(ruleSet, cacheStyle, true);
     }
 
     // Creates opaque styles that can be used for Text
@@ -107,7 +107,7 @@ export class Styles extends RX.Styles {
 
     // Creates opaque styles that can be used for TextInput
     createTextInputStyle(ruleSet: Types.TextInputStyle, cacheStyle: boolean = true): Types.TextInputStyleRuleSet {
-        return this._adaptStyles(ruleSet, cacheStyle);
+        return this._adaptStyles(ruleSet, cacheStyle, true);
     }
 
     // Creates opaque styles that can be used for TextInput
@@ -250,7 +250,7 @@ export class Styles extends RX.Styles {
         return parentConstructor.name ? parentConstructor.name : parentConstructor;
     }
 
-    private _adaptStyles(def: any, validate: boolean): Readonly<any> {
+    private _adaptStyles(def: any, validate: boolean, isTextStyle = false): Readonly<any> {
         if (validate) {
             StyleLeakDetector.detectLeaks(def);
         }
@@ -346,7 +346,11 @@ export class Styles extends RX.Styles {
                 delete def.shadowColor;
             }
 
-            def['boxShadow'] = width + 'px ' + height + 'px ' + radius + 'px 0px ' + color;
+            if (isTextStyle) {
+                def['textShadow'] = width + 'px ' + height + 'px ' + radius + 'px ' + color;
+            } else {
+                def['boxShadow'] = width + 'px ' + height + 'px ' + radius + 'px 0px ' + color;
+            }
         }
 
         // CSS (and React JS) support lineHeight defined as either a multiple of the font


### PR DESCRIPTION
This change adds support for Text shadows, which is supported natively in RN and easily achieved with the `text-shadow` CSS property on Web.

Decided to use the existing shadow style properties, rather than add new ones.  This approach requires an additional parameter to be sent to `_adaptStyles` to differentiate between Text and non-Text styles (we can't do an `instanceof` or a meaningful typeguard on the style itself unfortunately).  I decided on a simple flag for text styles for now since it's simplest and I don't see any need to future proof against needing support for other styles.

In my testing, text shadow props don't show up for the Animated classes, hence why I didn't add the flag there.  A simple workaround is to wrap the text in an Animated.View, and it'll work.

Verified on Web, Android and iOS.