### PR TITLE
[Web] #300 Fix the bug where AccessibilityAnnouncer creates a div which is reachable by screen readers

### DIFF
--- a/src/web/AccessibilityAnnouncer.tsx
+++ b/src/web/AccessibilityAnnouncer.tsx
@@ -119,9 +119,7 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
                 aria-atomic={ 'true' }
                 aria-relevant={ 'additions text' }
                 aria-hidden={ this.state.ariaHidden }
-                role={ 'presentation' }
-                tabIndex={ -1 }
-                aria-label={ this.state.announcementText }
+                role={ _isMac ? '' : 'Status' }
             >
                 { announcement }
             </div>

--- a/src/web/AccessibilityAnnouncer.tsx
+++ b/src/web/AccessibilityAnnouncer.tsx
@@ -112,6 +112,10 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
                 aria-live={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Assertive) }
                 aria-atomic={ 'true' }
                 aria-relevant={ 'additions text' }
+                aria-hidden={ 'true' }
+                role={ 'presentation' }
+                tabIndex={ -1 }
+                aria-label={ this.state.announcementText }
             >
                 { announcement }
             </div>

--- a/src/web/AccessibilityAnnouncer.tsx
+++ b/src/web/AccessibilityAnnouncer.tsx
@@ -19,6 +19,9 @@ export interface AccessibilityAnnouncerState {
     // Screen Reader text to be announced.
     announcementText: string;
 
+    // Hides the div from aria tree when it's not used so that it can't be accessed from screen reader
+    ariaHidden: boolean;
+
     // Render announcementText in a nested div to work around browser quirks for windows.
     // Nested divs break mac.
     announcementTextInNestedDiv: boolean;
@@ -62,7 +65,8 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
                     // annnouncementText should never be in nested div for mac.
                     // Voice over ignores reading nested divs in aria-live container.
                     this.setState({
-                        announcementText: announcement
+                        announcementText: announcement,
+                        ariaHidden: false
                     });
                 } else {
 
@@ -71,7 +75,8 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
                     // not announce aria-live reliably without this, for example.
                     this.setState({
                         announcementText: announcement,
-                        announcementTextInNestedDiv: !this.state.announcementTextInNestedDiv
+                        announcementTextInNestedDiv: !this.state.announcementTextInNestedDiv,
+                        ariaHidden: false
                     });
                 }
             });
@@ -82,6 +87,7 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
     private _getInitialState(): AccessibilityAnnouncerState {
         return {
             announcementText: '',
+            ariaHidden: true,
             announcementTextInNestedDiv: false
         };
     }
@@ -112,7 +118,7 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
                 aria-live={ AccessibilityUtil.accessibilityLiveRegionToString(Types.AccessibilityLiveRegion.Assertive) }
                 aria-atomic={ 'true' }
                 aria-relevant={ 'additions text' }
-                aria-hidden={ 'true' }
+                aria-hidden={ this.state.ariaHidden }
                 role={ 'presentation' }
                 tabIndex={ -1 }
                 aria-label={ this.state.announcementText }
@@ -134,7 +140,8 @@ export class AccessibilityAnnouncer extends React.Component<{}, AccessibilityAnn
 
         this._clearAnnouncementTimer = window.setTimeout(() => {
             this.setState({
-                announcementText: ''
+                announcementText: '',
+                ariaHidden: true
             });
         }, 2000);
     }


### PR DESCRIPTION
This is a continuation of #798, the previous PR was closed and I cannot reopen it.

#300 Fix the bug where AccessibilityAnnouncer would create a div which is reachable by screen readers, the role of the div "Group" was also included in the announcement.

The combination of aria-hidden={ 'true' }, role={ 'presentation' } and tabIndex={ -1 } ensures that this div and its children are hidden from screen readers, they become unreachable and their roles won't be announced anymore.

The aria-hidden={'true'} will hide the object from aria and disable the aria-live function. So it's changed to a state ariaHidden, which will be set to true when there's no announcement through _startClearAnnouncementTimer, and set to false when there's a new announcement.

However, this does mean that the screen reader will not be reading { announcement } at line 126 anymore. Instead it will be reading the attribute aria-label. The announcement is still triggered by the change of { announcement }.