### PR TITLE
Add hideDeleteButton prop to TextInput for use in UWP apps

### DIFF
--- a/docs/docs/components/textinput.md
+++ b/docs/docs/components/textinput.md
@@ -53,6 +53,9 @@ disableFullscreenUI: boolean = false; // Android-specific
 // Can text be edited by the user?
 editable: boolean = true;
 
+// UWP-only (Windows-only) prop for hiding the 'X' delete button
+hideDeleteButton: boolean = false;
+
 // iOS-only prop for controlling the keyboard appearance
 keyboardAppearance: 'default' | 'light' | 'dark';
 

--- a/samples/RXPTest/src/Tests/TextInputInteractiveTest.tsx
+++ b/samples/RXPTest/src/Tests/TextInputInteractiveTest.tsx
@@ -262,6 +262,20 @@ class TextInputView extends RX.Component<RX.CommonProps, TextInputViewState> {
                     </RX.Text>
                 </RX.View>
 
+                <RX.View style={ _styles.explainTextContainer } key={ 'explanation8' }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'This text input box uses the "hideDeleteButton" prop to hide the `X` that appears while typing. ' +
+                          '(This is only relevant to UWP apps on Windows). ' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={ _styles.resultContainer }>
+                    <RX.TextInput
+                        style={ _styles.textInput1 }
+                        placeholder={ 'This box will not have the usual `X` delete button as you type.' }
+                        hideDeleteButton={ true }
+                    />
+                </RX.View>
+
                 <RX.View style={ _styles.placeholder }/>
 
             </RX.View>

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -874,6 +874,7 @@ export interface TextInputPropsShared extends CommonProps, CommonAccessibilityPr
     blurOnSubmit?: boolean;
     defaultValue?: string;
     editable?: boolean;
+    hideDeleteButton?: boolean;
     keyboardType?: 'default' | 'numeric' | 'email-address' | 'number-pad';
     maxLength?: number;
     multiline?: boolean;
@@ -881,7 +882,6 @@ export interface TextInputPropsShared extends CommonProps, CommonAccessibilityPr
     placeholderTextColor?: string;
     secureTextEntry?: boolean;
     value?: string;
-    hideDeleteButton?: boolean;
 
      // Should fonts be scaled according to system setting? Defaults
     // to true. iOS and Android only.

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -881,6 +881,7 @@ export interface TextInputPropsShared extends CommonProps, CommonAccessibilityPr
     placeholderTextColor?: string;
     secureTextEntry?: boolean;
     value?: string;
+    hideDeleteButton?: boolean;
 
      // Should fonts be scaled according to system setting? Defaults
     // to true. iOS and Android only.

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -116,7 +116,8 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
             accessibilityLabel: this.props.accessibilityLabel,
             allowFontScaling: this.props.allowFontScaling,
             maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
-            underlineColorAndroid: 'transparent'
+            underlineColorAndroid: 'transparent',
+            hideDeleteButton: this.props.hideDeleteButton
         };
 
         this._selectionToSet = undefined;

--- a/src/typings/react-native-extensions.d.ts
+++ b/src/typings/react-native-extensions.d.ts
@@ -31,6 +31,7 @@ declare module 'react-native' {
         onPaste?: (e: RN.NativeSyntheticEvent) => void;
         maxContentSizeMultiplier?: number;
         tabIndex?: number;
+        hideDeleteButton?: boolean;
     }
 
     interface ExtendedImageProps extends RN.ImageProps {


### PR DESCRIPTION
Adds a prop that can be set to true (default false) to hide the 'X' delete button in TextInput boxes in UWP apps.