### PR TITLE
Fix regression introduced by #753

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
@@ -218,7 +218,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -290,7 +290,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.11"

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -257,7 +257,7 @@ export class EventHelpers {
             mouseEvent.clientY = mouseEvent.pageY = nativeEvent.pageY;
         }
 
-        mouseEvent.button = this.toMouseButton(e.nativeEvent as Types.TouchEvent);
+        mouseEvent.button = this.toMouseButton(e.nativeEvent);
 
         if (nativeEvent.shiftKey) {
             mouseEvent.shiftKey = nativeEvent.shiftKey;
@@ -293,8 +293,7 @@ export class EventHelpers {
         return dndEvent;
     }
 
-    toMouseButton(e: Types.TouchEvent): number {
-        const nativeEvent = e as any;
+    toMouseButton(nativeEvent: any): number {
         if (nativeEvent.button !== undefined) {
             return nativeEvent.button;
         } else if (nativeEvent.isRightButton || nativeEvent.IsRightButton) {
@@ -324,7 +323,7 @@ export class EventHelpers {
     }
 
     isRightMouseButton(e: Types.SyntheticEvent): boolean {
-        return (this.toMouseButton(e as Types.TouchEvent) === 2);
+        return (this.toMouseButton(e.nativeEvent) === 2);
     }
 
     // Keyboard events do not inherently hold a position that can be used to show flyouts on keyboard input.


### PR DESCRIPTION
Right click stopped working in UWP due to the change in isRightMouseButton. 
The expected parameter is a synthetic event as received from RN implementations, with a nativeEvent payload.
Change #753 cast that to the native payload expected by toMouseButton, which is incorrect. That broke UWP and I seriously doubt it worked for Mac.
I kept the use of toMouseButton by fixing isRightMouseButton to pass the right payload.

More, using Types.TouchEvent (or any Types.* definition) to describe the nativeEvent is wrong in my opinion. It's proven by the first thing toMouseButton used to do: casting to any, not to mention by the regression itself.
So I switched the parameter type to "any" and I removed SOME of the useless casts. I didn't touch the gesture code because it's complex and I may not understand it well, perhaps @thezero could fix when he has time. 

Cc: @alregner 