### PR TITLE
Expose clearButtonMode RX.TextInput property

### DIFF
--- a/docs/docs/components/textinput.md
+++ b/docs/docs/components/textinput.md
@@ -53,9 +53,6 @@ disableFullscreenUI: boolean = false; // Android-specific
 // Can text be edited by the user?
 editable: boolean = true;
 
-// UWP-only (Windows-only) prop for hiding the 'X' delete button
-hideDeleteButton: boolean = false;
-
 // iOS-only prop for controlling the keyboard appearance
 keyboardAppearance: 'default' | 'light' | 'dark';
 

--- a/docs/docs/components/textinput.md
+++ b/docs/docs/components/textinput.md
@@ -117,7 +117,7 @@ spellCheck: boolean = [value of autoCorrect];
 // iOS and Windows only property for controlling when the clear button should appear on the right side of the text view.
 // Default behavior is dependent on platform: equivalent to 'never' on iOS, and 'always' on Windows.
 // Button is hidden when text view is empty, regardless of the property value.
-clearButtonMode: 'never' | 'while-editing' | 'unless-editing' | 'always'
+clearButtonMode: 'never' | 'while-editing' | 'unless-editing' | 'always';
 
 // See below for supported styles
 style: TextInputStyleRuleSet | TextInputStyleRuleSet[] = [];

--- a/docs/docs/components/textinput.md
+++ b/docs/docs/components/textinput.md
@@ -114,6 +114,11 @@ secureTextEntry: boolean = false;
 // Should spell checking be applied to contents?
 spellCheck: boolean = [value of autoCorrect];
 
+// iOS and Windows only property for controlling when the clear button should appear on the right side of the text view.
+// Default behavior is dependent on platform: equivalent to 'never' on iOS, and 'always' on Windows.
+// Button is hidden when text view is empty, regardless of the property value.
+clearButtonMode: 'never' | 'while-editing' | 'unless-editing' | 'always'
+
 // See below for supported styles
 style: TextInputStyleRuleSet | TextInputStyleRuleSet[] = [];
 

--- a/samples/RXPTest/src/Tests/TextInputInteractiveTest.tsx
+++ b/samples/RXPTest/src/Tests/TextInputInteractiveTest.tsx
@@ -262,20 +262,6 @@ class TextInputView extends RX.Component<RX.CommonProps, TextInputViewState> {
                     </RX.Text>
                 </RX.View>
 
-                <RX.View style={ _styles.explainTextContainer } key={ 'explanation8' }>
-                    <RX.Text style={ _styles.explainText }>
-                        { 'This text input box uses the "hideDeleteButton" prop to hide the `X` that appears while typing. ' +
-                          '(This is only relevant to UWP apps on Windows). ' }
-                    </RX.Text>
-                </RX.View>
-                <RX.View style={ _styles.resultContainer }>
-                    <RX.TextInput
-                        style={ _styles.textInput1 }
-                        placeholder={ 'This box will not have the usual `X` delete button as you type.' }
-                        hideDeleteButton={ true }
-                    />
-                </RX.View>
-
                 <RX.View style={ _styles.placeholder }/>
 
             </RX.View>

--- a/samples/RXPTest/src/Tests/TextInputInteractiveTest.tsx
+++ b/samples/RXPTest/src/Tests/TextInputInteractiveTest.tsx
@@ -262,6 +262,20 @@ class TextInputView extends RX.Component<RX.CommonProps, TextInputViewState> {
                     </RX.Text>
                 </RX.View>
 
+                <RX.View style={ _styles.explainTextContainer } key={ 'explanation8' }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'This text input box uses the "clearButtonMode" prop to hide the `X` that appears while typing. ' +
+                          '(This is only relevant to iOS and UWP apps). ' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={ _styles.resultContainer }>
+                    <RX.TextInput
+                        style={ _styles.textInput1 }
+                        placeholder={ 'This box will not have the usual `X` delete button as you type.' }
+                        clearButtonMode={ 'never' }
+                    />
+                </RX.View>
+
                 <RX.View style={ _styles.placeholder }/>
 
             </RX.View>

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -904,6 +904,9 @@ export interface TextInputPropsShared extends CommonProps, CommonAccessibilityPr
     // iOS and Android only property for controlling the text input selection color
     selectionColor?: string;
 
+    // iOS and Windows only property for controlling when the clear button should appear on the right side of the text view.
+    clearButtonMode?: 'never' | 'while-editing' | 'unless-editing' | 'always';
+
     onKeyPress?: (e: KeyboardEvent) => void;
     onFocus?: (e: FocusEvent) => void;
     onBlur?: (e: FocusEvent) => void;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -874,7 +874,6 @@ export interface TextInputPropsShared extends CommonProps, CommonAccessibilityPr
     blurOnSubmit?: boolean;
     defaultValue?: string;
     editable?: boolean;
-    hideDeleteButton?: boolean;
     keyboardType?: 'default' | 'numeric' | 'email-address' | 'number-pad';
     maxLength?: number;
     multiline?: boolean;

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -116,8 +116,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
             accessibilityLabel: this.props.accessibilityLabel,
             allowFontScaling: this.props.allowFontScaling,
             maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
-            underlineColorAndroid: 'transparent',
-            hideDeleteButton: this.props.hideDeleteButton
+            underlineColorAndroid: 'transparent'
         };
 
         this._selectionToSet = undefined;

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -116,7 +116,8 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
             accessibilityLabel: this.props.accessibilityLabel,
             allowFontScaling: this.props.allowFontScaling,
             maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
-            underlineColorAndroid: 'transparent'
+            underlineColorAndroid: 'transparent',
+            clearButtonMode: this.props.clearButtonMode
         };
 
         this._selectionToSet = undefined;

--- a/src/typings/react-native-extensions.d.ts
+++ b/src/typings/react-native-extensions.d.ts
@@ -31,7 +31,6 @@ declare module 'react-native' {
         onPaste?: (e: RN.NativeSyntheticEvent) => void;
         maxContentSizeMultiplier?: number;
         tabIndex?: number;
-        hideDeleteButton?: boolean;
     }
 
     interface ExtendedImageProps extends RN.ImageProps {


### PR DESCRIPTION
This piggybacks on existing iOS property, and the UWP implementation will follow suit.