### PR TITLE
Pass testId from VirtualListView to ScrollView

### DIFF
--- a/extensions/virtuallistview/src/VirtualListView.tsx
+++ b/extensions/virtuallistview/src/VirtualListView.tsx
@@ -1141,6 +1141,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
         return (
             <RX.ScrollView
                 ref={ _scrollViewRef }
+                testId={this.props.testId}
                 onLayout={ this._onLayoutContainer }
                 onScroll={ this._onScroll }
                 keyboardDismissMode={ this.props.keyboardDismissMode }

--- a/extensions/virtuallistview/src/VirtualListView.tsx
+++ b/extensions/virtuallistview/src/VirtualListView.tsx
@@ -64,6 +64,8 @@ export interface VirtualListViewItemInfo extends VirtualListCellInfo {
 }
 
 export interface VirtualListViewProps<ItemInfo extends VirtualListViewItemInfo> extends RX.CommonStyledProps<RX.Types.ViewStyleRuleSet> {
+    testId?: string;
+    
     // Ordered list of descriptors for items to display in the list.
     itemList: ItemInfo[];
 


### PR DESCRIPTION
I believe this will *almost* fix issue #747.

It seemed like a small change, so I figured I'd go ahead and make a PR myself.

I tested by building the root xp project and the extension, and then dropping the transpiled files from the extensions dir in dist/ into the vlv package in my project's node_modules.

 ~~I used XCode's layout inspector to confirm that the testId is being propagated from XP to RN to Native.~~
What I saw was the testId being propagated correctly when I use RX.ScrollView directly, *not* when I use VirtualListView. It looks like this change either isn't enough, or I'm going about testing this wrong. 
