### PR TITLE
Use semver in reactxp dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "tslint": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.110",
-    "@types/react": "^16.0.36",
-    "@types/react-dom": "^16.0.6",
-    "@types/react-native": "^0.56.4",
+    "@types/lodash": "4.14.110",
+    "@types/react": "16.0.36",
+    "@types/react-dom": "16.0.6",
+    "@types/react-native": "0.56.4",
     "assert": "^1.4.1",
     "lodash": "^4.17.10",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
     "tslint": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
   },
   "dependencies": {
-    "@types/lodash": "4.14.110",
-    "@types/react": "16.0.36",
-    "@types/react-dom": "16.0.6",
-    "@types/react-native": "0.56.4",
-    "assert": "1.4.1",
-    "lodash": "4.17.10",
-    "prop-types": "15.6.2",
-    "rebound": "0.1.0",
-    "subscribableevent": "1.0.0",
-    "synctasks": "0.3.3"
+    "@types/lodash": "^4.14.110",
+    "@types/react": "^16.0.36",
+    "@types/react-dom": "^16.0.6",
+    "@types/react-native": "^0.56.4",
+    "assert": "^1.4.1",
+    "lodash": "^4.17.10",
+    "prop-types": "^15.6.2",
+    "rebound": "^0.1.0",
+    "subscribableevent": "^1.0.0",
+    "synctasks": "^0.3.3"
   },
   "peerDependencies": {
     "react": "^16.4.0",


### PR DESCRIPTION
This prevents consumers from accidentally importing and bundling two versions of the same library

For example, if I have version 1.0.0 in reactxp and 1.0.1 in my app, I would bundle both versions.  If reactxp has semver, it allows 1.0.1 to be bundled once since it's compatible with the referenced version in reactxp