### PR TITLE
More windows fixes to address focus manager updates and RNW.Hyperlink peculiarities

### DIFF
--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -309,7 +309,7 @@ export abstract class FocusManager {
         this.removeFocusLimitation();
     }
 
-    subscribe(component: FocusableComponentInternal, callback: FocusableComponentStateCallback) {
+    static subscribe(component: FocusableComponentInternal, callback: FocusableComponentStateCallback) {
         const storedComponent = FocusManager._getStoredComponent(component);
 
         if (storedComponent) {
@@ -321,7 +321,7 @@ export abstract class FocusManager {
         }
     }
 
-    unsubscribe(component: FocusableComponentInternal, callback: FocusableComponentStateCallback) {
+    static unsubscribe(component: FocusableComponentInternal, callback: FocusableComponentStateCallback) {
         const storedComponent = FocusManager._getStoredComponent(component);
 
         if (storedComponent && storedComponent.callbacks) {
@@ -335,7 +335,7 @@ export abstract class FocusManager {
         this._restrictionStateCallback = callback;
     }
 
-    isComponentFocusRestrictedOrLimited(component: FocusableComponentInternal): boolean {
+    static isComponentFocusRestrictedOrLimited(component: FocusableComponentInternal): boolean {
         const storedComponent = FocusManager._getStoredComponent(component);
         return !!storedComponent &&
             (storedComponent.restricted || storedComponent.limitedCount > 0 || storedComponent.limitedCountAccessible > 0);

--- a/src/native-common/Link.tsx
+++ b/src/native-common/Link.tsx
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * Link.tsx
 *
 * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -23,7 +23,7 @@ export interface LinkContext {
     isRxParentAText?: boolean;
 }
 
-export class Link extends React.Component<Types.LinkProps, {}> {
+export class LinkBase<S> extends React.Component<Types.LinkProps, S> {
     static contextTypes = {
         focusArbitrator: PropTypes.object,
         isRxParentAText: PropTypes.bool
@@ -126,6 +126,10 @@ export class Link extends React.Component<Types.LinkProps, {}> {
     blur() {
         // No-op
     }
+}
+
+export class Link extends LinkBase<{}> {
+
 }
 
 export default Link;

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -116,11 +116,13 @@ export class FocusManager extends FocusManagerBase {
     }
 
     protected /* static */ _updateComponentFocusRestriction(storedComponent: StoredFocusableComponent) {
-        if ((storedComponent.restricted || (storedComponent.limitedCount > 0)) && !('origTabIndex' in storedComponent)) {
+        if ((storedComponent.restricted || (storedComponent.limitedCount > 0) || (storedComponent.limitedCountAccessible > 0))
+            && !('origTabIndex' in storedComponent)) {
             storedComponent.origTabIndex = FocusManager._setComponentTabIndexOverride(
                 storedComponent.component as FocusableComponentInternal, -1);
             FocusManager._callFocusableComponentStateChangeCallbacks(storedComponent, true);
-        } else if (!storedComponent.restricted && !storedComponent.limitedCount && ('origTabIndex' in storedComponent)) {
+        } else if (!storedComponent.restricted && !storedComponent.limitedCount && !storedComponent.limitedCountAccessible
+            && ('origTabIndex' in storedComponent)) {
             FocusManager._removeComponentTabIndexOverride(storedComponent.component as FocusableComponentInternal);
             delete storedComponent.origTabIndex;
             FocusManager._callFocusableComponentStateChangeCallbacks(storedComponent, false);

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -10,10 +10,13 @@
 import React = require('react');
 import RN = require('react-native');
 import RNW = require('react-native-windows');
-import { applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
+import Types = require('../common/Types');
+
+import { applyFocusableComponentMixin, FocusManager, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
 
 import EventHelpers from '../native-common/utils/EventHelpers';
-import { Link as LinkCommon } from '../native-common/Link';
+import { FocusArbitratorProvider } from '../common/utils/AutoFocusHelper';
+import { LinkBase } from '../native-common/Link';
 
 const KEY_CODE_ENTER = 13;
 const KEY_CODE_SPACE = 32;
@@ -23,13 +26,51 @@ const UP_KEYCODES = [KEY_CODE_SPACE];
 
 let FocusableText = RNW.createFocusableComponent(RN.Text);
 
-export class Link extends LinkCommon implements FocusManagerFocusableComponent {
+export interface LinkState {
+    isRestrictedOrLimited: boolean;
+}
+
+export class Link extends LinkBase<LinkState> implements FocusManagerFocusableComponent {
+    constructor(props: Types.LinkProps) {
+        super(props);
+
+        this.state = {
+            isRestrictedOrLimited: false
+        };
+    }
+
+    componentDidMount() {
+        super.componentDidMount();
+        // Retrieve focus restriction state and subscribe for further changes.
+        // This is the earliest point this can be done since Focus Manager uses a pre-"componentDidMount" hook
+        // to connect to component instances
+        this.setState({
+            isRestrictedOrLimited: FocusManager.isComponentFocusRestrictedOrLimited(this)
+        });
+        FocusManager.subscribe(this, this._restrictedOrLimitedCallback);
+    }
+
+    componentWillUnmount() {
+        // This is for symmetry, but the callbacks have already been deleted by FocusManager since its
+        // hook executes first
+        FocusManager.subscribe(this, this._restrictedOrLimitedCallback);
+    }
+
+    private _restrictedOrLimitedCallback = (restrictedOrLimited: boolean): void => {
+        this.setState({
+            isRestrictedOrLimited: restrictedOrLimited
+        });
+    }
+
     protected _render(internalProps: RN.TextProps) {
         if (this.context && !this.context.isRxParentAText) {
+            // Standalone link. We use a keyboard focusable RN.Text
             return this._renderLinkAsFocusableText(internalProps);
-        } else if (RNW.HyperlinkWindows) {
+        } else if (RNW.HyperlinkWindows && !this.state.isRestrictedOrLimited) {
+            // Inline Link. We use a native Hyperlink inline if RNW supports it and element is not "focus restricted/limited"
             return this._renderLinkAsNativeHyperlink(internalProps);
         } else {
+            // Inline Link. We defer to base class (that uses a plain RN.Text) for the rest of the cases.
             return super._render(internalProps);
         }
     }
@@ -40,7 +81,7 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
             <FocusableText
                 { ...focusableTextProps }
             />
-        );    
+        );
     }
 
     private _focusableElement : RNW.FocusableWindows<RN.TextProps> | null = null;
@@ -74,7 +115,7 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
             onFocus: this._onFocus,
             onAccessibilityTap: this._onPress
         };
-        
+
         return focusableTextProps;
     }
 
@@ -124,6 +165,23 @@ export class Link extends LinkCommon implements FocusManagerFocusableComponent {
         } else {
             super.setNativeProps(nativeProps);
         }
+    }
+
+    requestFocus() {
+        FocusArbitratorProvider.requestFocus(
+            this,
+            () => this.focus(),
+            () => this._isAvailableToFocus()
+        );
+    }
+
+    private _isAvailableToFocus(): boolean {
+        if (this._focusableElement && this._focusableElement.focus) {
+            return true;
+        } else if (this._nativeHyperlinkElement && this._nativeHyperlinkElement.focus) {
+            return true;
+        }
+        return false;
     }
 
     private _onKeyDown = (e: React.SyntheticEvent<any>): void => {


### PR DESCRIPTION
- Render regular RN.Text if RX.Link is under a focus
restriction/limitation. This seems to be the only reliable way to
prevent the link from receiving keyboard focus.
- Fixed regression on applying tabIndex/isTabStop overrides by
accounting for the new limitedCountAccessible counter
- Made RX.Link advertise its focus capability to focus
arbitrator correctly.