### PR TITLE
[Web] Prevent a crash during onLayout handling

### DIFF
--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -254,6 +254,9 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
     }
 
     protected _getContainer(): HTMLElement|null {
+        if (!this._isMounted) {
+            return null;
+        }
         return ReactDOM.findDOMNode(this) as HTMLElement;
     }
 


### PR DESCRIPTION
_checkAndReportLayout calls into _getContainer which calls ReactDon.findDomNode
It's possible for the component to already be unmounted, so we should protect this call and return null if there's no longer a node