### PR TITLE
Simple abstraction to support RN.Animated.Event semantics

### DIFF
--- a/docs/docs/animations.md
+++ b/docs/docs/animations.md
@@ -103,6 +103,7 @@ animatedOpacityValue.setValue(0.0);
 ReactXP animation APIs on the web are implemented using DOM style transitions, as opposed to using JavaScript code to drive the animation. This results in much better performance and (in most cases) glitch-free animations, but it imposes some limitations on the use of the animation APIs.
 * All active animated values associated with a particular element must share the same timing parameters (duration, easing function, delay, loop) and must be started at the same time.
 * Each animated value can be associated with only one animated attribute that is actively running.
-* Interpolated values are limited to only two values -- a begin and end value -- and must be specified in increasing order.
-* For interpolated values, the starting and ending values of an animation must correspond to the two interpolation keys.
+* Interpolated values used with startTransition are limited to only two values -- a begin and end value -- and must be specified in increasing order.
+* Interpolated values not used with startTransition must have numeric outputValues, since we're interpolating between them ourselves.
+* For interpolated values, the starting and ending values of a transition animation must correspond to the two interpolation keys.
 * If an animation is stopped, the value will not reflect the intermediate position in the case of transforms and interpolated values.

--- a/docs/docs/components/scrollview.md
+++ b/docs/docs/components/scrollview.md
@@ -56,7 +56,7 @@ scrollXAnimatedValue?: RX.Types.AnimatedValue;
 scrollYAnimatedValue?: RX.Types.AnimatedValue;
 
 // Android only property to control overScroll mode
-overScrollMode?: 'always' | 'always-if-content-scrolls' | 'never';
+overScrollMode?: 'auto' | 'always' | 'never';
 
 // Snap to page boundaries?
 pagingEnabled: boolean = false; // Android & iOS only

--- a/docs/docs/components/scrollview.md
+++ b/docs/docs/components/scrollview.md
@@ -47,6 +47,14 @@ onScroll: (newScrollTop: number, newScrollLeft: number) => void = undefined;
 onScrollBeginDrag: () => void = undefined;
 onScrollEndDrag: () => void = undefined;
 
+// Animation helpers to allow usage of the RN.Animated.Event system through ReactXP.
+// AnimatedValue objects hooked up to either (or both) of these properties will be automatically
+// hooked into the onScroll handler of the scrollview and .setValue() will be called on them
+// with the updated values.  On supported platforms, it will use RN.Animated.event() to do
+// a native-side/-backed coupled animation.
+scrollXAnimatedValue?: RX.Types.AnimatedValue;
+scrollYAnimatedValue?: RX.Types.AnimatedValue;
+
 // Android only property to control overScroll mode
 overScrollMode?: 'always' | 'always-if-content-scrolls' | 'never';
 

--- a/docs/docs/extensions/virtuallistview.md
+++ b/docs/docs/extensions/virtuallistview.md
@@ -179,6 +179,8 @@ disableBouncing?: boolean; // iOS only, bounce override
 scrollIndicatorInsets?: { top: number, left: number,
     bottom: number, right: number }; // iOS only
 onScroll?: (scrollTop: number, scrollLeft: number) => void;
+scrollXAnimatedValue?: RX.Types.AnimatedValue;
+scrollYAnimatedValue?: RX.Types.AnimatedValue;
 ```
 
 ## Methods

--- a/extensions/virtuallistview/src/VirtualListView.tsx
+++ b/extensions/virtuallistview/src/VirtualListView.tsx
@@ -97,6 +97,8 @@ export interface VirtualListViewProps<ItemInfo extends VirtualListViewItemInfo> 
     disableBouncing?: boolean; // iOS only, bounce override
     scrollIndicatorInsets?: { top: number, left: number, bottom: number, right: number }; // iOS only
     onScroll?: (scrollTop: number, scrollLeft: number) => void;
+    scrollXAnimatedValue?: RX.Types.AnimatedValue;
+    scrollYAnimatedValue?: RX.Types.AnimatedValue;
 
     // Logging callback to debug issues related to the VirtualListView.
     logInfo?: (textToLog: string) => void;
@@ -1146,10 +1148,12 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
                 testId={this.props.testId}
                 onLayout={ this._onLayoutContainer }
                 onScroll={ this._onScroll }
+                scrollXAnimatedValue={ this.props.scrollXAnimatedValue }
+                scrollYAnimatedValue={ this.props.scrollYAnimatedValue }
                 keyboardDismissMode={ this.props.keyboardDismissMode }
                 keyboardShouldPersistTaps={ this.props.keyboardShouldPersistTaps }
                 scrollsToTop={ this.props.scrollsToTop }
-                scrollEventThrottle={ 32 } // 30 events per second max
+                scrollEventThrottle={ 32 } // 32ms throttle -> ~30 events per second max
                 style={ scrollViewStyle }
                 bounces={ !this.props.disableBouncing }
                 onKeyPress={ this._onKeyDown }

--- a/samples/RXPTest/src/Tests/ScrollViewEventTest.tsx
+++ b/samples/RXPTest/src/Tests/ScrollViewEventTest.tsx
@@ -66,6 +66,20 @@ class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
     private _isMounted = false;
     private _test1Timer: number | undefined;
 
+    private _scrollAnimEventValue = RX.Animated.createValue(0);
+    private _coupledOpacityValue = this._scrollAnimEventValue.interpolate({
+        inputRange: [0, 500],
+        outputRange: [1, 0.2]
+    });
+    private _coupledTranslateXValue = this._scrollAnimEventValue.interpolate({
+        inputRange: [0, 500],
+        outputRange: [500, 0]
+    });
+    private _coupledAnimStyle = RX.Styles.createAnimatedViewStyle({
+        opacity: this._coupledOpacityValue,
+        transform: [{ translateX: this._coupledTranslateXValue }]
+    });
+
     constructor(props: RX.CommonProps) {
         super(props);
 
@@ -125,6 +139,7 @@ class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
                         scrollEventThrottle={ 1000 }
                         scrollIndicatorInsets={ { top: 20, left: 0, bottom: 20, right: 0 } }
                         onScroll={ this._onScrollTest1 }
+                        scrollYAnimatedValue={ this._scrollAnimEventValue }
                         onContentSizeChange={ this._onContentSizeChangeTest1 }
                         onScrollBeginDrag={ this._onScrollBeginDragTest1 }
                         onScrollEndDrag={ this._onScrollEndDragTest1 }
@@ -134,6 +149,9 @@ class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
                         </RX.View>
                     </RX.ScrollView>
                 </RX.View>
+                <RX.Animated.View style={ this._coupledAnimStyle }>
+                    This should move left and go translucent as you scroll.
+                </RX.Animated.View>
                 <RX.View>
                     <RX.Text style={ _styles.labelText }>
                         { 'Scroll top: ' + this.state.test1ScrollTop }

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -865,6 +865,14 @@ export interface ScrollViewProps extends CommonProps, CommonAccessibilityProps {
 
     // Windows-only property to control tab navigation inside the view
     tabNavigation?: 'local' | 'cycle' | 'once';
+
+    // Animation helpers to allow usage of the RN.Animated.Event system through ReactXP.
+    // Animated.Values hooked up to either (or both) of these properties will be automatically
+    // hooked into the onScroll handler of the scrollview and .setValue() will be called on them
+    // with the updated values.  On supported platforms, it will use RN.Animated.event() to do
+    // a native-side/-backed coupled animation.
+    scrollXAnimatedValue?: RX.Types.AnimatedValue;
+    scrollYAnimatedValue?: RX.Types.AnimatedValue;
 }
 
 // Link
@@ -1130,7 +1138,6 @@ export type LocationFailureCallback = (error: LocationErrorType) => void;
 // Animated
 // ----------------------------------------------------------------------
 export module Animated {
-
     export type EndResult = { finished: boolean };
     export type EndCallback = (result: EndResult) => void;
     export type CompositeAnimation = {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -806,8 +806,7 @@ export interface ScrollIndicatorInsets {
 }
 
 // ScrollView
-export interface ScrollViewProps extends CommonProps, CommonAccessibilityProps {
-    style?: StyleRuleSetRecursive<ScrollViewStyleRuleSet>;
+export interface ScrollViewProps extends CommonStyledProps<ScrollViewStyleRuleSet>, CommonAccessibilityProps {
     children?: ReactNode;
 
     vertical?: boolean; // By default true
@@ -858,7 +857,7 @@ export interface ScrollViewProps extends CommonProps, CommonAccessibilityProps {
     scrollsToTop?: boolean;
 
     // Android only property to control overScroll mode
-    overScrollMode?: 'always' | 'always-if-content-scrolls' | 'never';
+    overScrollMode?: 'auto' | 'always' | 'never';
 
     // iOS-only property to control scroll indicator insets
     scrollIndicatorInsets?: ScrollIndicatorInsets;

--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -18,7 +18,7 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
     private _scrollLeft = 0;
     protected _nativeView: any;
 
-    protected _render(nativeProps: RN.ScrollViewProps&React.Props<RN.ScrollView>): JSX.Element {
+    protected _render(nativeProps: RN.ScrollViewProps & React.Props<RN.ScrollView>): JSX.Element {
         if (this.props.scrollXAnimatedValue || this.props.scrollYAnimatedValue) {
             // Have to jump over to an Animated ScrollView to use an RN.Animated.event...
             return (
@@ -52,20 +52,25 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
         if (this.props.scrollXAnimatedValue || this.props.scrollYAnimatedValue) {
             // For more details on this craziness, reference:
             // https://facebook.github.io/react-native/docs/animated#handling-gestures-and-other-events
-            let handlerWrapper: any = { nativeEvent: { contentOffset: { } } };
+            let handlerWrapper: RN.EventMapping = {
+                nativeEvent: {
+                    contentOffset: { }
+                }
+            };
             if (this.props.scrollXAnimatedValue) {
                 handlerWrapper.nativeEvent.contentOffset.x = this.props.scrollXAnimatedValue;
             }
             if (this.props.scrollYAnimatedValue) {
                 handlerWrapper.nativeEvent.contentOffset.y = this.props.scrollYAnimatedValue;
             }
-            let eventConfig: any = {
+            let eventConfig: RN.AnimatedEventConfig<RN.NativeScrollEvent> = {
                 useNativeDriver: true
             };
             if (this.props.onScroll) {
                 eventConfig.listener = this._onScroll;
             }
-            scrollHandler = RN.Animated.event([handlerWrapper], eventConfig);
+            // react-native.d.ts is wrong for the eventconfig typing, so casting to any for now.
+            scrollHandler = RN.Animated.event([handlerWrapper], eventConfig as any);
         } else if (this.props.onScroll) {
             scrollHandler = this._onScroll;
         } else {
@@ -85,8 +90,9 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
         // We also set removeClippedSubviews to false, overriding the default value. Most of the scroll views
         // we use are virtualized anyway.
 
-        const internalProps: RN.ScrollViewProps&React.Props<RN.ScrollView> = {
+        const internalProps: RN.ScrollViewProps & React.Props<RN.ScrollView> = {
             ref: this._setNativeView,
+            // Bug in react-native.d.ts.  style should be "style?: StyleProp<ScrollViewStyle>;" but instead is ViewStyle.
             style: this.props.style as any,
             onScroll: scrollHandler,
             automaticallyAdjustContentInsets: false,
@@ -105,7 +111,7 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
             decelerationRate: typeof this.props.snapToInterval === 'number' ? 'fast' : undefined,
             scrollsToTop: this.props.scrollsToTop,
             removeClippedSubviews: false,
-            overScrollMode: this.props.overScrollMode as any,
+            overScrollMode: this.props.overScrollMode,
             scrollIndicatorInsets: this.props.scrollIndicatorInsets,
             onScrollBeginDrag: this.props.onScrollBeginDrag,
             onScrollEndDrag: this.props.onScrollEndDrag,

--- a/src/typings/react-native-extensions.d.ts
+++ b/src/typings/react-native-extensions.d.ts
@@ -88,4 +88,12 @@ declare module 'react-native' {
     interface ExtendedAlertOptions extends RN.AlertOptions {
         rootViewHint?: number;
     }
+
+    // Private interfaces adapted from react-native.d.ts related to Animated.event
+    type EventMapping = { [key: string]: Mapping } | AnimatedValue;
+    type ValueListenerCallback = (state: { value: number }) => void;
+    interface AnimatedEventConfig<T> {
+        listener?: (event: RN.NativeSyntheticEvent<T>) => void;
+        useNativeDriver?: boolean;
+    }
 }

--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -210,17 +210,16 @@ export class InterpolatedValue extends Value {
         });
         this._interpolationConfig = newInterpolationConfig;
 
-        let self = this;
         rootValue._addListener({
-            setValue(valueObject: Value, newValue: number | string): void {
-                self.setValue(valueObject._getOutputValue());
+            setValue: (valueObject: Value, newValue: number | string) => {
+                this.setValue(valueObject._getOutputValue());
             },
-            startTransition(valueObject: Value, from: number|string, toValue: number|string, duration: number,
-                    easing: string, delay: number, onEnd: RX.Types.Animated.EndCallback): void {
-                self._startTransition(toValue, duration, easing, delay, onEnd);
+            startTransition: (valueObject: Value, from: number|string, toValue: number|string, duration: number,
+                    easing: string, delay: number, onEnd: RX.Types.Animated.EndCallback) => {
+                this._startTransition(toValue, duration, easing, delay, onEnd);
             },
-            stopTransition(valueObject: Value): number|string|undefined {
-                self._stopTransition();
+            stopTransition: (valueObject: Value) => {
+                this._stopTransition();
                 return undefined;
             }
         });

--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -97,7 +97,7 @@ export class Value extends RX.Types.AnimatedValue {
         return this._getInterpolatedValue(this._value);
     }
 
-    _getInterpolatedValue(inputVal: number|string): number | string {
+    _getInterpolatedValue(inputVal: number | string): number | string {
         return inputVal;
     }
 
@@ -685,7 +685,7 @@ function createAnimatedComponent<PropsType extends RX.Types.CommonProps>(Compone
 
         // Generates the CSS value for the specified attribute given
         // an animated value object.
-        private _generateCssAttributeValue(attrib: string, newValue: number|string): string {
+        private _generateCssAttributeValue(attrib: string, newValue: number | string): string {
             // If the value is a raw number, append the default units.
             // If it's a string, we assume the caller has specified the units.
             if (typeof newValue === 'number') {
@@ -694,7 +694,7 @@ function createAnimatedComponent<PropsType extends RX.Types.CommonProps>(Compone
             return newValue;
         }
 
-        private _generateCssTransformValue(transform: string, newValue: number|string): string {
+        private _generateCssTransformValue(transform: string, newValue: number | string): string {
             // If the value is a raw number, append the default units.
             // If it's a string, we assume the caller has specified the units.
             if (typeof newValue === 'number') {

--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -204,16 +204,6 @@ export class InterpolatedValue extends Value {
             throw 'The interpolation config is invalid. Input and output arrays must be same length.';
         }
 
-        // This API doesn't currently support more than two elements in the
-        // interpolation array. Supporting this in the web would require the
-        // use of JS-driven animations or keyframes, both of which are prohibitively
-        // expensive from a performance and responsiveness perspective.
-        if (this._config.inputRange.length !== 2) {
-            if (AppConfig.isDevelopmentMode()) {
-                console.log('Web implementation of interpolate API currently supports only two interpolation values.');
-            }
-        }
-
         const newInterpolationConfig: { [key: number]: string|number } = {};
         _.each(this._config.inputRange, (key, index) => {
             newInterpolationConfig[key] = this._config.outputRange[index];
@@ -234,6 +224,21 @@ export class InterpolatedValue extends Value {
                 return undefined;
             }
         });
+    }
+
+    _startTransition(toValue: number|string, duration: number, easing: string, delay: number,
+            onEnd: RX.Types.Animated.EndCallback): void {
+        // This API doesn't currently support more than two elements in the
+        // interpolation array. Supporting this in the web would require the
+        // use of JS-driven animations or keyframes, both of which are prohibitively
+        // expensive from a performance and responsiveness perspective.
+        if (this._config.inputRange.length !== 2) {
+            if (AppConfig.isDevelopmentMode()) {
+                console.log('Web implementation of interpolate API currently supports only two interpolation values.');
+            }
+        }
+
+        super._startTransition(toValue, duration, easing, delay, onEnd);
     }
 
     _getInterpolatedValue(inputVal: number|string): number | string {

--- a/src/web/ScrollView.tsx
+++ b/src/web/ScrollView.tsx
@@ -192,13 +192,21 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
         // Force the list of deferred changes to be reported now.
         ViewBase._reportDeferredLayoutChanges();
 
-        if (this.props.onScroll) {
+        if (this.props.onScroll || this.props.scrollXAnimatedValue || this.props.scrollYAnimatedValue) {
             onLayoutPromise.then(() => {
                 const container = this._getContainer();
                 if (!container) {
                     return;
                 }
-                this.props.onScroll!!!(container.scrollTop, container.scrollLeft);
+                if (this.props.onScroll) {
+                    this.props.onScroll!!!(container.scrollTop, container.scrollLeft);
+                }
+                if (this.props.scrollXAnimatedValue) {
+                    this.props.scrollXAnimatedValue.setValue(container.scrollLeft);
+                }        
+                if (this.props.scrollYAnimatedValue) {
+                    this.props.scrollYAnimatedValue.setValue(container.scrollTop);
+                }        
             });
         }
     }, (this.props.scrollEventThrottle || _defaultScrollThrottleValue), { leading: true, trailing: true });

--- a/src/web/utils/lodashMini.ts
+++ b/src/web/utils/lodashMini.ts
@@ -22,6 +22,7 @@ import get = require('lodash/get');
 import isArray = require('lodash/isArray');
 import isEmpty = require('lodash/isEmpty');
 import isEqual = require('lodash/isEqual');
+import isNumber = require('lodash/isNumber');
 import isObject = require('lodash/isObject');
 import isUndefined = require('lodash/isUndefined');
 import kebabCase = require('lodash/kebabCase');
@@ -52,6 +53,7 @@ export {
     isArray,
     isEmpty,
     isEqual,
+    isNumber,
     isObject,
     isUndefined,
     kebabCase,

--- a/src/windows/ScrollView.tsx
+++ b/src/windows/ScrollView.tsx
@@ -11,12 +11,11 @@ import * as React from 'react';
 import * as RN from 'react-native';
 
 import { ScrollView as ScrollViewBase } from '../native-common/ScrollView';
-import { Types } from '../common/Interfaces';
 import EventHelpers from '../native-common/utils/EventHelpers';
 
 export class ScrollView extends ScrollViewBase {
 
-    protected _render(props: Types.ScrollViewProps): JSX.Element {
+    protected _render(nativeProps: RN.ScrollViewProps&React.Props<RN.ScrollView>): JSX.Element {
         var onKeyDownCallback = this.props.onKeyPress ? this._onKeyDown : undefined;
 
         // TODO: #737970 Remove special case for UWP when this bug is fixed. The bug
@@ -24,19 +23,16 @@ export class ScrollView extends ScrollViewBase {
         //   order for the UI to acknowledge your interaction.
         const keyboardShouldPersistTaps = 'always';
 
-        const nativeProps = {
-            ...props,
+        // Have to hack the windows-specific onKeyDown into the props here.
+        const updatedNativeProps: any = {
+            ...nativeProps,
             onKeyDown: onKeyDownCallback,
             keyboardShouldPersistTaps: keyboardShouldPersistTaps,
             tabNavigation: this.props.tabNavigation,
             disableKeyboardBasedScrolling: true,
-        } as RN.ScrollViewProps;
+        };
 
-        return (
-            <RN.ScrollView { ...nativeProps }>
-                { props.children }
-            </RN.ScrollView>
-        );
+        return super._render(updatedNativeProps);
     }
 
     private _onKeyDown = (e: React.SyntheticEvent<any>) => {

--- a/src/windows/ScrollView.tsx
+++ b/src/windows/ScrollView.tsx
@@ -15,7 +15,7 @@ import EventHelpers from '../native-common/utils/EventHelpers';
 
 export class ScrollView extends ScrollViewBase {
 
-    protected _render(nativeProps: RN.ScrollViewProps&React.Props<RN.ScrollView>): JSX.Element {
+    protected _render(nativeProps: RN.ScrollViewProps & React.Props<RN.ScrollView>): JSX.Element {
         var onKeyDownCallback = this.props.onKeyPress ? this._onKeyDown : undefined;
 
         // TODO: #737970 Remove special case for UWP when this bug is fixed. The bug


### PR DESCRIPTION
First whack at building a simple abstraction on top of the new RN.Animated.event() ability into the RX.ScrollView control. RN.Animated.event nominally lets you handle any parameter of the native callback object and map it into an animated value, but, in reality, for a scrollview, there's only x and y scroll position to take into account. As such, my theory is that we should simplify the abstraction down to simply passing in a scroll{X,Y}AnimatedValue property to the scrollview, and it can do the appropriate wacky mappings to the react native event objects to map it through.

After implementing this, I realized that the web's AnimatedValue class was making a bad assumption.  It was assuming that you could only interpolate a single value from another value, so they became coupled. This is broken in the common case with native combined with animated.event, where you have a single native-mapped animated.value that's mapped to a scroll position, and then interpolate several other values from that root value.

Opening PR to validate with @erictraut that the approach is fine, and then I'll update the sample app before merge if so.