### PR TITLE
Using SyncTasks.fromThenable to wrap the ES6 promises so that we don'…

### DIFF
--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -35,35 +35,23 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
     };
 
     static prefetch(url: string): SyncTasks.Promise<boolean> {
-        const defer = SyncTasks.Defer<boolean>();
-
-        RN.Image.prefetch(url).then((value: boolean) => {
-            defer.resolve(value);
-        }).catch((error: any) => {
-            defer.reject(error);
-        });
-
-        return defer.promise();
+        return SyncTasks.fromThenable(RN.Image.prefetch(url));
     }
 
     static getMetadata(url: string): SyncTasks.Promise<Types.ImageMetadata> {
-        const defer = SyncTasks.Defer<Types.ImageMetadata>();
-
-        Image.prefetch(url).then(success => {
+        return SyncTasks.fromThenable(Image.prefetch(url)).then(success => {
             if (!success) {
-                defer.reject(`Prefetching url ${ url } did not succeed.`);
+                return SyncTasks.Rejected(`Prefetching url ${ url } did not succeed.`);
             } else {
+                const defer = SyncTasks.Defer<Types.ImageMetadata>();
                 RN.Image.getSize(url, (width, height) => {
                     defer.resolve({ width, height });
                 }, error => {
                     defer.reject(error);
                 });
+                return defer.promise();
             }
-        }).catch((error: any) => {
-            defer.reject(error);
         });
-
-        return defer.promise();
     }
 
     protected _mountedComponent: RN.Image | null = null;

--- a/src/native-common/Linking.ts
+++ b/src/native-common/Linking.ts
@@ -23,46 +23,35 @@ export class Linking extends CommonLinking {
     }
 
     protected _openUrl(url: string): SyncTasks.Promise<void> {
-        let defer = SyncTasks.Defer<void>();
-
-        RN.Linking.canOpenURL(url).then(value => {
+        return SyncTasks.fromThenable(RN.Linking.canOpenURL(url))
+        .then(value => {
             if (!value) {
-                defer.reject({
+                return SyncTasks.Rejected({
                     code: Types.LinkingErrorCode.NoAppFound,
                     url: url,
                     description: 'No app found to handle url: ' + url
                 } as Types.LinkingErrorInfo);
             } else {
-                RN.Linking.openURL(url).then(() => {
-                    defer.resolve(void 0);
-                }, err => {
-                    defer.reject(err);
-                });
+                return SyncTasks.fromThenable(RN.Linking.openURL(url));
             }
         }).catch(error => {
-            defer.reject({
+            return SyncTasks.Rejected({
                 code: Types.LinkingErrorCode.UnexpectedFailure,
                 url: url,
                 description: error
             } as Types.LinkingErrorInfo);
         });
-
-        return defer.promise();
     }
 
     getInitialUrl(): SyncTasks.Promise<string|undefined> {
-        let defer = SyncTasks.Defer<string|undefined>();
-
-        RN.Linking.getInitialURL().then(url => {
-            defer.resolve(!!url ? url : undefined);
-        }).catch(error => {
-            defer.reject({
+        return SyncTasks.fromThenable(RN.Linking.getInitialURL())
+        .then(url => !!url ? url : undefined)
+        .catch(error => {
+            return SyncTasks.Rejected({
                 code: Types.LinkingErrorCode.InitialUrlNotFound,
                 description: error
             } as Types.LinkingErrorInfo);
         });
-
-        return defer.promise();
     }
 
     // Launches Email app


### PR DESCRIPTION
…t get exceptions in callback handlers bubbling all the way back up to RX.Linking's error catcher and confusing developers.