### PR TITLE
Added support for multi window apps to Alert.

### DIFF
--- a/docs/docs/apis/alert.md
+++ b/docs/docs/apis/alert.md
@@ -59,6 +59,11 @@ interface AlertOptions {
 
     // Optional theme (web only)
     theme?: AlertModalTheme;
+
+    // (Android, iOS, and Windows only)
+    // Optional: the id of the root view this alert is associated with.
+    // Defaults to the view set by UserInterface.setMainView().
+    rootViewId?: string;
 }
 
 ```

--- a/docs/docs/apis/modal.md
+++ b/docs/docs/apis/modal.md
@@ -20,7 +20,7 @@ A modal covers the entire screen but is transparent. Its children define the vis
 ## Types
 ``` javascript
 interface ModalOptions {
-    // Android & iOS only.
+    // Android, iOS, and Windows only.
     // The id of the root view this modal is associated with.
     // Defaults to the view set by UserInterface.setMainView();
     rootViewId?: string;

--- a/docs/docs/apis/popup.md
+++ b/docs/docs/apis/popup.md
@@ -83,7 +83,7 @@ interface PopupOptions {
     // repeatedly. Note that this is only a hint, popups cannot be force-cached.
     cacheable?: boolean;
 
-    // Android & iOS only.
+    // Android, iOS, and Windows only.
     // The id of the root view this popup is associated with.
     // Defaults to the view set by UserInterface.setMainView();
     rootViewId?: string;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1053,7 +1053,7 @@ export interface PopupOptions {
     // repeatedly. Note that this is only a hint, popups cannot be force-cached.
     cacheable?: boolean;
 
-    // Android & iOS only.
+    // Android, iOS, and Windows only.
     // The id of the root view this popup is associated with.
     // Defaults to the view set by UserInterface.setMainView();
     rootViewId?: string;
@@ -1061,7 +1061,7 @@ export interface PopupOptions {
 
 // Modal
 export interface ModalOptions {
-    // Android & iOS only.
+    // Android, iOS, and Windows only.
     // The id of the root view this modal is associated with.
     // Defaults to the view set by UserInterface.setMainView();
     rootViewId?: string;
@@ -1098,6 +1098,7 @@ export interface AlertModalTheme {
 export interface AlertOptions {
     icon?: string;
     theme?: AlertModalTheme;
+    rootViewId?: string;
 }
 
 //

--- a/src/native-common/Alert.ts
+++ b/src/native-common/Alert.ts
@@ -9,14 +9,27 @@
 
 import RN = require('react-native');
 
+import AppConfig from '../common/AppConfig';
 import RX = require('../common/Interfaces');
 import Types = require('../common/Types');
+import UserInterface from '../native-common/UserInterface';
 
 // Native implementation for alert dialog boxes
 export class Alert implements RX.Alert {
     public show(title: string, message?: string, buttons?: Types.AlertButtonSpec[],
             options?: RX.Types.AlertOptions): void {
-        RN.Alert.alert(title, message, buttons);
+
+        let alertOptions: RN.ExtendedAlertOptions = {};
+        if (options && options.rootViewId) {
+            const nodeHandle = UserInterface.findNodeHandleByRootViewId(options.rootViewId);
+            if (nodeHandle) {
+                alertOptions.rootViewHint = nodeHandle;
+            } else if (AppConfig.isDevelopmentMode()) {
+                console.warn('rootViewId does not exist: ', options.rootViewId);
+            }
+        }
+
+        RN.Alert.alert(title, message, buttons, alertOptions);
     }
 }
 

--- a/src/native-common/RootView.tsx
+++ b/src/native-common/RootView.tsx
@@ -20,6 +20,7 @@ import FrontLayerViewManager from './FrontLayerViewManager';
 import MainViewStore from './MainViewStore';
 import Styles from './Styles';
 import Types = require('../common/Types');
+import UserInterface from '../native-common/UserInterface';
 
 // Fields should be prefixed with 'reactxp' to help avoid naming collisions.
 // All fields should be removed from this.props before passing downwards.
@@ -89,7 +90,17 @@ abstract class BaseRootView<P extends BaseRootViewProps> extends React.Component
         });
     }
 
+    componentDidMount(): void {
+        if (this._rootViewId) {
+            UserInterface.notifyRootViewInstanceCreated(this._rootViewId, RN.findNodeHandle(this)!!!);
+        }
+    }
+
     componentWillUnmount(): void {
+        if (this._rootViewId) {
+            UserInterface.notifyRootViewInstanceDestroyed(this._rootViewId);
+        }
+
         if (this._frontLayerViewChangedSubscription) {
             this._frontLayerViewChangedSubscription.unsubscribe();
             this._frontLayerViewChangedSubscription = undefined;

--- a/src/typings/react-native-extensions.d.ts
+++ b/src/typings/react-native-extensions.d.ts
@@ -79,4 +79,8 @@ declare module 'react-native' {
     interface ExtendedAccessibilityInfoStatic extends RN.AccessibilityInfoStatic {
         static initialHighContrast: boolean|undefined;
     }
+
+    interface ExtendedAlertOptions extends RN.AlertOptions {
+        rootViewHint?: number;
+    }
 }


### PR DESCRIPTION
A committed but not yet released version of RN for Windows adds support for alerts in multi window apps by the means of a new option in RN.AlertOptions. This option is a react tag that is used as a hint by the native side to detect the right top level window to parent the native alert.
ReactXP API models the identification of root views through "rootViewId" properties. They are already used for modals/popups, so we're adding same property to RXP.AlertOptions.
The implementation keeps a list of active root views in order to quickly map the rootViewId to the RNW expected react tag hint.
This mechanism will be used for other APIs as well in future PRs (there's one where we pass the rootViewId to RNW directly, and that in not very clean since it expects RNW to understand RXP properties)