### PR TITLE
Fixed spelling errors and typos within the documentation.

### DIFF
--- a/docs/docs/apis/accessibility.md
+++ b/docs/docs/apis/accessibility.md
@@ -28,6 +28,6 @@ announceForAccessibility(announcement: string): void;
 // Indicates whether a screen reader is currently enabled.
 isScreenReaderEnabled(): boolean;
 
-// Inidicates whether the OS-level "high-contrast" setting is enabled.
+// Indicates whether the OS-level "high-contrast" setting is enabled.
 isHighContrastEnabled(): boolean;
 ```

--- a/docs/docs/apis/statusbar.md
+++ b/docs/docs/apis/statusbar.md
@@ -27,6 +27,6 @@ setNetworkActivityIndicatorVisible(value: boolean): void;
 // Specifies the background color of the status bar (applies on Android only)
 setBackgroundColor(color: string, animated: boolean): void;
 
-// Specifies whether the status bar is transluscent or transparent
+// Specifies whether the status bar is translucent or transparent
 setTranslucent(translucent: boolean): void;
 ```

--- a/docs/docs/apis/userinterface.md
+++ b/docs/docs/apis/userinterface.md
@@ -73,7 +73,7 @@ enableTouchLatencyEvents(latencyThresholdMs: number): void;
 
 // Returns true if the application is in the keyboard navigation state,
 // when the user is using Tab key to navigate through the focusable
-// elements (on applicalbe platforms).
+// elements (on applicable platforms).
 isNavigatingWithKeyboard(): boolean;
 ```
 

--- a/docs/docs/components/link.md
+++ b/docs/docs/components/link.md
@@ -26,7 +26,7 @@ autoFocus: boolean = false;
 
 // Should the scale multiplier be capped when allowFontScaling is set to true?
 // Possible values include the following:
-// null/undefined (default) - inheret from parent/global default
+// null/undefined (default) - inherit from parent/global default
 // 0 - no max
 // >= 1 - sets the maxContentSizeMultiplier of this node to this value
 // Note: Older versions of React Native don’t support this interface.

--- a/docs/docs/components/view.md
+++ b/docs/docs/components/view.md
@@ -223,7 +223,7 @@ requestFocus(): void;
 blur(): void;
 
 // The focus does not go outside the view with restrictFocusWithin by default,
-// setFocusRestricted() allows to turn this restricton off and back on.
+// setFocusRestricted() allows to turn this restriction off and back on.
 setFocusRestricted(restricted: boolean): void; // web only
 
 

--- a/docs/docs/extensions/database.md
+++ b/docs/docs/extensions/database.md
@@ -9,6 +9,6 @@ next: extensions/imagesvg
 
 ReactXP provides a [Storage API](/reactxp/docs/apis/storage) for reading and writing simple key/value pairs. Many apps have more complex storage requirements. For this, we developed a no-SQL database wrapper that works on React Native and on browsers. The solution isn't tied to ReactXP, but they work well together.
 
-For more details, refer to the [NoSqlProvider](https://github.com/Microsoft/NoSQLProvider) github site.
+For more details, refer to the [NoSqlProvider](https://github.com/Microsoft/NoSQLProvider) GitHub site.
 
 To install: ```npm install nosqlprovider```

--- a/docs/docs/extensions/restclient.md
+++ b/docs/docs/extensions/restclient.md
@@ -11,7 +11,7 @@ ReactXP provides basic [Network APIs](/reactxp/docs/apis/network) for determinin
 
 This extension provides a cross-platform mechanism for wrapping a simple REST API. It supports optional retry logic (including exponential backoff).
 
-For more details, refer to the [SimpleRestClients](https://github.com/Microsoft/SimpleRestClients) github site.
+For more details, refer to the [SimpleRestClients](https://github.com/Microsoft/SimpleRestClients) GitHub site.
 
 To install: ```npm install simplerestclients``` or  ```yarn add simplerestclients```
 


### PR DESCRIPTION
I have fixed spelling errors and typos found within the documentation, and also capitalized brand names accordingly.