### PR TITLE
Added screen reader support to FocusManager/Windows

### DIFF
--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -40,10 +40,6 @@ export interface StoredFocusableComponent {
     restricted: boolean;
     limitedCount: number;
     limitedCountAccessible: number;
-    origTabIndex?: number;
-    origAriaHidden?: string;
-    curTabIndex?: number;
-    curAriaHidden?: boolean;
     removed?: boolean;
     callbacks?: FocusableComponentStateCallback[];
 }

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -80,7 +80,7 @@ export abstract class FocusManager {
     // Whenever the focusable element is mounted, we let the application
     // know so that FocusManager could account for this element during the
     // focus restriction.
-    addFocusableComponent(component: FocusableComponentInternal, accessibleOnly?: boolean) {
+    addFocusableComponent(component: FocusableComponentInternal, accessibleOnly: boolean = false) {
         if (component.focusableComponentId) {
             return;
         }
@@ -92,7 +92,7 @@ export abstract class FocusManager {
             id: componentId,
             numericId: numericComponentId,
             component: component,
-            accessibleOnly: !!accessibleOnly,
+            accessibleOnly: accessibleOnly,
             restricted: false,
             limitedCount: 0,
             limitedCountAccessible: 0,

--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -387,7 +387,11 @@ export abstract class FocusManager {
 // isConditionallyFocusable is an optional callback which will be
 // called for componentDidMount() or for componentWillUpdate() to
 // determine if the component is actually focusable.
-export function applyFocusableComponentMixin(Component: any, isConditionallyFocusable?: Function, accessibleOnly?: boolean) {
+//
+// accessibleOnly is true for components that support just being focused
+// by screen readers.
+// By default components support both screen reader and keyboard focusing.
+export function applyFocusableComponentMixin(Component: any, isConditionallyFocusable?: Function, accessibleOnly: boolean = false) {
     let contextTypes = Component.contextTypes || {};
     contextTypes.focusManager = PropTypes.object;
     Component.contextTypes = contextTypes;

--- a/src/native-common/AccessibilityUtil.ts
+++ b/src/native-common/AccessibilityUtil.ts
@@ -12,7 +12,10 @@ import _ = require('./lodashMini');
 import React = require('react');
 import RN = require('react-native');
 
-import { AccessibilityUtil as CommonAccessibilityUtil, AccessibilityPlatformUtil } from '../common/AccessibilityUtil';
+import { AccessibilityUtil as CommonAccessibilityUtil,
+    AccessibilityPlatformUtil } from '../common/AccessibilityUtil';
+
+export { ImportantForAccessibilityValue } from '../common/AccessibilityUtil';
 
 import Types = require('../common/Types');
 

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * Text.tsx
 *
 * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -31,7 +31,7 @@ export interface TextContext {
 }
 
 export class Text extends React.Component<Types.TextProps, Types.Stateless> implements React.ChildContextProvider<TextContext> {
-    static contextTypes = {
+    static contextTypes: React.ValidationMap<any> = {
         focusArbitrator: PropTypes.object,
         isRxParentAContextMenuResponder: PropTypes.bool
     };

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -12,6 +12,7 @@ import { FocusManager as FocusManagerBase,
     applyFocusableComponentMixin as applyFocusableComponentMixinBase,
     StoredFocusableComponent as StoredFocusableComponentBase } from '../../common/utils/FocusManager';
 
+import { ImportantForAccessibilityValue } from '../../native-common/AccessibilityUtil';
 import AppConfig from '../../common/AppConfig';
 import Platform from '../../native-common/Platform';
 import UserInterface from '../../native-common/UserInterface';
@@ -36,6 +37,7 @@ export interface StoredFocusableComponent extends StoredFocusableComponentBase {
 
 export interface FocusManagerFocusableComponent {
     getTabIndex(): number | undefined;
+    getImportantForAccessibility(): ImportantForAccessibilityValue | undefined;
     onFocus(): void;
     focus(): void;
     updateNativeTabIndexAndIFA(): void;
@@ -217,6 +219,18 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
         } else if (this.tabIndexOverride !== undefined) {
             // Override available, use this one
             return this.tabIndexOverride;
+        } else {
+            // Override not available, defer to original handler to return the prop
+            return origCallback.call(this);
+        }
+    });
+
+    // Hook 'getImportantForAccessibility'
+    inheritMethod('getImportantForAccessibility', function (this: FocusableComponentInternal, origCallback: any) {
+        // Check local override first, then focus manager one
+        if (this.importantForAccessibilityOverride !== undefined) {
+            // Local override available, use this one
+            return this.importantForAccessibilityOverride;
         } else {
             // Override not available, defer to original handler to return the prop
             return origCallback.call(this);

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -40,7 +40,7 @@ export interface FocusManagerFocusableComponent {
     getImportantForAccessibility(): ImportantForAccessibilityValue | undefined;
     onFocus(): void;
     focus(): void;
-    updateNativeTabIndexAndIFA(): void;
+    updateNativeAccessibilityProps(): void;
 }
 
 export interface FocusableComponentInternal extends FocusManagerFocusableComponent, FocusableComponentInternalBase {
@@ -183,22 +183,22 @@ export class FocusManager extends FocusManagerBase {
         }
 
         // Refresh the native view
-        updateNativeTabIndexAndIFA(component);
+        updateNativeAccessibilityProps(component);
     }
 }
 
-function updateNativeTabIndexAndIFA(component: FocusableComponentInternal) {
+function updateNativeAccessibilityProps(component: FocusableComponentInternal) {
     // Call special method on component avoiding state changes/re-renderings
-    if (component.updateNativeTabIndexAndIFA) {
-        component.updateNativeTabIndexAndIFA();
+    if (component.updateNativeAccessibilityProps) {
+        component.updateNativeAccessibilityProps();
     } else {
         if (AppConfig.isDevelopmentMode()) {
-            console.error('FocusableComponentMixin: updateNativeTabIndexAndIFA doesn\'t exist!');
+            console.error('FocusableComponentMixin: updateNativeAccessibilityProps doesn\'t exist!');
         }
     }
 }
 
-export function applyFocusableComponentMixin(Component: any, isConditionallyFocusable?: Function, accessibleOnly?: boolean) {
+export function applyFocusableComponentMixin(Component: any, isConditionallyFocusable?: Function, accessibleOnly: boolean = false) {
     // Call base
     // This adds the basic "monitor focusable components" functionality.
     applyFocusableComponentMixinBase(Component, isConditionallyFocusable, accessibleOnly);
@@ -266,7 +266,7 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
                     this.tabIndexLocalOverride = 0;
 
                     // Refresh the native view
-                    updateNativeTabIndexAndIFA(this);
+                    updateNativeAccessibilityProps(this);
 
                     this.tabIndexLocalOverrideTimer = setTimeout(() => {
                         if (this.tabIndexLocalOverrideTimer !== undefined) {
@@ -275,7 +275,7 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
                             delete this.tabIndexLocalOverride;
 
                             // Refresh the native view
-                            updateNativeTabIndexAndIFA(this);
+                            updateNativeAccessibilityProps(this);
                         }
                     }, 500);
                 }

--- a/src/native-desktop/utils/FocusManager.ts
+++ b/src/native-desktop/utils/FocusManager.ts
@@ -61,7 +61,11 @@ export class FocusManager extends FocusManagerBase {
     private static focusFirst() {
         const focusable = Object.keys(FocusManager._allFocusableComponents)
             .map(componentId => FocusManager._allFocusableComponents[componentId])
-            .filter(storedComponent => !storedComponent.removed && !storedComponent.restricted && !storedComponent.limitedCount);
+            .filter(storedComponent =>
+                !storedComponent.removed &&
+                !storedComponent.restricted &&
+                !storedComponent.limitedCount &&
+                !storedComponent.limitedCountAccessible);
 
         if (focusable.length) {
             focusable.sort((a, b) => {

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -128,7 +128,8 @@ export class FocusManager extends FocusManagerBase {
     }
 
     private static _isComponentAvailable(storedComponent: StoredFocusableComponent): boolean {
-        return !storedComponent.removed &&
+        return !storedComponent.accessibleOnly &&
+            !storedComponent.removed &&
             !storedComponent.restricted &&
             storedComponent.limitedCount === 0 &&
             storedComponent.limitedCountAccessible === 0;

--- a/src/web/utils/FocusManager.ts
+++ b/src/web/utils/FocusManager.ts
@@ -11,7 +11,7 @@ import ReactDOM = require('react-dom');
 
 import { FocusManager as FocusManagerBase,
     FocusableComponentInternal,
-    StoredFocusableComponent } from '../../common/utils/FocusManager';
+    StoredFocusableComponent as StoredFocusableComponentBase } from '../../common/utils/FocusManager';
 import { FocusArbitratorProvider, FocusCandidateType, FocusCandidateInternal } from '../../common/utils/AutoFocusHelper';
 
 import UserInterface from '../UserInterface';
@@ -27,6 +27,13 @@ import {
 } from  '../../common/utils/FocusManager';
 
 export { FocusableComponentStateCallback };
+
+export interface StoredFocusableComponent extends StoredFocusableComponentBase {
+    origTabIndex?: number;
+    origAriaHidden?: string;
+    curTabIndex?: number;
+    curAriaHidden?: boolean;
+}
 
 export class FocusManager extends FocusManagerBase {
     private static _setTabIndexTimer: number|undefined;

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -210,7 +210,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
         return this.props.tabIndex || 0;
     }
 
-    updateNativeTabIndex(): void {
+    updateNativeTabIndexAndIFA(): void {
         if (this._buttonElement) {
             let tabIndex: number | undefined = this.getTabIndex();
             let windowsTabFocusable: boolean = !this.props.disabled && tabIndex !== undefined && tabIndex >= 0;

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -29,6 +29,7 @@ let FocusableAnimatedView = RNW.createFocusableComponent(RN.Animated.View);
 
 export interface ButtonContext extends ButtonContextBase {
     isRxParentAContextMenuResponder?: boolean;
+    isRxParentAFocusableInSameFMRealm?: boolean;
 }
 
 export class Button extends ButtonBase implements React.ChildContextProvider<ButtonContext>, FocusManagerFocusableComponent {
@@ -38,6 +39,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
 
     static childContextTypes: React.ValidationMap<any> = {
         isRxParentAContextMenuResponder: PropTypes.bool,
+        isRxParentAFocusableInSameFMRealm: PropTypes.bool,
         ...ButtonBase.childContextTypes
     };
 
@@ -121,6 +123,10 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
         // This instance can be a responder (even when button is disabled). It may or may not have to invoke an onContextMenu handler, but
         // it will consume all corresponding touch events, so overwriting any parent-set value is the correct thing to do.
         childContext.isRxParentAContextMenuResponder = !!this.props.onContextMenu;
+
+        // This button will hide other "accessible focusable" controls as part of being restricted/limited by a focus manager
+        // (more detailed description is in windows/View.tsx)
+        childContext.isRxParentAFocusableInSameFMRealm = true;
 
         return childContext;
     }
@@ -217,7 +223,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
 
     getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
         // Focus Manager may override this
-        // We force a default of YES if no property is provided
+        // We force a default of YES if no property is provided, consistent with the base class
         return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility,
             Types.ImportantForAccessibility.Yes);
     }

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -11,7 +11,9 @@ import PropTypes = require('prop-types');
 import React = require('react');
 import RN = require('react-native');
 import RNW = require('react-native-windows');
+import Types = require('../common/Types');
 
+import AccessibilityUtil, { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
 import { Button as ButtonBase, ButtonContext as ButtonContextBase } from '../native-common/Button';
 import EventHelpers from '../native-common/utils/EventHelpers';
 import UserInterface from '../native-common/UserInterface';
@@ -51,6 +53,8 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
         // The intermediate "focusable, but not in the tab order" case is not supported.
         let windowsTabFocusable: boolean = !this.props.disabled && tabIndex !== undefined && tabIndex >= 0;
 
+        let importantForAccessibility: ImportantForAccessibilityValue | undefined = this.getImportantForAccessibility();
+
         // We don't use 'string' ref type inside ReactXP
         let originalRef = (internalProps as any).ref;
         if (typeof originalRef === 'string') {
@@ -66,6 +70,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
             onMouseLeave: this._onMouseLeave,
             isTabStop: windowsTabFocusable,
             tabIndex: tabIndex,
+            importantForAccessibility: importantForAccessibility,
             disableSystemFocusVisuals: false,
             handledKeyDownKeys: DOWN_KEYCODES,
             handledKeyUpKeys: UP_KEYCODES,
@@ -210,14 +215,22 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
         return this.props.tabIndex || 0;
     }
 
+    getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
+        // Focus Manager may override this
+        return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility,
+            Types.ImportantForAccessibility.Yes);
+    }
+
     updateNativeTabIndexAndIFA(): void {
         if (this._buttonElement) {
             let tabIndex: number | undefined = this.getTabIndex();
             let windowsTabFocusable: boolean = !this.props.disabled && tabIndex !== undefined && tabIndex >= 0;
+            let importantForAccessibility: string | undefined = this.getImportantForAccessibility();
 
             this._buttonElement.setNativeProps({
                 tabIndex: tabIndex,
-                isTabStop: windowsTabFocusable
+                isTabStop: windowsTabFocusable,
+                importantForAccessibility: importantForAccessibility
             });
         }
     }

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -217,6 +217,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
 
     getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
         // Focus Manager may override this
+        // We force a default of YES if no property is provided
         return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility,
             Types.ImportantForAccessibility.Yes);
     }

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -29,7 +29,7 @@ let FocusableAnimatedView = RNW.createFocusableComponent(RN.Animated.View);
 
 export interface ButtonContext extends ButtonContextBase {
     isRxParentAContextMenuResponder?: boolean;
-    isRxParentAFocusableInSameFMRealm?: boolean;
+    isRxParentAFocusableInSameFocusManager?: boolean;
 }
 
 export class Button extends ButtonBase implements React.ChildContextProvider<ButtonContext>, FocusManagerFocusableComponent {
@@ -39,7 +39,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
 
     static childContextTypes: React.ValidationMap<any> = {
         isRxParentAContextMenuResponder: PropTypes.bool,
-        isRxParentAFocusableInSameFMRealm: PropTypes.bool,
+        isRxParentAFocusableInSameFocusManager: PropTypes.bool,
         ...ButtonBase.childContextTypes
     };
 
@@ -126,7 +126,7 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
 
         // This button will hide other "accessible focusable" controls as part of being restricted/limited by a focus manager
         // (more detailed description is in windows/View.tsx)
-        childContext.isRxParentAFocusableInSameFMRealm = true;
+        childContext.isRxParentAFocusableInSameFocusManager = true;
 
         return childContext;
     }
@@ -228,11 +228,11 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
             Types.ImportantForAccessibility.Yes);
     }
 
-    updateNativeTabIndexAndIFA(): void {
+    updateNativeAccessibilityProps(): void {
         if (this._buttonElement) {
             let tabIndex: number | undefined = this.getTabIndex();
             let windowsTabFocusable: boolean = !this.props.disabled && tabIndex !== undefined && tabIndex >= 0;
-            let importantForAccessibility: string | undefined = this.getImportantForAccessibility();
+            let importantForAccessibility: ImportantForAccessibilityValue | undefined = this.getImportantForAccessibility();
 
             this._buttonElement.setNativeProps({
                 tabIndex: tabIndex,

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -218,8 +218,8 @@ export class Link extends LinkBase<LinkState> implements FocusManagerFocusableCo
     getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
         // Focus Manager may override this
 
-        // Go by default of YES, LinkProps has no corresponding accessibility property
-        return AccessibilityUtil.importantForAccessibilityToString(Types.ImportantForAccessibility.Yes);
+        // Go by default of Auto, LinkProps has no corresponding accessibility property
+        return AccessibilityUtil.importantForAccessibilityToString(Types.ImportantForAccessibility.Auto);
     }
 
     updateNativeTabIndexAndIFA(): void {

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -212,7 +212,7 @@ export class Link extends LinkBase<LinkState> implements FocusManagerFocusableCo
         return this.props.tabIndex || 0;
     }
 
-    updateNativeTabIndex(): void {
+    updateNativeTabIndexAndIFA(): void {
         if (this._focusableElement) {
             let tabIndex: number | undefined = this.getTabIndex();
             let windowsTabFocusable: boolean = tabIndex !== undefined && tabIndex >= 0;

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -12,7 +12,7 @@ import RN = require('react-native');
 import RNW = require('react-native-windows');
 import Types = require('../common/Types');
 
-import { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
+import AccessibilityUtil, { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
 import { applyFocusableComponentMixin, FocusManager, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
 
 import EventHelpers from '../native-common/utils/EventHelpers';
@@ -218,8 +218,8 @@ export class Link extends LinkBase<LinkState> implements FocusManagerFocusableCo
     getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
         // Focus Manager may override this
 
-        // Go by default, LinkProps has no corresponding accessibility property
-        return undefined;
+        // Go by default of YES, LinkProps has no corresponding accessibility property
+        return AccessibilityUtil.importantForAccessibilityToString(Types.ImportantForAccessibility.Yes);
     }
 
     updateNativeTabIndexAndIFA(): void {

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -222,7 +222,7 @@ export class Link extends LinkBase<LinkState> implements FocusManagerFocusableCo
         return AccessibilityUtil.importantForAccessibilityToString(Types.ImportantForAccessibility.Auto);
     }
 
-    updateNativeTabIndexAndIFA(): void {
+    updateNativeAccessibilityProps(): void {
         if (this._focusableElement) {
             let tabIndex: number | undefined = this.getTabIndex();
             let windowsTabFocusable: boolean = tabIndex !== undefined && tabIndex >= 0;

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -12,6 +12,7 @@ import RN = require('react-native');
 import RNW = require('react-native-windows');
 import Types = require('../common/Types');
 
+import { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
 import { applyFocusableComponentMixin, FocusManager, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
 
 import EventHelpers from '../native-common/utils/EventHelpers';
@@ -89,6 +90,7 @@ export class Link extends LinkBase<LinkState> implements FocusManagerFocusableCo
     private _createFocusableTextProps(internalProps: RN.TextProps) {
         let tabIndex: number | undefined = this.getTabIndex();
         let windowsTabFocusable: boolean =  tabIndex !== undefined && tabIndex >= 0;
+        let importantForAccessibility: ImportantForAccessibilityValue | undefined = this.getImportantForAccessibility();
 
         // We don't use 'string' ref type inside ReactXP
         let originalRef = (internalProps as any).ref;
@@ -103,6 +105,7 @@ export class Link extends LinkBase<LinkState> implements FocusManagerFocusableCo
             ref: this._onFocusableRef,
             isTabStop: windowsTabFocusable,
             tabIndex: tabIndex,
+            importantForAccessibility: importantForAccessibility,
             disableSystemFocusVisuals: false,
             handledKeyDownKeys: DOWN_KEYCODES,
             handledKeyUpKeys: UP_KEYCODES,
@@ -212,14 +215,23 @@ export class Link extends LinkBase<LinkState> implements FocusManagerFocusableCo
         return this.props.tabIndex || 0;
     }
 
+    getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
+        // Focus Manager may override this
+
+        // Go by default, LinkProps has no corresponding accessibility property
+        return undefined;
+    }
+
     updateNativeTabIndexAndIFA(): void {
         if (this._focusableElement) {
             let tabIndex: number | undefined = this.getTabIndex();
             let windowsTabFocusable: boolean = tabIndex !== undefined && tabIndex >= 0;
+            let importantForAccessibility: ImportantForAccessibilityValue | undefined = this.getImportantForAccessibility();
 
             this._focusableElement.setNativeProps({
                 tabIndex: tabIndex,
-                isTabStop: windowsTabFocusable
+                isTabStop: windowsTabFocusable,
+                importantForAccessibility: importantForAccessibility
             });
         }
     }

--- a/src/windows/Text.tsx
+++ b/src/windows/Text.tsx
@@ -60,8 +60,6 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
     getImportantForAccessibility(): string | undefined {
         // Focus Manager may override this
 
-        // Note: currently native-common flavor doesn't pass any accessibility properties to RN.TextInput.
-        // This should ideally be fixed.
         // We force a default of Auto if no property is provided
         return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility,
             Types.ImportantForAccessibility.Auto);
@@ -79,7 +77,7 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
 
 // Text is focusable just by screen readers
 applyFocusableComponentMixin(Text, function (this: Text, nextProps?: Types.TextProps, nextState?: any, nextCtx?: TextContext) {
-    // This control should be tracked by a FocusManager if there's no other control tracked by the same focus manager in
+    // This control should be tracked by a FocusManager if there's no other control tracked by the same FocusManager in
     // the parent path
     return nextCtx && ('isRxParentAFocusableInSameFMRealm' in nextCtx)
         ? !nextCtx.isRxParentAFocusableInSameFMRealm : !this.context.isRxParentAFocusableInSameFMRealm;

--- a/src/windows/Text.tsx
+++ b/src/windows/Text.tsx
@@ -7,12 +7,81 @@
 * RN Windows-specific implementation of the cross-platform Text abstraction.
 */
 
-import { Text as TextBase } from '../native-common/Text';
+import AccessibilityUtil from '../native-common/AccessibilityUtil';
+import PropTypes = require('prop-types');
+import { Text as TextBase, TextContext as TextContextBase } from '../native-common/Text';
+import Types = require('../common/Types');
 
-export class Text extends TextBase {
+import { applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
+export interface TextContext extends TextContextBase {
+    isRxParentAFocusableInSameFMRealm?: boolean;
+}
+
+export class Text extends TextBase implements React.ChildContextProvider<TextContext>, FocusManagerFocusableComponent {
+    static contextTypes: React.ValidationMap<any> = {
+        isRxParentAFocusableInSameFMRealm: PropTypes.bool,
+        ...TextBase.contextTypes
+    };
+
+    // Context is provided by super - just re-typing here
+    context!: TextContext;
+
+    static childContextTypes: React.ValidationMap<any> = {
+        isRxParentAFocusableInSameFMRealm: PropTypes.bool,
+        ...TextBase.childContextTypes
+    };
+
     requestFocus() {
         // UWP doesn't support casually focusing RN.Text elements. We override requestFocus in order to drop any focus requests
     }
+
+    getChildContext(): TextContext {
+        let childContext: TextContext = super.getChildContext();
+
+        // This control will hide other "accessible focusable" controls as part of being restricted/limited by a focus manager
+        // (more detailed description is in windows/View.tsx)
+        childContext.isRxParentAFocusableInSameFMRealm = true;
+
+        return childContext;
+    }
+
+    // From FocusManagerFocusableComponent interface
+    //
+    onFocus() {
+        // Focus Manager hook
+        // Not used
+    }
+
+    getTabIndex(): number {
+        // Not used
+        return -1;
+    }
+
+    getImportantForAccessibility(): string | undefined {
+        // Focus Manager may override this
+
+        // Note: currently native-common flavor doesn't pass any accessibility properties to RN.TextInput.
+        // This should ideally be fixed.
+        // We force a default of Auto if no property is provided
+        return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility,
+            Types.ImportantForAccessibility.Auto);
+    }
+
+    updateNativeTabIndexAndIFA(): void {
+        if (this._mountedComponent) {
+            let importantForAccessibility = this.getImportantForAccessibility();
+            this._mountedComponent.setNativeProps({
+                importantForAccessibility: importantForAccessibility
+            });
+        }
+    }
 }
+
+// Text is focusable just by screen readers
+applyFocusableComponentMixin(Text, function (this: Text, nextProps?: Types.TextProps, nextCtx?: TextContext) {
+    // This control should be tracked by a FocusManager if there's no other control tracked by the same focus manager in
+    // the parent path
+    return !nextCtx || !nextCtx.isRxParentAFocusableInSameFMRealm;
+}, true);
 
 export default Text;

--- a/src/windows/Text.tsx
+++ b/src/windows/Text.tsx
@@ -7,19 +7,19 @@
 * RN Windows-specific implementation of the cross-platform Text abstraction.
 */
 
-import AccessibilityUtil from '../native-common/AccessibilityUtil';
+import AccessibilityUtil, { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
 import PropTypes = require('prop-types');
 import { Text as TextBase, TextContext as TextContextBase } from '../native-common/Text';
 import Types = require('../common/Types');
 
 import { applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
 export interface TextContext extends TextContextBase {
-    isRxParentAFocusableInSameFMRealm?: boolean;
+    isRxParentAFocusableInSameFocusManager?: boolean;
 }
 
 export class Text extends TextBase implements React.ChildContextProvider<TextContext>, FocusManagerFocusableComponent {
     static contextTypes: React.ValidationMap<any> = {
-        isRxParentAFocusableInSameFMRealm: PropTypes.bool,
+        isRxParentAFocusableInSameFocusManager: PropTypes.bool,
         ...TextBase.contextTypes
     };
 
@@ -27,7 +27,7 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
     context!: TextContext;
 
     static childContextTypes: React.ValidationMap<any> = {
-        isRxParentAFocusableInSameFMRealm: PropTypes.bool,
+        isRxParentAFocusableInSameFocusManager: PropTypes.bool,
         ...TextBase.childContextTypes
     };
 
@@ -40,7 +40,7 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
 
         // This control will hide other "accessible focusable" controls as part of being restricted/limited by a focus manager
         // (more detailed description is in windows/View.tsx)
-        childContext.isRxParentAFocusableInSameFMRealm = true;
+        childContext.isRxParentAFocusableInSameFocusManager = true;
 
         return childContext;
     }
@@ -57,7 +57,7 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
         return -1;
     }
 
-    getImportantForAccessibility(): string | undefined {
+    getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
         // Focus Manager may override this
 
         // We force a default of Auto if no property is provided
@@ -65,7 +65,7 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
             Types.ImportantForAccessibility.Auto);
     }
 
-    updateNativeTabIndexAndIFA(): void {
+    updateNativeAccessibilityProps(): void {
         if (this._mountedComponent) {
             let importantForAccessibility = this.getImportantForAccessibility();
             this._mountedComponent.setNativeProps({
@@ -79,8 +79,8 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
 applyFocusableComponentMixin(Text, function (this: Text, nextProps?: Types.TextProps, nextState?: any, nextCtx?: TextContext) {
     // This control should be tracked by a FocusManager if there's no other control tracked by the same FocusManager in
     // the parent path
-    return nextCtx && ('isRxParentAFocusableInSameFMRealm' in nextCtx)
-        ? !nextCtx.isRxParentAFocusableInSameFMRealm : !this.context.isRxParentAFocusableInSameFMRealm;
+    return nextCtx && ('isRxParentAFocusableInSameFocusManager' in nextCtx)
+        ? !nextCtx.isRxParentAFocusableInSameFocusManager : !this.context.isRxParentAFocusableInSameFocusManager;
 }, true);
 
 export default Text;

--- a/src/windows/Text.tsx
+++ b/src/windows/Text.tsx
@@ -78,10 +78,11 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
 }
 
 // Text is focusable just by screen readers
-applyFocusableComponentMixin(Text, function (this: Text, nextProps?: Types.TextProps, nextCtx?: TextContext) {
+applyFocusableComponentMixin(Text, function (this: Text, nextProps?: Types.TextProps, nextState?: any, nextCtx?: TextContext) {
     // This control should be tracked by a FocusManager if there's no other control tracked by the same focus manager in
     // the parent path
-    return !nextCtx || !nextCtx.isRxParentAFocusableInSameFMRealm;
+    return nextCtx && ('isRxParentAFocusableInSameFMRealm' in nextCtx)
+        ? !nextCtx.isRxParentAFocusableInSameFMRealm : !this.context.isRxParentAFocusableInSameFMRealm;
 }, true);
 
 export default Text;

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -9,6 +9,7 @@
 
 import React = require('react');
 import RN = require('react-native');
+import Types = require('../common/Types');
 
 import AccessibilityUtil, { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
 import { applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
@@ -60,7 +61,9 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
 
         // Note: currently native-common flavor doesn't pass any accessibility properties to RN.TextInput.
         // This should ideally be fixed.
-        return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility);
+        // We force a default of YES if no property is provided
+        return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility,
+            Types.ImportantForAccessibility.Yes);
     }
 
     updateNativeTabIndexAndIFA(): void {

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -10,6 +10,7 @@
 import React = require('react');
 import RN = require('react-native');
 
+import AccessibilityUtil, { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
 import { applyFocusableComponentMixin, FocusManagerFocusableComponent } from '../native-desktop/utils/FocusManager';
 
 import { TextInput as TextInputBase } from '../native-common/TextInput';
@@ -19,6 +20,7 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
     protected _render(props: RN.TextInputProps, onMount: (textInput: any) => void): JSX.Element {
         const extendedProps: RN.ExtendedTextInputProps = {
             tabIndex: this.getTabIndex(),
+            importantForAccessibility: this.getImportantForAccessibility(),
             onFocus: (e: RN.NativeSyntheticEvent<RN.TextInputFocusEventData>) => this._onFocusEx(e, props.onFocus)
         };
 
@@ -53,13 +55,23 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
         return this.props.tabIndex || 0;
     }
 
+    getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
+        // Focus Manager may override this
+
+        // Note: currently native-common flavor doesn't pass any accessibility properties to RN.TextInput.
+        // This should ideally be fixed.
+        return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility);
+    }
+
     updateNativeTabIndexAndIFA(): void {
         if (this._mountedComponent) {
             let tabIndex = this.getTabIndex();
+            let importantForAccessibility = this.getImportantForAccessibility();
             this._mountedComponent.setNativeProps({
                 tabIndex: tabIndex,
                 value: this.state.inputValue, // mandatory for some reason
-                isTabStop: this.props.editable && tabIndex >= 0
+                isTabStop: this.props.editable && tabIndex >= 0,
+                importantForAccessibility: importantForAccessibility
             });
         }
     }

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -61,9 +61,9 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
 
         // Note: currently native-common flavor doesn't pass any accessibility properties to RN.TextInput.
         // This should ideally be fixed.
-        // We force a default of YES if no property is provided
+        // We force a default of Auto if no property is provided
         return AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility,
-            Types.ImportantForAccessibility.Yes);
+            Types.ImportantForAccessibility.Auto);
     }
 
     updateNativeTabIndexAndIFA(): void {

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -66,7 +66,7 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
             Types.ImportantForAccessibility.Auto);
     }
 
-    updateNativeTabIndexAndIFA(): void {
+    updateNativeAccessibilityProps(): void {
         if (this._mountedComponent) {
             let tabIndex = this.getTabIndex();
             let importantForAccessibility = this.getImportantForAccessibility();

--- a/src/windows/TextInput.tsx
+++ b/src/windows/TextInput.tsx
@@ -53,7 +53,7 @@ export class TextInput extends TextInputBase implements FocusManagerFocusableCom
         return this.props.tabIndex || 0;
     }
 
-    updateNativeTabIndex(): void {
+    updateNativeTabIndexAndIFA(): void {
         if (this._mountedComponent) {
             let tabIndex = this.getTabIndex();
             this._mountedComponent.setNativeProps({

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -498,9 +498,9 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     getImportantForAccessibility(): string | undefined {
         // Focus Manager may override this
 
-        // Use a default of YES if the computed value is undefined (we don't change the base class to use n explicit default for now
+        // Use a default of Auto if the computed value is undefined
         return this._internalProps.importantForAccessibility ||
-            AccessibilityUtil.importantForAccessibilityToString(Types.ImportantForAccessibility.Yes);
+            AccessibilityUtil.importantForAccessibilityToString(Types.ImportantForAccessibility.Auto);
     }
 
     updateNativeTabIndexAndIFA(): void {

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -269,6 +269,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         if (this.props.tabIndex !== undefined) {
             let tabIndex: number = this.getTabIndex() || 0;
             let windowsTabFocusable: boolean =  tabIndex >= 0;
+            let importantForAccessibility: string | undefined = this.getImportantForAccessibility();
 
             // We don't use 'string' ref type inside ReactXP
             let originalRef = this._internalProps.ref;
@@ -283,6 +284,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
                 componentRef: componentRef,
                 isTabStop: windowsTabFocusable,
                 tabIndex: tabIndex,
+                importantForAccessibility: importantForAccessibility,
                 disableSystemFocusVisuals: false,
                 handledKeyDownKeys: DOWN_KEYCODES,
                 handledKeyUpKeys: UP_KEYCODES,
@@ -480,14 +482,21 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         return this.props.tabIndex;
     }
 
+    getImportantForAccessibility(): string | undefined {
+        // Focus Manager may override this
+        return this._internalProps.importantForAccessibility;
+    }
+
     updateNativeTabIndexAndIFA(): void {
         if (this._focusableElement) {
             let tabIndex: number = this.getTabIndex() || 0;
             let windowsTabFocusable: boolean = tabIndex >= 0;
+            let importantForAccessibility: string | undefined = this.getImportantForAccessibility();
 
             this._focusableElement.setNativeProps({
                 tabIndex: tabIndex,
-                isTabStop: windowsTabFocusable
+                isTabStop: windowsTabFocusable,
+                importantForAccessibility: importantForAccessibility
             });
         }
     }

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -14,6 +14,7 @@ import RNW = require('react-native-windows');
 import Types = require('../common/Types');
 import PropTypes = require('prop-types');
 
+import AccessibilityUtil from '../native-common/AccessibilityUtil';
 import AppConfig from '../common/AppConfig';
 import { View as ViewCommon, ViewContext as ViewContextCommon } from '../native-common/View';
 import EventHelpers from '../native-common/utils/EventHelpers';
@@ -484,7 +485,10 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
 
     getImportantForAccessibility(): string | undefined {
         // Focus Manager may override this
-        return this._internalProps.importantForAccessibility;
+
+        // Use a default of YES if the computed value is undefined (we don't change the base class to use n explicit default for now
+        return this._internalProps.importantForAccessibility ||
+            AccessibilityUtil.importantForAccessibilityToString(Types.ImportantForAccessibility.Yes);
     }
 
     updateNativeTabIndexAndIFA(): void {

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -35,7 +35,7 @@ export interface ViewContext extends ViewContextCommon {
     focusManager?: FocusManager;
     popupContainer?: PopupContainerView;
     isRxParentAContextMenuResponder?: boolean;
-    isRxParentAFocusableInSameFMRealm?: boolean;
+    isRxParentAFocusableInSameFocusManager?: boolean;
 }
 
 let FocusableView = RNW.createFocusableComponent(RN.View);
@@ -56,7 +56,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         focusManager: PropTypes.object,
         popupContainer: PropTypes.object,
         isRxParentAContextMenuResponder: PropTypes.bool,
-        isRxParentAFocusableInSameFMRealm: PropTypes.bool,
+        isRxParentAFocusableInSameFocusManager: PropTypes.bool,
         ...ViewCommon.childContextTypes
     };
 
@@ -362,7 +362,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
             // trigger performance issues.
             // One way to narrow down to a manageable set is to ignore "accessible focusable" controls that are children of keyboard
             // focusable controls, as long as they are tracked by same FocusManager .
-            childContext.isRxParentAFocusableInSameFMRealm = false;
+            childContext.isRxParentAFocusableInSameFocusManager = false;
         }
         if (this._popupContainer) {
             childContext.popupContainer = this._popupContainer;
@@ -378,7 +378,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
             childContext.isRxParentAContextMenuResponder = !!this.props.onContextMenu;
 
             // This button will hide other "accessible focusable" controls as part of being restricted/limited by a focus manager
-            childContext.isRxParentAFocusableInSameFMRealm = true;
+            childContext.isRxParentAFocusableInSameFocusManager = true;
         }
 
         return childContext;
@@ -503,7 +503,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
             AccessibilityUtil.importantForAccessibilityToString(Types.ImportantForAccessibility.Auto);
     }
 
-    updateNativeTabIndexAndIFA(): void {
+    updateNativeAccessibilityProps(): void {
         if (this._focusableElement) {
             let tabIndex: number = this.getTabIndex() || 0;
             let windowsTabFocusable: boolean = tabIndex >= 0;

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -14,7 +14,7 @@ import RNW = require('react-native-windows');
 import Types = require('../common/Types');
 import PropTypes = require('prop-types');
 
-import AccessibilityUtil from '../native-common/AccessibilityUtil';
+import AccessibilityUtil, { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
 import AppConfig from '../common/AppConfig';
 import { View as ViewCommon, ViewContext as ViewContextCommon } from '../native-common/View';
 import EventHelpers from '../native-common/utils/EventHelpers';
@@ -495,7 +495,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         return this.props.tabIndex;
     }
 
-    getImportantForAccessibility(): string | undefined {
+    getImportantForAccessibility(): ImportantForAccessibilityValue | undefined {
         // Focus Manager may override this
 
         // Use a default of Auto if the computed value is undefined
@@ -507,7 +507,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         if (this._focusableElement) {
             let tabIndex: number = this.getTabIndex() || 0;
             let windowsTabFocusable: boolean = tabIndex >= 0;
-            let importantForAccessibility: string | undefined = this.getImportantForAccessibility();
+            let importantForAccessibility: ImportantForAccessibilityValue | undefined = this.getImportantForAccessibility();
 
             this._focusableElement.setNativeProps({
                 tabIndex: tabIndex,

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -480,7 +480,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
         return this.props.tabIndex;
     }
 
-    updateNativeTabIndex(): void {
+    updateNativeTabIndexAndIFA(): void {
         if (this._focusableElement) {
             let tabIndex: number = this.getTabIndex() || 0;
             let windowsTabFocusable: boolean = tabIndex >= 0;


### PR DESCRIPTION
1. Bought the Windows implementation in sync with web with regards to hiding restricted/limited focusable controls from screen readers (prior code supported just the limitation of keyboard based navigation).
This is done by adding a way for FocusManager to override the "importantForAccessibility" property using a similar mechanism like the tabIndex one.
2. Addressed the hiding of non-keyboard focusable controls like RX.Text. To support this kind of controls I added an "accessible only" category, basically a lightweight version of FocusManager tracked control that only supports overriding "importantForAccessibility".
    - An optimization is used to prevent tracking ALL RX.Text instances in an app. This is based on the fact that hiding a node through an "importantForAccessibility==='no-hide-descendants'" hides the whole child subtree, making the tracking of those child controls unnecessary.
    - Current implementation is set up for Windows. Web could follow/adapt same path.
3. Moved some web-only state from StoredComponent class to the web derivation + some other small fixes for some regressions.

This PR is sent before a rebase, will do that tomorrow + PR feedback fixes.