### PR TITLE
Set size attribute of input HTML element to 1.

### DIFF
--- a/src/web/TextInput.tsx
+++ b/src/web/TextInput.tsx
@@ -139,6 +139,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
                     disabled={ !editable }
                     maxLength={ this.props.maxLength }
                     placeholder={ this.props.placeholder }
+                    size={ 1 }
 
                     onChange= { this._onInputChanged }
                     onKeyDown={ this._onKeyDown }


### PR DESCRIPTION
The input HTML element has size 20 by default. This means that it has to allocate at least 20 characters, which makes the input to have a minimum width that can fit those characters (the final minimum width in pixels depends on the browser and the font. More info: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input). This behavior differs from mobile implementation that doesn't have a minimum width by default.

Since size attribute has to be greater than 0, setting it to 1 is the closest we can get to have same behavior across platforms.