### PR TITLE
Added getMetadata image API

### DIFF
--- a/docs/docs/components/image.md
+++ b/docs/docs/components/image.md
@@ -70,7 +70,7 @@ getNativeWidth(): number;
 prefetch(url: string): Promise<boolean>;
 
 // Similarly to [prefetch], this method loads a remote image and stores it in
-// a cache. If prefetching was succesfull it will also get image dimensions. It will be
+// a cache. If prefetching was successful it will also get image dimensions. It will be
 // useful if you need [getNativeHeight] or [getNativeWidth] after image
 // was loaded because you will get this info together with prefetching and before
 // you actually need to show the image.

--- a/docs/docs/components/image.md
+++ b/docs/docs/components/image.md
@@ -68,4 +68,11 @@ getNativeWidth(): number;
 // image only has to be fetched from the local cache rather than over the
 // network.
 prefetch(url: string): Promise<boolean>;
+
+// Similarly to [prefetch], this method loads a remote image and stores it in
+// a cache. If prefetching was succesfull it will also get image dimensions. It will be
+// useful if you need [getNativeHeight] or [getNativeWidth] after image
+// was loaded because you will get this info together with prefetching and before
+// you actually need to show the image.
+getMetadata(url: string): Promise<ImageMetadata>
 ```

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -535,6 +535,11 @@ export interface ImageProps extends ImagePropsShared {
     style?: StyleRuleSetRecursive<ImageStyleRuleSet>;
 }
 
+export interface ImageMetadata {
+    width: number;
+    height: number;
+}
+
 export interface AnimatedImageProps extends ImagePropsShared {
     style?: StyleRuleSetRecursive<AnimatedImageStyleRuleSet | ImageStyleRuleSet>;
 }

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -51,7 +51,7 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
 
         Image.prefetch(url).then(success => {
             if (!success) {
-                defer.reject('Prefetching url ' + url + ' not succeeded.');
+                defer.reject('Prefetching url ' + url + ' did not succeed.');
             } else {
                 RN.Image.getSize(url, (width, height) => {
                     defer.resolve({

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -46,6 +46,29 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
         return defer.promise();
     }
 
+    static getMetadata(url: string): SyncTasks.Promise<Types.ImageMetadata> {
+        const defer = SyncTasks.Defer<Types.ImageMetadata>();
+
+        Image.prefetch(url).then(success => {
+            if (!success) {
+                defer.reject('Prefetching url ' + url + ' not succeeded.');
+            } else {
+                RN.Image.getSize(url, (width, height) => {
+                    defer.resolve({
+                        width: width,
+                        height: height
+                    });
+                }, error => {
+                    defer.reject(error);
+                });
+            }
+        }).catch((error: any) => {
+            defer.reject(error);
+        });
+
+        return defer.promise();
+    }
+
     protected _mountedComponent: RN.ReactNativeBaseComponent<any, any>|null = null;
     private _nativeImageWidth: number|undefined;
     private _nativeImageHeight: number|undefined;

--- a/src/typings/react-native.d.ts
+++ b/src/typings/react-native.d.ts
@@ -505,6 +505,7 @@ declare module 'react-native' {
 
     class Image extends ReactNativeBaseComponent<ImageProperties, {}> {
         static prefetch(url: string): Promise<boolean>;
+        static getSize(uri: string, success: (width: number, height: number) => void, failure: (error: any) => void): any;
     }
     class ActivityIndicator extends ReactNativeBaseComponent<ActivityIndicatorProps, {}> { }
     class Text extends ReactNativeBaseComponent<TextProps, {}> { }

--- a/src/web/Image.tsx
+++ b/src/web/Image.tsx
@@ -154,6 +154,30 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         return defer.promise();
     }
 
+    static getMetadata(url: string): SyncTasks.Promise<Types.ImageMetadata> {
+        const defer = SyncTasks.Defer<Types.ImageMetadata>();
+
+        const img = new (window as any).Image();
+        img.src = url;
+
+        img.onload = ((event: Event) => {
+            defer.resolve({
+                width: img.naturalWidth,
+                height: img.naturalHeight
+            });
+        });
+
+        img.onerror = ((event: Event) => {
+            defer.reject('Failed to prefetch url ' + url);
+        });
+
+        img.onabort = ((event: Event) => {
+            defer.reject('Prefetch cancelled for url ' + url);
+        });
+
+        return defer.promise();
+    }
+
     private _isMounted = false;
     private _nativeImageWidth: number|undefined;
     private _nativeImageHeight: number|undefined;

--- a/src/web/Image.tsx
+++ b/src/web/Image.tsx
@@ -137,7 +137,6 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         const defer = SyncTasks.Defer<boolean>();
 
         const img = new (window as any).Image();
-        img.src = url;
 
         img.onload = ((event: Event) => {
             defer.resolve(true);
@@ -150,6 +149,7 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         img.onabort = ((event: Event) => {
             defer.reject('Prefetch cancelled for url ' + url);
         });
+        img.src = url;
 
         return defer.promise();
     }
@@ -158,7 +158,6 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         const defer = SyncTasks.Defer<Types.ImageMetadata>();
 
         const img = new (window as any).Image();
-        img.src = url;
 
         img.onload = ((event: Event) => {
             defer.resolve({
@@ -174,6 +173,7 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         img.onabort = ((event: Event) => {
             defer.reject('Prefetch cancelled for url ' + url);
         });
+        img.src = url;
 
         return defer.promise();
     }


### PR DESCRIPTION
Added new Image API method that exposes RN.Image.getSize. It allows to prefetch image and get imageInfo (currently only dimensions) without extra call.