### PR TITLE
isRightMouseButton implementation that works also on mac.

### DIFF
--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -307,7 +307,7 @@ export class EventHelpers {
     }
 
     isRightMouseButton(e: Types.SyntheticEvent): boolean {
-        return !!e.nativeEvent.isRightButton;
+        return (this.toMouseButton(e as Types.TouchEvent) === 2);
     }
 
     // Keyboard events do not inherently hold a position that can be used to show flyouts on keyboard input.


### PR DESCRIPTION
Current implementation of isRightMouseButton depends on nativeEvent.isRightButton which is UWP specific. This version calls toMouseButton() which works for platforms that properly fill nativeEvent.button and falls back to nativeEvent.isRightButton if nativeEvent.button property is undefined.