### PR TITLE
Fix  "isNavigatingWithKeyboard" for the multi root-view case

### DIFF
--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -53,8 +53,6 @@ export type FocusableComponentStateCallback = (restrictedOrLimited: boolean) => 
 export type FocusManagerRestrictionStateCallback = (restricted: RestrictFocusType) => void;
 
 export abstract class FocusManager {
-    private static _rootFocusManager: FocusManager;
-
     private static _restrictionStack: FocusManager[] = [];
     protected static _currentRestrictionOwner: FocusManager|undefined;
     private static _restoreRestrictionTimer: number|undefined;
@@ -72,15 +70,7 @@ export abstract class FocusManager {
     private _restrictionStateCallback: FocusManagerRestrictionStateCallback|undefined;
 
     constructor(parent: FocusManager|undefined) {
-        if (parent) {
-            this._parent = parent;
-        } else if (FocusManager._rootFocusManager) {
-            if (AppConfig.isDevelopmentMode()) {
-                console.error('FocusManager: root is already set');
-            }
-        } else {
-            FocusManager._rootFocusManager = this;
-        }
+        this._parent = parent;
     }
 
     protected abstract /* static */ addFocusListenerOnComponent(component: FocusableComponentInternal, onFocus: () => void): void;

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -47,7 +47,7 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
 
         _focusManager: FocusManager;
         _keyboardHandlerInstalled = false;
-        _isNavigatingWithKeyboard: boolean = false;
+        _isNavigatingWithKeyboard: boolean;
         _isNavigatingWithKeyboardUpateTimer: number | undefined;
 
         constructor(...args: any[]) {
@@ -55,6 +55,12 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
             // Initialize the root FocusManager which is aware of all
             // focusable elements.
             this._focusManager = new FocusManager(undefined);
+
+            // Keep current state in sync with the truth in UserInterface, to accomodate the multiple root views case
+            UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
+                this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+            });
+            this._isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
         }
 
         _onTouchStartCapture = (e: SyntheticEvent) => {

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -30,14 +30,6 @@ const _styles = RN.StyleSheet.create({
     }
   });
 
-let _isNavigatingWithKeyboard: boolean;
-
-// Keep current state in sync with the truth in UserInterface, to accomodate the multiple root views case
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
-
 //
 // Mixin with keyboard management behaviors. It enhances the two RootView flavors by adding:
 // 1. Support for maintaining UserInterface.keyboardNavigationEvent
@@ -99,9 +91,7 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
                 this._isNavigatingWithKeyboardUpateTimer = undefined;
             }
 
-            if (_isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
-                _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-
+            if (UserInterface.isNavigatingWithKeyboard() !== isNavigatingWithKeyboard) {
                 UserInterface.keyboardNavigationEvent.fire(isNavigatingWithKeyboard);
             }
         }

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -30,6 +30,14 @@ const _styles = RN.StyleSheet.create({
     }
   });
 
+let _isNavigatingWithKeyboard: boolean;
+
+// Keep current state in sync with the truth in UserInterface, to accomodate the multiple root views case
+UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
+    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+});
+_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
+
 //
 // Mixin with keyboard management behaviors. It enhances the two RootView flavors by adding:
 // 1. Support for maintaining UserInterface.keyboardNavigationEvent
@@ -47,7 +55,6 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
 
         _focusManager: FocusManager;
         _keyboardHandlerInstalled = false;
-        _isNavigatingWithKeyboard: boolean;
         _isNavigatingWithKeyboardUpateTimer: number | undefined;
 
         constructor(...args: any[]) {
@@ -55,12 +62,6 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
             // Initialize the root FocusManager which is aware of all
             // focusable elements.
             this._focusManager = new FocusManager(undefined);
-
-            // Keep current state in sync with the truth in UserInterface, to accomodate the multiple root views case
-            UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-                this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-            });
-            this._isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
         }
 
         _onTouchStartCapture = (e: SyntheticEvent) => {
@@ -98,8 +99,8 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
                 this._isNavigatingWithKeyboardUpateTimer = undefined;
             }
 
-            if (this._isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
-                this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+            if (_isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
+                _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 
                 UserInterface.keyboardNavigationEvent.fire(isNavigatingWithKeyboard);
             }

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -18,13 +18,6 @@ import UserInterface from '../../native-common/UserInterface';
 
 const isNativeWindows: boolean = Platform.getType() === 'windows';
 
-let _isNavigatingWithKeyboard: boolean;
-
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
-
 import { FocusableComponentStateCallback } from  '../../common/utils/FocusManager';
 export { FocusableComponentStateCallback };
 
@@ -101,7 +94,7 @@ export class FocusManager extends FocusManagerBase {
             FocusManager._resetFocusTimer = undefined;
         }
 
-        if (_isNavigatingWithKeyboard && focusFirstWhenNavigatingWithKeyboard) {
+        if (UserInterface.isNavigatingWithKeyboard() && focusFirstWhenNavigatingWithKeyboard) {
             // When we're in the keyboard navigation mode, we want to have the
             // first focusable component to be focused straight away, without the
             // necessity to press Tab.

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -18,7 +18,7 @@ import UserInterface from '../../native-common/UserInterface';
 
 const isNativeWindows: boolean = Platform.getType() === 'windows';
 
-let _isNavigatingWithKeyboard: boolean;
+let _isNavigatingWithKeyboard: boolean = UserInterface.isNavigatingWithKeyboard();
 
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
     _isNavigatingWithKeyboard = isNavigatingWithKeyboard;

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -18,11 +18,12 @@ import UserInterface from '../../native-common/UserInterface';
 
 const isNativeWindows: boolean = Platform.getType() === 'windows';
 
-let _isNavigatingWithKeyboard: boolean = UserInterface.isNavigatingWithKeyboard();
+let _isNavigatingWithKeyboard: boolean;
 
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
     _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 });
+_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
 
 import { FocusableComponentStateCallback } from  '../../common/utils/FocusManager';
 export { FocusableComponentStateCallback };

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -41,13 +41,6 @@ const _styles = {
 const _longPressTime = 1000;
 const _defaultAccessibilityTrait = Types.AccessibilityTrait.Button;
 
-let _isNavigatingWithKeyboard: boolean;
-
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
-
 export interface ButtonContext {
     hasRxButtonAscendant?: boolean;
     focusArbitrator?: FocusArbitratorProvider;
@@ -250,7 +243,7 @@ export class Button extends ButtonBase {
     // When we get focus on an element, show the hover effect on the element.
     // This ensures that users using keyboard also get the similar experience as mouse users for accessibility.
     private _onFocus = (e: Types.FocusEvent) => {
-        this._isFocusedWithKeyboard = _isNavigatingWithKeyboard;
+        this._isFocusedWithKeyboard = UserInterface.isNavigatingWithKeyboard();
         this._onHoverStart(e);
 
         if (this.props.onFocus) {

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -41,7 +41,7 @@ const _styles = {
 const _longPressTime = 1000;
 const _defaultAccessibilityTrait = Types.AccessibilityTrait.Button;
 
-let _isNavigatingWithKeyboard = false;
+let _isNavigatingWithKeyboard: boolean = UserInterface.isNavigatingWithKeyboard();
 
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
     _isNavigatingWithKeyboard = isNavigatingWithKeyboard;

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -41,11 +41,12 @@ const _styles = {
 const _longPressTime = 1000;
 const _defaultAccessibilityTrait = Types.AccessibilityTrait.Button;
 
-let _isNavigatingWithKeyboard: boolean = UserInterface.isNavigatingWithKeyboard();
+let _isNavigatingWithKeyboard: boolean;
 
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
     _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 });
+_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
 
 export interface ButtonContext {
     hasRxButtonAscendant?: boolean;

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -117,6 +117,13 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         // Initialize the root FocusManager which is aware of all
         // focusable elements.
         this._focusManager = new FocusManager(undefined);
+
+        // Keep current state in sync with the truth in UserInterface, to keep the code consistent with
+        // the native counterpart that supports multiple root views.
+        UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
+            this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+        });
+        this._isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
     }
 
     getChildContext() {

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -89,15 +89,6 @@ if (typeof document !== 'undefined') {
     document.head.appendChild(style);
 }
 
-let _isNavigatingWithKeyboard: boolean;
-
-// Keep current state in sync with the truth in UserInterface, to keep the code consistent with
-// the native counterpart that supports multiple root views.
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
-
 export class RootView extends React.Component<RootViewProps, RootViewState> {
     static childContextTypes: React.ValidationMap<any> = {
         focusManager: PropTypes.object
@@ -450,7 +441,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                 return;
             }
 
-            if (!_isNavigatingWithKeyboard && curShouldEnable) {
+            if (!UserInterface.isNavigatingWithKeyboard() && curShouldEnable) {
                 this._updateKeyboardNavigationState(true);
             }
         }, 0);
@@ -487,9 +478,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
             this._isNavigatingWithKeyboardUpateTimer = undefined;
         }
 
-        if (_isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
-            _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-
+        if (UserInterface.isNavigatingWithKeyboard() !== isNavigatingWithKeyboard) {
             UserInterface.keyboardNavigationEvent.fire(isNavigatingWithKeyboard);
 
             const focusClass = isNavigatingWithKeyboard ? this.props.keyBoardFocusOutline : this.props.mouseFocusOutline;

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -89,6 +89,15 @@ if (typeof document !== 'undefined') {
     document.head.appendChild(style);
 }
 
+let _isNavigatingWithKeyboard: boolean;
+
+// Keep current state in sync with the truth in UserInterface, to keep the code consistent with
+// the native counterpart that supports multiple root views.
+UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
+    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+});
+_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
+
 export class RootView extends React.Component<RootViewProps, RootViewState> {
     static childContextTypes: React.ValidationMap<any> = {
         focusManager: PropTypes.object
@@ -100,7 +109,6 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
     private _clickHandlerInstalled = false;
     private _keyboardHandlerInstalled = false;
     private _focusManager: FocusManager;
-    private _isNavigatingWithKeyboard: boolean = false;
     private _isNavigatingWithKeyboardUpateTimer: number|undefined;
 
     private _shouldEnableKeyboardNavigationModeOnFocus = false;
@@ -117,13 +125,6 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
         // Initialize the root FocusManager which is aware of all
         // focusable elements.
         this._focusManager = new FocusManager(undefined);
-
-        // Keep current state in sync with the truth in UserInterface, to keep the code consistent with
-        // the native counterpart that supports multiple root views.
-        UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-            this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-        });
-        this._isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
     }
 
     getChildContext() {
@@ -449,7 +450,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                 return;
             }
 
-            if (!this._isNavigatingWithKeyboard && curShouldEnable) {
+            if (!_isNavigatingWithKeyboard && curShouldEnable) {
                 this._updateKeyboardNavigationState(true);
             }
         }, 0);
@@ -486,8 +487,8 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
             this._isNavigatingWithKeyboardUpateTimer = undefined;
         }
 
-        if (this._isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
-            this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
+        if (_isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
+            _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 
             UserInterface.keyboardNavigationEvent.fire(isNavigatingWithKeyboard);
 

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -19,7 +19,7 @@ import UserInterface from '../UserInterface';
 const ATTR_NAME_TAB_INDEX = 'tabindex';
 const ATTR_NAME_ARIA_HIDDEN = 'aria-hidden';
 
-let _isNavigatingWithKeyboard: boolean;
+let _isNavigatingWithKeyboard: boolean = UserInterface.isNavigatingWithKeyboard();
 let _isShiftPressed: boolean;
 
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -19,13 +19,7 @@ import UserInterface from '../UserInterface';
 const ATTR_NAME_TAB_INDEX = 'tabindex';
 const ATTR_NAME_ARIA_HIDDEN = 'aria-hidden';
 
-let _isNavigatingWithKeyboard: boolean;
 let _isShiftPressed: boolean;
-
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
 
 import {
     applyFocusableComponentMixin as applyFocusableComponentMixinCommon,
@@ -60,7 +54,7 @@ export class FocusManager extends FocusManagerBase {
         });
 
         document.body.addEventListener('focusout', event => {
-            if (!_isNavigatingWithKeyboard || (event.target === document.body)) {
+            if (!UserInterface.isNavigatingWithKeyboard() || (event.target === document.body)) {
                 return;
             }
 
@@ -79,7 +73,7 @@ export class FocusManager extends FocusManagerBase {
             _checkFocusTimer = setTimeout(() => {
                 _checkFocusTimer = undefined;
 
-                if (_isNavigatingWithKeyboard &&
+                if (UserInterface.isNavigatingWithKeyboard() &&
                         (!FocusManager._currentFocusedComponent || !FocusManager._currentFocusedComponent.removed) &&
                         (!document.activeElement || (document.activeElement === document.body))) {
                     // This should work for Electron and the browser should
@@ -181,7 +175,7 @@ export class FocusManager extends FocusManagerBase {
             FocusManager._resetFocusTimer = undefined;
         }
 
-        if (_isNavigatingWithKeyboard && focusFirstWhenNavigatingWithKeyboard) {
+        if (UserInterface.isNavigatingWithKeyboard() && focusFirstWhenNavigatingWithKeyboard) {
             // When we're in the keyboard navigation mode, we want to have the
             // first focusable component to be focused straight away, without the
             // necessity to press Tab.

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -19,12 +19,13 @@ import UserInterface from '../UserInterface';
 const ATTR_NAME_TAB_INDEX = 'tabindex';
 const ATTR_NAME_ARIA_HIDDEN = 'aria-hidden';
 
-let _isNavigatingWithKeyboard: boolean = UserInterface.isNavigatingWithKeyboard();
+let _isNavigatingWithKeyboard: boolean;
 let _isShiftPressed: boolean;
 
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
     _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 });
+_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
 
 import {
     applyFocusableComponentMixin as applyFocusableComponentMixinCommon,

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -22,13 +22,6 @@ const KEY_CODE_SPACE = 32;
 const DOWN_KEYCODES = [KEY_CODE_SPACE, KEY_CODE_ENTER];
 const UP_KEYCODES = [KEY_CODE_SPACE];
 
-let _isNavigatingWithKeyboard: boolean;
-
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-   _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
-
 let FocusableAnimatedView = RNW.createFocusableComponent(RN.Animated.View);
 
 export interface ButtonContext extends ButtonContextBase {
@@ -175,7 +168,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
             this.onFocus();
         }
 
-        this._isFocusedWithKeyboard = _isNavigatingWithKeyboard;
+        this._isFocusedWithKeyboard = UserInterface.isNavigatingWithKeyboard();
         this._onHoverStart(e);
 
         if (this.props.onFocus) {

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -22,11 +22,12 @@ const KEY_CODE_SPACE = 32;
 const DOWN_KEYCODES = [KEY_CODE_SPACE, KEY_CODE_ENTER];
 const UP_KEYCODES = [KEY_CODE_SPACE];
 
-let _isNavigatingWithKeyboard: boolean = UserInterface.isNavigatingWithKeyboard();
+let _isNavigatingWithKeyboard: boolean;
 
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
 });
+_isNavigatingWithKeyboard = UserInterface.isNavigatingWithKeyboard();
 
 let FocusableAnimatedView = RNW.createFocusableComponent(RN.Animated.View);
 
@@ -98,7 +99,6 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
 
     focus() {
         if (this._focusableElement && this._focusableElement.focus) {
-            console.trace();
             this._focusableElement.focus();
         }
 

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -22,7 +22,7 @@ const KEY_CODE_SPACE = 32;
 const DOWN_KEYCODES = [KEY_CODE_SPACE, KEY_CODE_ENTER];
 const UP_KEYCODES = [KEY_CODE_SPACE];
 
-let _isNavigatingWithKeyboard = false;
+let _isNavigatingWithKeyboard: boolean = UserInterface.isNavigatingWithKeyboard();
 
 UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
@@ -98,6 +98,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
 
     focus() {
         if (this._focusableElement && this._focusableElement.focus) {
+            console.trace();
             this._focusableElement.focus();
         }
 


### PR DESCRIPTION
1. Propagate "isNavigatingWithKeyboard" across all RootView instances. The flag is global, the truth is in UserInterface instance, and RootView instances continue to drive the changes as before.
2. Fixed the initializing of  "isNavigatingWithKeyboard" when subscribing to changes.
3. Removed some dev logging conflicting with the advertised support of multiple root views.