### PR TITLE
Set decelerationRate to 'fast' if snapToInterval is set

### DIFF
--- a/docs/docs/components/scrollview.md
+++ b/docs/docs/components/scrollview.md
@@ -51,8 +51,8 @@ onScrollEndDrag: () => void = undefined;
 overScrollMode?: 'always' | 'always-if-content-scrolls' | 'never';
 
 // Snap to page boundaries?
-pagingEnabled: boolean = false; // iOS only
-snapToInterval: number = undefined; // iOS only
+pagingEnabled: boolean = false; // Android & iOS only
+snapToInterval: number = undefined; // iOS only - If set, decelerationRate is set to 'fast'
 
 // Is scrolling enabled?
 scrollEnabled: boolean = true;

--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -77,6 +77,7 @@ export class ScrollView extends ViewBase<Types.ScrollViewProps, Types.Stateless>
             bounces: this.props.bounces,
             pagingEnabled: this.props.pagingEnabled,
             snapToInterval: this.props.snapToInterval,
+            decelerationRate: typeof this.props.snapToInterval === 'number' ? 'fast' : undefined,
             scrollsToTop: this.props.scrollsToTop,
             removeClippedSubviews: false,
             overScrollMode: this.props.overScrollMode,


### PR DESCRIPTION
The ScrollView `decelerationRate` is typically set to 'fast' when using `snapToInterval`, rather than the default.  Instead of exposing a new platform-specific prop, we've decided to just do this automatically if the user is setting `snapToInterval`.