### PR TITLE
Expose the 'collapsable' prop on View

### DIFF
--- a/docs/docs/components/view.md
+++ b/docs/docs/components/view.md
@@ -50,6 +50,10 @@ ariaRoleDescription?: string = undefined; // Web only
 // Block touches for this component and all of its children
 blockPointerEvents: boolean = false; // iOS and Android only
 
+// Set to false to prevent the optimization that may cause this 
+// view to be removed from the hierarchy if it doesn't draw anything.
+collapsable: boolean = true; // Android only
+
 // Disable default opacity animation on touch on views that have
 // onPress handlers
 disableTouchOpacityAnimation: boolean = false;  // iOS and Android only

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -618,6 +618,7 @@ export interface ViewPropsShared extends CommonProps, CommonAccessibilityProps {
     blockPointerEvents?: boolean; // Native-only prop for disabling touches on self and all child views
     shouldRasterizeIOS?: boolean; // iOS-only prop, if view should be rendered as a bitmap before compositing
     viewLayerTypeAndroid?: ViewLayerType; // Android only property
+    collapsable?: boolean; // Android only prop
 
     restrictFocusWithin?: boolean; // Web-only, during the keyboard navigation, the focus will not go outside this view
     limitFocusWithin?: LimitFocusType; // Web-only, make the view and all focusable subelements not focusable


### PR DESCRIPTION
Android removes View instances as a performance optimization in some scenarios, e.g. if they are only used for layout and don't draw anything.  If you have code that wants to get accurate layout information for one of those instances, then it requires setting that property to false.

The code already passes all props down, so this change just exposes it in the types and docs.