### PR TITLE
Expose selection from RN.Text

### DIFF
--- a/docs/docs/components/text.md
+++ b/docs/docs/components/text.md
@@ -111,6 +111,9 @@ requestFocus(): void;
 
 // Blurs the component.
 blur(): void;
+
+// When selection is enabled, retrieves the selected text.
+getSelectedText(): string; // Windows only
 ```
 
 ## Sample Usage

--- a/samples/RXPTest/src/Tests/TextTest.tsx
+++ b/samples/RXPTest/src/Tests/TextTest.tsx
@@ -24,7 +24,7 @@ const _styles = {
         color: CommonStyles.explainTextColor
     }),
     resultContainer: RX.Styles.createViewStyle({
-        alignSelf: 'stretch',
+        alignSelf: 'stretch',        
         marginHorizontal: 36,
         marginVertical: 12
     }),
@@ -75,21 +75,41 @@ const _styles = {
         fontSize: 16,
         lineHeight: 48,
         textDecorationLine: 'underline'
+    }),
+    selectTextContainer: RX.Styles.createViewStyle({
+        margin: 12,
+        flexDirection: 'row',
+        alignItems: 'center'
+    }),
+    testSelectText: RX.Styles.createTextStyle({
+        fontSize: CommonStyles.generalFontSize
+    }),
+    selectTextButton: RX.Styles.createButtonStyle({
+        backgroundColor: '#ddd',
+        borderWidth: 1,
+        margin: 20,
+        padding: 12,
+        borderRadius: 8,
+        borderColor: 'black'
     })
 };
 
 interface TextViewState {
     test5ColorIndex: number;
+    selectedText: string;
 }
 
 const _dynamicColors = ['black', 'red', 'green', 'blue'];
 
 class TextView extends RX.Component<RX.CommonProps, TextViewState> {
+    private _selectionText: RX.Text | undefined;
+
     constructor(props: RX.CommonProps) {
         super(props);
 
         this.state = {
-            test5ColorIndex: 0
+            test5ColorIndex: 0,
+            selectedText: ''
         };
     }
 
@@ -283,6 +303,30 @@ class TextView extends RX.Component<RX.CommonProps, TextViewState> {
                         { 'Text with a red shadow.' }
                     </RX.Text>
                 </RX.View>
+
+                <RX.View style={ _styles.selectTextContainer }>
+                    <RX.Text 
+                        style={ _styles.testSelectText } 
+                        selectable={ true }
+                        ref={ (comp: any) => { this._selectionText = comp; } }
+                        >
+                        { 'Select from this text.' }
+                    </RX.Text>
+                    <RX.Button
+                        style = { _styles.selectTextButton }
+                        onPress={ this._onPressCopySelectedText }
+                    >
+                        <RX.Text>
+                            { 'Copy selected.' }
+                        </RX.Text>
+                    </RX.Button>
+                    <RX.Text style={ _styles.testSelectText }>
+                        { 'Copied selected text:' }
+                    </RX.Text>
+                    <RX.Text style={ _styles.testSelectText }>
+                        { this.state.selectedText }
+                    </RX.Text>
+                </RX.View>
             </RX.View>
         );
     }
@@ -290,6 +334,15 @@ class TextView extends RX.Component<RX.CommonProps, TextViewState> {
     private _onPressTest5 = () => {
         let newIndex = (this.state.test5ColorIndex + 1) % _dynamicColors.length;
         this.setState({ test5ColorIndex: newIndex });
+    }
+
+    private _onPressCopySelectedText = () => {
+        if (this._selectionText) {
+            var selectedText: string = '';
+            // TODO Enable when ReactXP dependency is updated.
+            // selectedText = this._selectionText.getSelectedText();
+            this.setState({ selectedText: selectedText });
+        }
     }
 }
 

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -253,6 +253,7 @@ export abstract class Text extends React.Component<Types.TextProps> implements F
     abstract focus(): void;
     abstract requestFocus(): void;
     abstract blur(): void;
+    abstract getSelectedText(): string;
 }
 
 export abstract class TextInput extends React.Component<Types.TextInputProps> implements FocusableComponent {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -569,7 +569,6 @@ export interface AnimatedImageProps extends ImagePropsShared {
 // | example     |
 export interface TextPropsShared extends CommonProps {
     selectable?: boolean;
-    onSelectionChange?: (selectedText: string) => void;
     numberOfLines?: number;
 
     // Should fonts be scaled according to system setting? Defaults

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -569,6 +569,7 @@ export interface AnimatedImageProps extends ImagePropsShared {
 // | example     |
 export interface TextPropsShared extends CommonProps {
     selectable?: boolean;
+    onSelectionChange?: (selectedText: string) => void;
     numberOfLines?: number;
 
     // Should fonts be scaled according to system setting? Defaults

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -75,6 +75,7 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
                 allowFontScaling={ this.props.allowFontScaling }
                 onPress={ onPress }
                 selectable={ this.props.selectable }
+                onSelectionChange={ this._onSelectionChange }
                 textBreakStrategy={ 'simple' }
                 ellipsizeMode={ this.props.ellipsizeMode }
                 testID={ this.props.testId }
@@ -104,6 +105,13 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
             if (this.props.onPress) {
                 this.props.onPress(EventHelpers.toMouseEvent(e));
             }
+        }
+    }
+
+    private _onSelectionChange = (e: React.SyntheticEvent<any>) => {
+        if (this.props.onSelectionChange) {
+            let selectedText: string = (e.nativeEvent as any).selectedText;
+            this.props.onSelectionChange(selectedText);
         }
     }
 

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -95,7 +95,7 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
         this._mountedComponent = component;
     }
 
-    private _onPress = (e: RN.GestureResponderEvent) => {
+    protected _onPress = (e: RN.GestureResponderEvent) => {
         if (EventHelpers.isRightMouseButton(e)) {
             if (this.props.onContextMenu) {
                 this.props.onContextMenu(EventHelpers.toMouseEvent(e));
@@ -134,6 +134,10 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
 
     blur() {
         // No-op
+    }
+
+    getSelectedText(): string {
+        return ''; // Implemented for 'windows' only (requires support from RN).
     }
 }
 

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -75,7 +75,6 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
                 allowFontScaling={ this.props.allowFontScaling }
                 onPress={ onPress }
                 selectable={ this.props.selectable }
-                onSelectionChange={ this._onSelectionChange }
                 textBreakStrategy={ 'simple' }
                 ellipsizeMode={ this.props.ellipsizeMode }
                 testID={ this.props.testId }
@@ -105,13 +104,6 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
             if (this.props.onPress) {
                 this.props.onPress(EventHelpers.toMouseEvent(e));
             }
-        }
-    }
-
-    private _onSelectionChange = (e: React.SyntheticEvent<any>) => {
-        if (this.props.onSelectionChange) {
-            let selectedText: string = (e.nativeEvent as any).selectedText;
-            this.props.onSelectionChange(selectedText);
         }
     }
 

--- a/src/web/Text.tsx
+++ b/src/web/Text.tsx
@@ -182,7 +182,7 @@ export class Text extends TextBase {
     }
 
     getSelectedText(): string {
-        return ''; // Needs implementation (requires support from RN).
+        return ''; // Not implemented yet.
     }
 }
 

--- a/src/web/Text.tsx
+++ b/src/web/Text.tsx
@@ -180,6 +180,10 @@ export class Text extends TextBase {
             }
         }
     }
+
+    getSelectedText(): string {
+        return ''; // Needs implementation (requires support from RN).
+    }
 }
 
 export default Text;

--- a/src/windows/Text.tsx
+++ b/src/windows/Text.tsx
@@ -10,6 +10,8 @@
 import * as PropTypes from 'prop-types';
 
 import AccessibilityUtil, { ImportantForAccessibilityValue } from '../native-common/AccessibilityUtil';
+import React = require('react');
+import RN = require('react-native');
 import { Text as TextBase, TextContext as TextContextBase } from '../native-common/Text';
 import { Types } from '../common/Interfaces';
 
@@ -24,6 +26,8 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
         ...TextBase.contextTypes
     };
 
+    private _selectedText: string = '';
+
     // Context is provided by super - just re-typing here
     context!: TextContext;
 
@@ -31,6 +35,45 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
         isRxParentAFocusableInSameFocusManager: PropTypes.bool,
         ...TextBase.childContextTypes
     };
+
+    render() {
+        const importantForAccessibility = AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility);
+
+        // The presence of any of the onPress or onContextMenu makes the RN.Text a potential touch responder
+        const onPress = (this.props.onPress || this.props.onContextMenu) ? this._onPress : undefined;
+
+        // The presence of an onContextMenu on this instance or on the first responder parent up the tree
+        // should disable any system provided context menu
+        const disableContextMenu = !!this.props.onContextMenu || !!this.context.isRxParentAContextMenuResponder;
+
+        const extendedProps: RN.ExtendedTextProps = {
+            maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
+            disableContextMenu: disableContextMenu,
+            onSelectionChange: this._onSelectionChange
+        };
+
+        return (
+            <RN.Text
+                style={ this._getStyles() as RN.StyleProp<RN.TextStyle> }
+                ref={ this._onMount as any }
+                importantForAccessibility={ importantForAccessibility }
+                numberOfLines={ this.props.numberOfLines }
+                allowFontScaling={ this.props.allowFontScaling }
+                onPress={ onPress }
+                selectable={ this.props.selectable }
+                textBreakStrategy={ 'simple' }
+                ellipsizeMode={ this.props.ellipsizeMode }
+                testID={ this.props.testId }
+                { ...extendedProps }
+            >
+                { this.props.children }
+            </RN.Text>
+        );
+    }
+
+    private _onSelectionChange = (selEvent: React.SyntheticEvent<RN.Text>) => {
+        this._selectedText = (selEvent.nativeEvent as any).selectedText;
+    }
 
     requestFocus() {
         // UWP doesn't support casually focusing RN.Text elements. We override requestFocus in order to drop any focus requests
@@ -73,6 +116,10 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
                 importantForAccessibility: importantForAccessibility
             });
         }
+    }
+
+    getSelectedText(): string {
+        return this._selectedText;
     }
 }
 


### PR DESCRIPTION
In order to be able to do partial select/copy/paste, we'll expose the selected text and event from RNW. We need to expose this via ReactXP so that the application code can use them.