### PR TITLE
Improved docs for usage of ImageSvg extension

### DIFF
--- a/docs/docs/extensions/imagesvg.md
+++ b/docs/docs/extensions/imagesvg.md
@@ -11,7 +11,7 @@ This component displays a vector image (SVG format), which can come from a local
 
 The path(s) are specified using the standard SVG string format. Paths must be specified in a nested SvgPath component instance. Multiple SvgPath children can be specified, each with different stroke and fill parameters.
 
-To install: ```npm install reactxp-imagesvg```
+To install: ```npm install reactxp-imagesvg``` or  ```yarn add reactxp-imagesvg```
 
 ## ImageSvg Props
 ``` javascript
@@ -68,17 +68,18 @@ No methods
 
 ## Sample Usage
 ``` javascript
+import { default as RXImageSvg, SvgPath as RXSvgPath, Types as SvgTypes } from 'reactxp-imagesvg';
+
 return (
-    <RX.ImageSvg
+    <RXImageSvg
         height={ 20 }
         width={ 20 }
-        style={ _styles.container }
     >
-        <RX.SvgPath
+        <RXSvgPath
             fillColor={ 'orange' }
             d={ 'M 0 0 h 20 v 20 z' }
         />
-    </RX.ImageSvg>
+    </RXImageSvg>
 );
 ```
 


### PR DESCRIPTION
The docs was not complete and little incorrect, when it comes to using it.

1) I added possibility to install via yarn

2) Change the tag syntax to the one in the original code

3) Added needed import, so the next developer has not to search for it.