### PR TITLE
Fix  "isNavigatingWithKeyboard" for the multi root-view case (#652)

### DIFF
--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -51,8 +51,6 @@ export interface StoredFocusableComponent {
 export type FocusableComponentStateCallback = (restrictedOrLimited: boolean) => void;
 
 export abstract class FocusManager {
-    private static _rootFocusManager: FocusManager;
-
     private static _restrictionStack: FocusManager[] = [];
     protected static _currentRestrictionOwner: FocusManager|undefined;
     private static _restoreRestrictionTimer: number|undefined;
@@ -69,15 +67,7 @@ export abstract class FocusManager {
     protected _myFocusableComponentIds: { [id: string]: boolean } = {};
 
     constructor(parent: FocusManager|undefined) {
-        if (parent) {
-            this._parent = parent;
-        } else if (FocusManager._rootFocusManager) {
-            if (AppConfig.isDevelopmentMode()) {
-                console.error('FocusManager: root is already set');
-            }
-        } else {
-            FocusManager._rootFocusManager = this;
-        }
+        this._parent = parent;
     }
 
     protected abstract /* static */ addFocusListenerOnComponent(component: FocusableComponentInternal, onFocus: () => void): void;

--- a/src/native-desktop/RootView.tsx
+++ b/src/native-desktop/RootView.tsx
@@ -47,7 +47,6 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
 
         _focusManager: FocusManager;
         _keyboardHandlerInstalled = false;
-        _isNavigatingWithKeyboard: boolean = false;
         _isNavigatingWithKeyboardUpateTimer: number | undefined;
 
         constructor(...args: any[]) {
@@ -92,9 +91,7 @@ function applyDesktopBehaviorMixin<TRootViewBase extends Constructor<React.Compo
                 this._isNavigatingWithKeyboardUpateTimer = undefined;
             }
 
-            if (this._isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
-                this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-
+            if (UserInterface.isNavigatingWithKeyboard() !== isNavigatingWithKeyboard) {
                 UserInterface.keyboardNavigationEvent.fire(isNavigatingWithKeyboard);
             }
         }

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -18,12 +18,6 @@ import UserInterface from '../../native-common/UserInterface';
 
 const isNativeWindows: boolean = Platform.getType() === 'windows';
 
-let _isNavigatingWithKeyboard: boolean;
-
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-
 import { FocusableComponentStateCallback } from  '../../common/utils/FocusManager';
 export { FocusableComponentStateCallback };
 
@@ -100,7 +94,7 @@ export class FocusManager extends FocusManagerBase {
             FocusManager._resetFocusTimer = undefined;
         }
 
-        if (_isNavigatingWithKeyboard && focusFirstWhenNavigatingWithKeyboard) {
+        if (UserInterface.isNavigatingWithKeyboard() && focusFirstWhenNavigatingWithKeyboard) {
             // When we're in the keyboard navigation mode, we want to have the
             // first focusable component to be focused straight away, without the
             // necessity to press Tab.

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -41,12 +41,6 @@ const _styles = {
 const _longPressTime = 1000;
 const _defaultAccessibilityTrait = Types.AccessibilityTrait.Button;
 
-let _isNavigatingWithKeyboard = false;
-
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-
 export interface ButtonContext {
     hasRxButtonAscendant?: boolean;
     focusArbitrator?: FocusArbitratorProvider;
@@ -249,7 +243,7 @@ export class Button extends ButtonBase {
     // When we get focus on an element, show the hover effect on the element.
     // This ensures that users using keyboard also get the similar experience as mouse users for accessibility.
     private _onFocus = (e: Types.FocusEvent) => {
-        this._isFocusedWithKeyboard = _isNavigatingWithKeyboard;
+        this._isFocusedWithKeyboard = UserInterface.isNavigatingWithKeyboard();
         this._onHoverStart(e);
 
         if (this.props.onFocus) {

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -100,7 +100,6 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
     private _clickHandlerInstalled = false;
     private _keyboardHandlerInstalled = false;
     private _focusManager: FocusManager;
-    private _isNavigatingWithKeyboard: boolean = false;
     private _isNavigatingWithKeyboardUpateTimer: number|undefined;
 
     private _shouldEnableKeyboardNavigationModeOnFocus = false;
@@ -442,7 +441,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
                 return;
             }
 
-            if (!this._isNavigatingWithKeyboard && curShouldEnable) {
+            if (!UserInterface.isNavigatingWithKeyboard() && curShouldEnable) {
                 this._updateKeyboardNavigationState(true);
             }
         }, 0);
@@ -479,9 +478,7 @@ export class RootView extends React.Component<RootViewProps, RootViewState> {
             this._isNavigatingWithKeyboardUpateTimer = undefined;
         }
 
-        if (this._isNavigatingWithKeyboard !== isNavigatingWithKeyboard) {
-            this._isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-
+        if (UserInterface.isNavigatingWithKeyboard() !== isNavigatingWithKeyboard) {
             UserInterface.keyboardNavigationEvent.fire(isNavigatingWithKeyboard);
 
             const focusClass = isNavigatingWithKeyboard ? this.props.keyBoardFocusOutline : this.props.mouseFocusOutline;

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -19,12 +19,7 @@ import UserInterface from '../UserInterface';
 const ATTR_NAME_TAB_INDEX = 'tabindex';
 const ATTR_NAME_ARIA_HIDDEN = 'aria-hidden';
 
-let _isNavigatingWithKeyboard: boolean;
 let _isShiftPressed: boolean;
-
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-    _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
 
 import {
     applyFocusableComponentMixin as applyFocusableComponentMixinCommon,
@@ -59,7 +54,7 @@ export class FocusManager extends FocusManagerBase {
         });
 
         document.body.addEventListener('focusout', event => {
-            if (!_isNavigatingWithKeyboard || (event.target === document.body)) {
+            if (!UserInterface.isNavigatingWithKeyboard() || (event.target === document.body)) {
                 return;
             }
 
@@ -78,7 +73,7 @@ export class FocusManager extends FocusManagerBase {
             _checkFocusTimer = setTimeout(() => {
                 _checkFocusTimer = undefined;
 
-                if (_isNavigatingWithKeyboard &&
+                if (UserInterface.isNavigatingWithKeyboard() &&
                         (!FocusManager._currentFocusedComponent || !FocusManager._currentFocusedComponent.removed) &&
                         (!document.activeElement || (document.activeElement === document.body))) {
                     // This should work for Electron and the browser should
@@ -180,7 +175,7 @@ export class FocusManager extends FocusManagerBase {
             FocusManager._resetFocusTimer = undefined;
         }
 
-        if (_isNavigatingWithKeyboard && focusFirstWhenNavigatingWithKeyboard) {
+        if (UserInterface.isNavigatingWithKeyboard() && focusFirstWhenNavigatingWithKeyboard) {
             // When we're in the keyboard navigation mode, we want to have the
             // first focusable component to be focused straight away, without the
             // necessity to press Tab.

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -22,12 +22,6 @@ const KEY_CODE_SPACE = 32;
 const DOWN_KEYCODES = [KEY_CODE_SPACE, KEY_CODE_ENTER];
 const UP_KEYCODES = [KEY_CODE_SPACE];
 
-let _isNavigatingWithKeyboard = false;
-
-UserInterface.keyboardNavigationEvent.subscribe(isNavigatingWithKeyboard => {
-   _isNavigatingWithKeyboard = isNavigatingWithKeyboard;
-});
-
 let FocusableAnimatedView = RNW.createFocusableComponent(RN.Animated.View);
 
 export interface ButtonContext extends ButtonContextBase {
@@ -174,7 +168,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
             this.onFocus();
         }
 
-        this._isFocusedWithKeyboard = _isNavigatingWithKeyboard;
+        this._isFocusedWithKeyboard = UserInterface.isNavigatingWithKeyboard();
         this._onHoverStart(e);
 
         if (this.props.onFocus) {


### PR DESCRIPTION
* Fix initial values for some _isNavigatingWithKeyboard variables

* Made isNavigatingWithKeyboard multi root view aware

* Remove the single root check from FocusManager

* Better subscription lifetime to avoid leaks

* Simplifying to a pull model

(cherry picked from commit 7a7ca9467241541e257abec103b85b31065c0a97)