### PR TITLE
Use localhost:8080 so /etc/hosts changes are unnecessary

### DIFF
--- a/samples/TodoList/docs/setup-and-build.md
+++ b/samples/TodoList/docs/setup-and-build.md
@@ -4,24 +4,11 @@
 ## Web Build
 To test the web build, you can run a local web server in node.
 
-### Hosts
-The hosts file defines the mappings between hostnames and IP addresses. Here are the steps to redirect the website URL so you can test private bits.
-
-On Windows, the hosts file is located in "c:\windows\system32\drivers\etc\hosts" and can be edited from within notepad running as adminstrator.
-
-On MacOS, the hosts file is located in "/private/etc/hosts" and can be edited with your favorite editor.
-
-Add this line to your hosts file:
-    ```
-    127.0.0.1 todolist-dev.sample.com
-    ```
-
 ### Node.JS
-Follow the instructions below to modify your hosts directory.
 From a command line, go to the web directory and simply type:
 ```
 node nodeserver.js
 ```
-Within a browser, open http://todolist-dev.sample.com/. You should see some debug spew as the local web server handles requests.
+Within a browser, open http://localhost:8080/. You should see some debug spew as the local web server handles requests.
 
-On Windows, IIS cannot already be running on port 80, otherwise the node server will fail to start ("Error listen EACCES 0.0.0.0:80").
+On Windows, if there is another process already bound to port 80, the node server will fail to start ("Error listen EACCES 0.0.0.0:80").

--- a/samples/TodoList/nodeserver.js
+++ b/samples/TodoList/nodeserver.js
@@ -14,7 +14,7 @@ var finalhandler = require('finalhandler');
 
 // Find our static content in the web dir.
 var serve = serveStatic('./web');
-var port = 80;
+var port = 8080;
 
 var config = {
     version: '0.0.1.0'
@@ -44,8 +44,8 @@ function handler(request, response) {
     // Require that we're serving files from the proper domain. This is
     // necessary for OAuth flow and the cert.
     var knownHosts = [
-        'todolist-dev.sample.com',
-        'todolist.sample.com'
+        'localhost:8080',
+        'localhost'
     ];
 
     if (!_.includes(knownHosts, request.headers.host)) {
@@ -107,7 +107,7 @@ console.log(
     ' Keep this server running while developing and refresh your browser for\n' +
     ' fresh assets.\n\n' +
     ' Assuming your hosts and certs have been configured properly, visit\n' +
-    ' http://todolist-dev.sample.com.\n' +
+    ' http://localhost:8080\n' +
     '───────────────────────────────────────────────────────────────────────────\n'
 );
 


### PR DESCRIPTION
I really appreciate the examples, but it's best to run things like this on localhost:8080 so no privileged access (edits to /etc/hosts) is required under normal development conditions