### PR TITLE
We need to be showing the full img tag for ANY images with onload/one…

### DIFF
--- a/src/web/Image.tsx
+++ b/src/web/Image.tsx
@@ -232,7 +232,7 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         // We normally don't show an img tag because we use background images. However, if the caller has supplied an
         // onLoad or onError callback, we'll use the img tag until we receive an onLoad or onError.
         const newState: ImageState = {
-            showImgTag: (!performXhrRequest || !!cachedXhrBlobUrl) && (!!props.onLoad || !!props.onError),
+            showImgTag: !!props.onLoad || !!props.onError,
             xhrRequest: !!props.headers,
             displayUrl: displayUrl
         };


### PR DESCRIPTION
…rror events, since there's no way to get the dimensions off the background image to resolve the onload callback as callers expect.