### PR TITLE
Remove event type casting

### DIFF
--- a/src/native-common/FrontLayerViewManager.tsx
+++ b/src/native-common/FrontLayerViewManager.tsx
@@ -217,10 +217,7 @@ export class FrontLayerViewManager {
     }
 
     private _onBackgroundPressed = (e: RN.GestureResponderEvent) => {
-        let synthEvent: RN.ExtendedNativeSyntheticEvent = e as RN.ExtendedNativeSyntheticEvent;
-        if (synthEvent.persist) {
-            synthEvent.persist();
-        }
+        e.persist();
 
         const activePopupContext = this._getActiveOverlay();
         if (!(activePopupContext instanceof PopupStackContext)) {

--- a/src/typings/react-native-extensions.d.ts
+++ b/src/typings/react-native-extensions.d.ts
@@ -82,8 +82,4 @@ declare module 'react-native' {
     interface ExtendedAccessibilityInfoStatic extends RN.AccessibilityInfoStatic {
         static initialHighContrast: boolean|undefined;
     }
-
-    interface ExtendedNativeSyntheticEvent extends NativeSyntheticEvent {
-        persist?: () => void;
-    }
 }


### PR DESCRIPTION
[`this.props.onPressOut`](https://github.com/facebook/react-native/blob/master/Libraries/Components/Touchable/TouchableWithoutFeedback.js#L180)

```javascript
touchableHandleActivePressOut: function(e: PressEvent) {
    this.props.onPressOut && this.props.onPressOut(e);
},
```

[`PressEvent`](https://github.com/facebook/react-native/blob/master/Libraries/Types/CoreEventTypes.js#L45
)
```javascript

export type SyntheticEvent<T> = $ReadOnly<{|
  bubbles: ?boolean,
  cancelable: ?boolean,
  currentTarget: number,
  defaultPrevented: ?boolean,
  dispatchConfig: $ReadOnly<{|
    registrationName: string,
  |}>,
  eventPhase: ?number,
  isDefaultPrevented: () => boolean,
  isPropagationStopped: () => boolean,
  isTrusted: ?boolean,
  nativeEvent: T,
  persist: () => void,
  target: ?number,
  timeStamp: number,
  type: ?string,
|}>;

export type PressEvent = SyntheticEvent<
  $ReadOnly<{|
    changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
    force: number,
    identifier: number,
    locationX: number,
    locationY: number,
    pageX: number,
    pageY: number,
    target: ?number,
    timestamp: number,
    touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
  |}>,
>;
```

[`GestureResponderEvent`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L421)
```typescript
export interface GestureResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {}

// Similar to React.SyntheticEvent except for nativeEvent
export interface NativeSyntheticEvent<T> {
    bubbles: boolean;
    cancelable: boolean;
    currentTarget: NodeHandle;
    defaultPrevented: boolean;
    eventPhase: number;
    isTrusted: boolean;
    nativeEvent: T;
    isPropagationStopped(): boolean;
    isDefaultPrevented(): boolean;
    persist(): void;
    preventDefault(): void;
    stopPropagation(): void;
    target: NodeHandle;
    timeStamp: number;
    type: string;
}
```

