### PR TITLE
Remove code duplication for render in RX.Text

### DIFF
--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -57,14 +57,7 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
         // The presence of any of the onPress or onContextMenu makes the RN.Text a potential touch responder
         const onPress = (this.props.onPress || this.props.onContextMenu) ? this._onPress : undefined;
 
-        // The presence of an onContextMenu on this instance or on the first responder parent up the tree
-        // should disable any system provided context menu
-        const disableContextMenu = !!this.props.onContextMenu || !!this.context.isRxParentAContextMenuResponder;
-
-        const extendedProps: RN.ExtendedTextProps = {
-            maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
-            disableContextMenu: disableContextMenu
-        };
+        var extendedProps: RN.ExtendedTextProps = this._getExtendedProperties();
 
         return (
             <RN.Text
@@ -95,7 +88,18 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
         this._mountedComponent = component;
     }
 
-    protected _onPress = (e: RN.GestureResponderEvent) => {
+    protected _getExtendedProperties(): RN.ExtendedTextProps {
+        // The presence of an onContextMenu on this instance or on the first responder parent up the tree
+        // should disable any system provided context menu
+        const disableContextMenu = !!this.props.onContextMenu || !!this.context.isRxParentAContextMenuResponder;
+
+        return {
+            maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
+            disableContextMenu: disableContextMenu,
+        };
+    }
+
+    private _onPress = (e: RN.GestureResponderEvent) => {
         if (EventHelpers.isRightMouseButton(e)) {
             if (this.props.onContextMenu) {
                 this.props.onContextMenu(EventHelpers.toMouseEvent(e));

--- a/src/windows/Text.tsx
+++ b/src/windows/Text.tsx
@@ -36,39 +36,12 @@ export class Text extends TextBase implements React.ChildContextProvider<TextCon
         ...TextBase.childContextTypes
     };
 
-    render() {
-        const importantForAccessibility = AccessibilityUtil.importantForAccessibilityToString(this.props.importantForAccessibility);
-
-        // The presence of any of the onPress or onContextMenu makes the RN.Text a potential touch responder
-        const onPress = (this.props.onPress || this.props.onContextMenu) ? this._onPress : undefined;
-
-        // The presence of an onContextMenu on this instance or on the first responder parent up the tree
-        // should disable any system provided context menu
-        const disableContextMenu = !!this.props.onContextMenu || !!this.context.isRxParentAContextMenuResponder;
-
-        const extendedProps: RN.ExtendedTextProps = {
-            maxContentSizeMultiplier: this.props.maxContentSizeMultiplier,
-            disableContextMenu: disableContextMenu,
+    protected _getExtendedProperties(): RN.ExtendedTextProps {
+        var superExtendedProps: RN.ExtendedTextProps = super._getExtendedProperties();
+        return {
+            ...superExtendedProps,
             onSelectionChange: this._onSelectionChange
         };
-
-        return (
-            <RN.Text
-                style={ this._getStyles() as RN.StyleProp<RN.TextStyle> }
-                ref={ this._onMount as any }
-                importantForAccessibility={ importantForAccessibility }
-                numberOfLines={ this.props.numberOfLines }
-                allowFontScaling={ this.props.allowFontScaling }
-                onPress={ onPress }
-                selectable={ this.props.selectable }
-                textBreakStrategy={ 'simple' }
-                ellipsizeMode={ this.props.ellipsizeMode }
-                testID={ this.props.testId }
-                { ...extendedProps }
-            >
-                { this.props.children }
-            </RN.Text>
-        );
     }
 
     private _onSelectionChange = (selEvent: React.SyntheticEvent<RN.Text>) => {


### PR DESCRIPTION
User override method to get extended properties in order to avoid duplicating render for RX.Text in derived components.