### PR TITLE
#768 disable cursor type override

### DIFF
--- a/src/web/Text.tsx
+++ b/src/web/Text.tsx
@@ -104,19 +104,24 @@ export class Text extends React.Component<Types.TextProps, {}> {
         let combinedStyles = Styles.combine([this.props.numberOfLines === 1 ?
             _styles.ellipsis : _styles.defaultStyle, this.props.style]) as any;
 
-        // Handle cursor styles
         if (this.props.selectable) {
-            combinedStyles['cursor'] = 'text';
             combinedStyles['userSelect'] = 'text';
             combinedStyles['WebkitUserSelect'] = 'text';
             combinedStyles['MozUserSelect'] = 'text';
             combinedStyles['msUserSelect'] = 'text';
-        } else {
-            combinedStyles['cursor'] = 'inherit';
         }
+        
+        // Handle cursor styles
+        if (!combinedStyles.cursor) {
+            if (this.props.selectable) {
+                combinedStyles['cursor'] = 'text';
+            } else {
+                combinedStyles['cursor'] = 'inherit';
+            }
 
-        if (this.props.onPress) {
-            combinedStyles['cursor'] = 'pointer';
+            if (this.props.onPress) {
+                combinedStyles['cursor'] = 'pointer';
+            }
         }
 
         return combinedStyles;


### PR DESCRIPTION
Currently the cursor type can be overridden by the ReactXP despite developers´s explicit cursor selection. This PR allows the ReactXP to change the cursor only if the developer have not selected one.