### PR TITLE
Expose the ScrollView decelrationRate property

### DIFF
--- a/docs/docs/components/scrollview.md
+++ b/docs/docs/components/scrollview.md
@@ -51,8 +51,13 @@ onScrollEndDrag: () => void = undefined;
 overScrollMode?: 'always' | 'always-if-content-scrolls' | 'never';
 
 // Snap to page boundaries?
-pagingEnabled: boolean = false; // iOS only
+pagingEnabled: boolean = false; // Android & iOS only
 snapToInterval: number = undefined; // iOS only
+
+// Controls the scroll decelartion rate once user has lifted their finger.
+// normal (default) = 0.998
+// fast = 0.99
+decelerationRate: 'normal' | 'fast' | number = undefined; // iOS only
 
 // Is scrolling enabled?
 scrollEnabled: boolean = true;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -842,6 +842,11 @@ export interface ScrollViewProps extends CommonProps, CommonAccessibilityProps {
     // iOS-only property to control scroll indicator insets
     scrollIndicatorInsets?: ScrollIndicatorInsets;
 
+    // iOS-only property to control the scroll decelartion rate once user has lifted their finger.
+    // normal (default) = 0.998
+    // fast = 0.99
+    decelerationRate?: 'normal' | 'fast' | number;
+
     // Windows-only property to control tab navigation inside the view
     tabNavigation?: 'local' | 'cycle' | 'once';
 }

--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -77,6 +77,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, Types.Stateless>
             bounces: this.props.bounces,
             pagingEnabled: this.props.pagingEnabled,
             snapToInterval: this.props.snapToInterval,
+            decelerationRate: this.props.decelerationRate,
             scrollsToTop: this.props.scrollsToTop,
             removeClippedSubviews: false,
             overScrollMode: this.props.overScrollMode,


### PR DESCRIPTION
This iOS only property is typically always set to 'fast' when you're using `snapToInterval`.  In our testing, the default value of 'normal' doesn't give a good UX on iOS, so without this property the snapToInterval functionality is less useful. 