### PR TITLE
Extend UserInterface.measureWindow to support optional rootViewId param

### DIFF
--- a/docs/docs/apis/userinterface.md
+++ b/docs/docs/apis/userinterface.md
@@ -46,11 +46,12 @@ measureLayoutRelativeToWindow(component: React.Component<any, any>):
 measureLayoutRelativeToAncestor(component: React.Component<any, any>,
     ancestor: React.Component<any, any>): SyncTasks.Promise<LayoutInfo>;
 
-// Measures the dimension of the full window (or screen, in the case
+// Measures the dimension of window (based on specified root view id or 
+// defaults to main window or screen, in the case
 // of non-windowed platforms); the dimensions can also be obtained for any
 // view (including your app's top-level view) using the onLayout
 // callback
-measureWindow(): Types.Dimensions;
+measureWindow(rootViewId?: string): Types.Dimensions;
 
 // Measures the dimension of the specified root view window or defaults to
 // main window (or screen, in the case of non-windowed platforms);

--- a/docs/docs/apis/userinterface.md
+++ b/docs/docs/apis/userinterface.md
@@ -53,11 +53,6 @@ measureLayoutRelativeToAncestor(component: React.Component<any, any>,
 // callback
 measureWindow(rootViewId?: string): Types.Dimensions;
 
-// Measures the dimension of the specified root view window or defaults to
-// main window (or screen, in the case of non-windowed platforms);
-// Support measuring for platforms with multi window (UWP)
-measureRootViewWindow(rootViewId: string | undefined): Types.Dimensions;
-
 // Indicates the "size multiplier" for text increase or decrease, which
 // can be adjusted by users on some platforms; defaults to 1.0
 getContentSizeMultiplier(): SyncTasks.Promise<number>;

--- a/docs/docs/apis/userinterface.md
+++ b/docs/docs/apis/userinterface.md
@@ -52,6 +52,11 @@ measureLayoutRelativeToAncestor(component: React.Component<any, any>,
 // callback
 measureWindow(): Types.Dimensions;
 
+// Measures the dimension of the specified root view window or defaults to
+// main window (or screen, in the case of non-windowed platforms);
+// Support measuring for platforms with multi window (UWP)
+measureRootViewWindow(rootViewId: string | undefined): Types.Dimensions;
+
 // Indicates the "size multiplier" for text increase or decrease, which
 // can be adjusted by users on some platforms; defaults to 1.0
 getContentSizeMultiplier(): SyncTasks.Promise<number>;

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -75,6 +75,7 @@ export abstract class UserInterface {
     abstract measureLayoutRelativeToAncestor(component: React.Component<any, any>,
         ancestor: React.Component<any, any>): SyncTasks.Promise<Types.LayoutInfo>;
     abstract measureWindow(): Types.Dimensions;
+    abstract measureRootViewWindow(rootViewId: string | undefined): Types.Dimensions;
 
     // Content Size Multiplier
     abstract getContentSizeMultiplier(): SyncTasks.Promise<number>;

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -74,8 +74,7 @@ export abstract class UserInterface {
         SyncTasks.Promise<Types.LayoutInfo>;
     abstract measureLayoutRelativeToAncestor(component: React.Component<any, any>,
         ancestor: React.Component<any, any>): SyncTasks.Promise<Types.LayoutInfo>;
-    abstract measureWindow(): Types.Dimensions;
-    abstract measureRootViewWindow(rootViewId: string | undefined): Types.Dimensions;
+    abstract measureWindow(rootViewId?: string): Types.Dimensions;
 
     // Content Size Multiplier
     abstract getContentSizeMultiplier(): SyncTasks.Promise<number>;

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -17,6 +17,7 @@ import RN = require('react-native');
 import International from './International';
 import Types = require('../common/Types');
 import { PopupContainerViewBase, PopupContainerViewBaseProps, PopupContainerViewContext } from '../common/PopupContainerViewBase';
+import UserInterface = require('./UserInterface');
 
 // Width of the "alley" around popups so they don't get too close to the boundary of the screen boundary.
 const ALLEY_WIDTH = 2;
@@ -204,8 +205,9 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
             newState.constrainedPopupHeight = newState.popupHeight;
             newState.constrainedPopupWidth = newState.popupWidth;
 
-            // Get the width/height of the full window.
-            let window = RN.Dimensions.get('window');
+            // Get the width/height of root view window.
+            let window = UserInterface.default.measureRootViewWindow(this.props.popupOptions.rootViewId);
+
             let windowWidth = window.width;
             let windowHeight = window.height;
 

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -17,7 +17,7 @@ import RN = require('react-native');
 import International from './International';
 import Types = require('../common/Types');
 import { PopupContainerViewBase, PopupContainerViewBaseProps, PopupContainerViewContext } from '../common/PopupContainerViewBase';
-import UserInterface = require('./UserInterface');
+import UserInterface from './UserInterface';
 
 // Width of the "alley" around popups so they don't get too close to the boundary of the screen boundary.
 const ALLEY_WIDTH = 2;
@@ -206,7 +206,7 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
             newState.constrainedPopupWidth = newState.popupWidth;
 
             // Get the width/height of root view window.
-            let window = UserInterface.default.measureRootViewWindow(this.props.popupOptions.rootViewId);
+            let window = UserInterface.measureRootViewWindow(this.props.popupOptions.rootViewId);
 
             let windowWidth = window.width;
             let windowHeight = window.height;

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -206,7 +206,7 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
             newState.constrainedPopupWidth = newState.popupWidth;
 
             // Get the width/height of root view window.
-            let window = UserInterface.measureRootViewWindow(this.props.popupOptions.rootViewId);
+            let window = UserInterface.measureWindow(this.props.popupOptions.rootViewId);
 
             let windowWidth = window.width;
             let windowHeight = window.height;

--- a/src/native-common/UserInterface.tsx
+++ b/src/native-common/UserInterface.tsx
@@ -85,6 +85,27 @@ export class UserInterface extends RX.UserInterface {
         };
     }
 
+    measureRootViewWindow(rootViewId: string | undefined): Types.LayoutInfo {
+        let dimensions = RN.Dimensions.get('window');
+
+        if (rootViewId && RN.Platform.OS === 'windows') {
+            try {
+                dimensions = RN.Dimensions.get(rootViewId);
+            } catch (e) {
+                // Can happen if RNW doesn't support multi view dimensions tracking yet
+                console.warn('Couldn\'t get dimensions for rootViewId ' + rootViewId +
+                 ' check if RNW already supports multi view dimensions tracking');
+            }
+        }
+
+        return {
+            x: 0,
+            y: 0,
+            width: dimensions.width,
+            height: dimensions.height
+        };
+    }
+
     getContentSizeMultiplier(): SyncTasks.Promise<number> {
         let deferred = SyncTasks.Defer<number>();
 

--- a/src/native-common/UserInterface.tsx
+++ b/src/native-common/UserInterface.tsx
@@ -75,17 +75,7 @@ export class UserInterface extends RX.UserInterface {
         return deferred.promise();
     }
 
-    measureWindow(): Types.LayoutInfo {
-        const dimensions = RN.Dimensions.get('window');
-        return {
-            x: 0,
-            y: 0,
-            width: dimensions.width,
-            height: dimensions.height
-        };
-    }
-
-    measureRootViewWindow(rootViewId: string | undefined): Types.LayoutInfo {
+    measureWindow(rootViewId?: string): Types.LayoutInfo {
         let dimensions = RN.Dimensions.get('window');
 
         if (rootViewId && RN.Platform.OS === 'windows') {

--- a/src/web/UserInterface.ts
+++ b/src/web/UserInterface.ts
@@ -82,6 +82,11 @@ export class UserInterface extends RX.UserInterface {
         };
     }
 
+    measureRootViewWindow(rootViewId: string | undefined): Types.LayoutInfo {
+        // Mo multi window support, default to main window
+        return this.measureWindow();
+    }
+
     getContentSizeMultiplier(): SyncTasks.Promise<number> {
         // Browsers don't support font-specific scaling. They scale all of their
         // UI elements the same.

--- a/src/web/UserInterface.ts
+++ b/src/web/UserInterface.ts
@@ -73,18 +73,14 @@ export class UserInterface extends RX.UserInterface {
         return deferred.promise();
     }
 
-    measureWindow(): Types.LayoutInfo {
+    measureWindow(rootViewId?: string): Types.LayoutInfo {
+        // Mo multi window support, default to main window
         return {
             x: 0,
             y: 0,
             width: window.innerWidth,
             height: window.innerHeight
         };
-    }
-
-    measureRootViewWindow(rootViewId: string | undefined): Types.LayoutInfo {
-        // Mo multi window support, default to main window
-        return this.measureWindow();
     }
 
     getContentSizeMultiplier(): SyncTasks.Promise<number> {


### PR DESCRIPTION
Extend UserInterface with measureRootViewWindow and start using it in PopupContainerView to properly support multi window scenario on windows (UWP)