### PR TITLE
Make buttons drag and droppable

### DIFF
--- a/docs/docs/components/button.md
+++ b/docs/docs/components/button.md
@@ -89,6 +89,17 @@ onPressIn: (e: SyntheticEvent) => void;
 // user's finger or mouse cursor is no longer over the view
 onPressOut: (e: SyntheticEvent) => void;
 
+// For drag specific events, if onDragStart is present, the button is draggable.
+// onDragStart/onDrag/onDragEnd are source specific events
+// onDragEnter/onDragOver/onDragLeave/onDrop are destination specific events
+onDragStart: (e: DragEvent) => void = undefined;
+onDrag: (e: DragEvent) => void = undefined;
+onDragEnd: (e: DragEvent) => void = undefined;
+onDragEnter: (e: DragEvent) => void = undefined;
+onDragOver: (e: DragEvent) => void = undefined;
+onDragLeave: (e: DragEvent) => void = undefined;
+onDrop: (e: DragEvent) => void = undefined;
+
 // Rasterize contents using offscreen bitmap (perf optimization)
 shouldRasterizeIOS: boolean = false; // iOS only
 

--- a/samples/RXPTest/src/Tests/DragAndDropTest.tsx
+++ b/samples/RXPTest/src/Tests/DragAndDropTest.tsx
@@ -37,7 +37,7 @@ const _styles = {
     dragAndDropContainer: RX.Styles.createViewStyle({
         flexDirection: 'row',
         flex: 1,
-        height: 70
+        height: 100
     }),
     dragAndDropView: RX.Styles.createViewStyle({
         flex: 1,
@@ -50,8 +50,14 @@ const _styles = {
     }),
     dragAndDropObject: RX.Styles.createViewStyle({
         height: 40,
-        width: 40,
+        width: 80,
         backgroundColor: CommonStyles.successTextColor,
+        marginTop: 5
+    }),
+     dragAndDropButton: RX.Styles.createViewStyle({
+        height: 40,
+        width: 80,
+        backgroundColor: CommonStyles.buttonBackgroundColor,
         marginTop: 5
     })
 };
@@ -74,7 +80,8 @@ class DragAndDropView extends RX.Component<RX.CommonProps, DragAndDropViewState>
         super(props);
 
         this.state = {
-            isFileDragAndDropHover: false,
+            isFileDragAndDropHoverView: false,
+            isFileDragAndDropHoverButton: false,
             logViewDragAndDrop: [],
             filesDropped: [],
             isViewDragAndDropHover: false,
@@ -87,35 +94,58 @@ class DragAndDropView extends RX.Component<RX.CommonProps, DragAndDropViewState>
             <RX.View style={ _styles.container}>
                 <RX.View style={ _styles.textContainer } key={ 'explanation1' }>
                     <RX.Text style={ _styles.explainText }>
-                        { 'Drag one or more files over to the container below' }
+                        { 'Drag one or more files over to the view container below' }
                     </RX.Text>
                 </RX.View>
                 <RX.View 
-                    style={ [ _styles.labelContainer, this.state.isFileDragAndDropHover ? _styles.labelContainerHover : undefined ] }
-                    onDragEnter={ this._onDragEnterForFiles }
-                    onDragLeave={ this._onDragLeaveForFiles }
-                    onDragOver={ this._onDragOverForFiles }
-                    onDrop={ this._onDropForFiles }>
+                    style={ [ _styles.labelContainer, this.state.isFileDragAndDropHoverView ? _styles.labelContainerHover : undefined ] }
+                    onDragEnter={ this._onDragEnterForFilesFromView }
+                    onDragLeave={ this._onDragLeaveForFilesFromView }
+                    onDragOver={ this._onDragOverForFilesFromView }
+                    onDrop={ this._onDropForFilesFromView }>
                     <RX.Text style={ _styles.explainText }>
                         { 'Drop target' }
                     </RX.Text>
                 </RX.View>
 
+                 <RX.View style={ _styles.textContainer } key={ 'explanation2' }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'Drag one or more files over to the button container below' }
+                    </RX.Text>
+                </RX.View>
+                <RX.Button 
+                    style={ [ _styles.labelContainer, this.state.isFileDragAndDropHoverButton ? _styles.labelContainerHover : undefined ] }
+                    onDragEnter={ this._onDragEnterForFilesFromButton }
+                    onDragLeave={ this._onDragLeaveForFilesFromButton }
+                    onDragOver={ this._onDragOverForFilesFromButton }
+                    onDrop={ this._onDropForFilesFromButton }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'Drop target' }
+                    </RX.Text>
+                </RX.Button>
+
                 { this._renderDroppedFiles() }
 
-                <RX.View style={ _styles.textContainer } key={ 'explanation2' }>
+                <RX.View style={ _styles.textContainer } key={ 'explanation3' }>
                     <RX.Text style={ _styles.explainText }>
-                        { 'Drag the square from the left side to the right side' }
+                        { 'Drag the green view or grey button from the left side to the right side' }
                     </RX.Text>
                 </RX.View>
 
                 <RX.View style={ [ _styles.textContainer, _styles.dragAndDropContainer ] }>
                     <RX.View style={ [ _styles.dragAndDropView, _styles.explainText ] }>
                         <RX.View 
-                            onDragStart={ this._onDragStartForViews }
+                            onDragStart={ this._onDragStartForViewsOrButtons }
                             style={ _styles.dragAndDropObject }
                             >
+                            { 'Draggable View' }
                         </RX.View>
+                        <RX.Button 
+                            onDragStart={ this._onDragStartForViewsOrButtons }
+                            style={ _styles.dragAndDropButton }
+                            >
+                            { 'Draggable Button' }
+                        </RX.Button>
                     </RX.View>
                     <RX.View style={ _styles.dragAndDropView }>
                         <RX.Text style={ _styles.explainText }>
@@ -133,7 +163,6 @@ class DragAndDropView extends RX.Component<RX.CommonProps, DragAndDropViewState>
                         </RX.Text>
                     </RX.View>
                 </RX.View>
-
                 { this._renderViewDragStart() }
 
             </RX.View>
@@ -185,37 +214,7 @@ class DragAndDropView extends RX.Component<RX.CommonProps, DragAndDropViewState>
         );
     }
 
-    private _onDragEnterForFiles = (e: RX.Types.DragEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        this.setState({
-            isFileDragAndDropHover: true
-        });
-    }
-
-    private _onDragLeaveForFiles = (e: RX.Types.DragEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        this.setState({
-            isFileDragAndDropHover: false
-        });
-    }
-
-    private _onDragOverForFiles = (e: RX.Types.DragEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        this.setState({
-            isFileDragAndDropHover: true
-        });
-    }
-
-    private _onDropForFiles = (e: RX.Types.DragEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-
+    private _getFilesDropped(e: RX.Types.DragEvent) {
         let filesDropped: FileInfo[] = [];
         _.each(e.dataTransfer.files, fileData => {
             const fileInfo: FileInfo = {
@@ -226,14 +225,90 @@ class DragAndDropView extends RX.Component<RX.CommonProps, DragAndDropViewState>
             filesDropped.push(fileInfo);
         });
 
+        return filesDropped;
+    }
+
+    private _onDragEnterForFilesFromView = (e: RX.Types.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
         this.setState({
-            isFileDragAndDropHover: false,
+            isFileDragAndDropHoverView: true
+        });
+    }
+
+    private _onDragLeaveForFilesFromView = (e: RX.Types.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        this.setState({
+            isFileDragAndDropHoverView: false
+        });
+    }
+
+    private _onDragOverForFilesFromView = (e: RX.Types.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        this.setState({
+            isFileDragAndDropHoverView: true
+        });
+    }
+
+    private _onDropForFilesFromView = (e: RX.Types.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const filesDropped: FileInfo[] = this._getFilesDropped(e);
+
+        this.setState({
+            isFileDragAndDropHoverView: false,
             filesDropped: filesDropped
         });
     }
 
-    private _onDragStartForViews = (e: RX.Types.DragEvent) => {
-        e.dataTransfer.dropEffect = 'move';
+    private _onDragEnterForFilesFromButton = (e: RX.Types.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        this.setState({
+            isFileDragAndDropHoverButton: true
+        });
+    }
+
+    private _onDragLeaveForFilesFromButton = (e: RX.Types.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        this.setState({
+            isFileDragAndDropHoverButton: false
+        });
+    }
+
+    private _onDragOverForFilesFromButton = (e: RX.Types.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        this.setState({
+            isFileDragAndDropHoverButton: true
+        });
+    }
+
+    private _onDropForFilesFromButton = (e: RX.Types.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const filesDropped: FileInfo[] = this._getFilesDropped(e);
+
+        this.setState({
+            isFileDragAndDropHoverButton: false,
+            filesDropped: filesDropped
+        });
+    }
+
+    private _onDragStartForViewsOrButtons = (e: RX.Types.DragEvent) => {
+        e.dataTransfer.effectAllowed = 'copy';
+        e.dataTransfer.dropEffect = 'copy';
         e.dataTransfer.setData('transferData', new Date().toLocaleTimeString());
     }
 

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -496,6 +496,13 @@ export interface ButtonProps extends CommonStyledProps<ButtonStyleRuleSet>, Comm
     onKeyPress?: (e: KeyboardEvent) => void;
     onFocus?: (e: FocusEvent) => void;
     onBlur?: (e: FocusEvent) => void;
+    onDragStart?: (e: DragEvent) => void;
+    onDrag?: (e: DragEvent) => void;
+    onDragEnd?: (e: DragEvent) => void;
+    onDragEnter?: (e: DragEvent) => void;
+    onDragOver?: (e: DragEvent) => void;
+    onDragLeave?: (e: DragEvent) => void;
+    onDrop?: (e: DragEvent) => void;
 
     shouldRasterizeIOS?: boolean; // iOS-only prop, if view should be rendered as a bitmap before compositing
 

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -115,6 +115,14 @@ export class Button extends ButtonBase {
                 aria-controls={ this.props.ariaControls }
                 id={ this.props.id }
                 data-test-id={ this.props.testId }
+                draggable={ this.props.onDragStart ? true : false}
+                onDragStart={ this.props.onDragStart }
+                onDrag={ this.props.onDrag }
+                onDragEnd={ this.props.onDragEnd }
+                onDragEnter={ this.props.onDragEnter }
+                onDragOver={ this.props.onDragOver }
+                onDragLeave={ this.props.onDragLeave }
+                onDrop={ this.props.onDrop }
             >
                 { this.props.children }
             </button>


### PR DESCRIPTION
Currently we have ability to drag and drop views only. Extending the ability to make buttons drag and droppable. 

For web - added the properties to button. 
For native platforms - Buttons are internally views. So the properties will be available as it is already existing. 