### PR TITLE
Focus tweaks for UWP (#649)

### DIFF
--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -278,6 +278,9 @@ declare module 'react-native' {
         onMouseLeave?: Function;
         onMouseOver?: Function;
         onMouseMove?: Function;
+
+        // Windows
+        tabNavigation?: 'local' | 'cycle' | 'once';
     }
 
     interface ScrollViewProps extends ViewProps {

--- a/src/windows/ReactXP.ts
+++ b/src/windows/ReactXP.ts
@@ -41,7 +41,7 @@ import ScrollViewImpl from './ScrollView';
 import StatusBarImpl from './StatusBar';
 import StorageImpl from '../native-common/Storage';
 import StylesImpl from '../native-common/Styles';
-import TextImpl from '../native-common/Text';
+import TextImpl from './Text';
 import TextInputImpl from './TextInput';
 import UserInterfaceImpl from '../native-common/UserInterface';
 import UserPresenceImpl from '../native-common/UserPresence';
@@ -128,7 +128,8 @@ module ReactXP {
     const windowsAnimatedClasses =  {
         ...CommonAnimatedClasses,
         View: RN.Animated.createAnimatedComponent(ViewImpl),
-        TextInput:  RN.Animated.createAnimatedComponent(TextInputImpl)
+        TextInput:  RN.Animated.createAnimatedComponent(TextInputImpl),
+        Text:  RN.Animated.createAnimatedComponent(TextImpl)
     };
 
     export const Animated = makeAnimated(windowsAnimatedClasses, true);

--- a/src/windows/Text.tsx
+++ b/src/windows/Text.tsx
@@ -1,0 +1,18 @@
+/**
+* Text.tsx
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license.
+*
+* RN Windows-specific implementation of the cross-platform Text abstraction.
+*/
+
+import { Text as TextBase } from '../native-common/Text';
+
+export class Text extends TextBase {
+    requestFocus() {
+        // UWP doesn't support casually focusing RN.Text elements. We override requestFocus in order to drop any focus requests
+    }
+}
+
+export default Text;


### PR DESCRIPTION
* RX.Text can't get focus, period.

* RX.View with no tabIndex is not focusable

* Make View.tsx work with new tabNavigation Windows-only property

(cherry picked from commit 4f7263bbd207f17bb5462d1c796a16e68a1675e8)