### PR TITLE
Changed announceForAccessibility implementation to use Assertive live…

### DIFF
--- a/src/native-common/RootView.tsx
+++ b/src/native-common/RootView.tsx
@@ -139,7 +139,7 @@ abstract class BaseRootView<P extends BaseRootViewProps> extends React.Component
             <RN.View
                 style={ _styles.liveRegionContainer as RN.StyleProp<RN.ViewStyle> }
                 accessibilityLabel={ this.state.announcementText }
-                accessibilityLiveRegion={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Polite) }
+                accessibilityLiveRegion={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Assertive) }
             />
         );
     }

--- a/src/web/AccessibilityAnnouncer.tsx
+++ b/src/web/AccessibilityAnnouncer.tsx
@@ -109,7 +109,7 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
         return (
             <div
                 style={ _styles.liveRegionContainer as any }
-                aria-live={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Polite) }
+                aria-live={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Assertive) }
                 aria-atomic={ 'true' }
                 aria-relevant={ 'additions text' }
             >

--- a/src/windows/AccessibilityAnnouncer.tsx
+++ b/src/windows/AccessibilityAnnouncer.tsx
@@ -62,7 +62,7 @@ export class AccessibilityAnnouncer extends React.Component<{}, {}> {
             <RN.View
                 ref={ this._onViewRef }
                 style={ _styles.liveRegionContainer as RN.StyleProp<RN.ViewStyle> }
-                accessibilityLiveRegion={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Polite) }
+                accessibilityLiveRegion={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Assertive) }
             />
         );
     }


### PR DESCRIPTION
… region type instead of Polite. When Polite is used the request for announcement will be overridden by a subsequent narration. Usually this happens when code calls the announcement API and then focus is changed either programmatically or due to UI changes as result of event that was announced - in this case the automatic narration of a newly focused control suppresses the announcement, usually even before it starts. With announcement being Assertive, though, both automatic narration and the announcement are read and no information is lost.