### PR TITLE
[Web] #300 Fix the bug where AccessibilityAnnouncer creates a div which is reachable by screen readers

### DIFF
--- a/src/web/AccessibilityAnnouncer.tsx
+++ b/src/web/AccessibilityAnnouncer.tsx
@@ -112,6 +112,10 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
                 aria-live={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Assertive) }
                 aria-atomic={ 'true' }
                 aria-relevant={ 'additions text' }
+                aria-hidden={ 'true' }
+                role={ 'presentation' }
+                tabIndex={ -1 }
+                aria-label={ this.state.announcementText }
             >
                 { announcement }
             </div>


### PR DESCRIPTION
#300  Fix the bug where AccessibilityAnnouncer would create a div which is reachable by screen readers, the role of the div "Group" was also included in the announcement.

The combination of aria-hidden={ 'true' }, role={ 'presentation' } and tabIndex={ -1 } ensures that this div and its children are hidden from screen readers, they become unreachable and their roles won't be announced anymore.

However, this does mean that the screen reader will not be reading { announcement } at line 120 anymore. Instead it will be reading the attribute aria-label. The announcement is still triggered by the change of { announcement }.

