### PR TITLE
Added support for RTL/LTR setting changes on the fly

### DIFF
--- a/src/native-common/International.ts
+++ b/src/native-common/International.ts
@@ -12,6 +12,16 @@ import * as RN from 'react-native';
 import * as RX from '../common/Interfaces';
 
 export class International implements RX.International {
+    private _isRTL: boolean;
+
+    constructor() {
+        // RN.I18nManager.isRTL is a constant, a good start.
+        this._isRTL = RN.I18nManager.isRTL;
+
+        // Register for changes (some platforms may never raise this event)
+        RN.DeviceEventEmitter.addListener('isRTLChanged', (payload: RN.RtlEventNativePayload) => {this._isRTL = payload.isRTL; });
+    }
+
     allowRTL(allow: boolean): void {
         RN.I18nManager.allowRTL(allow);
     }
@@ -21,7 +31,7 @@ export class International implements RX.International {
     }
 
     isRTL(): boolean {
-        return RN.I18nManager.isRTL;
+        return this._isRTL;
     }
 }
 

--- a/src/typings/react-native-extensions.d.ts
+++ b/src/typings/react-native-extensions.d.ts
@@ -39,6 +39,10 @@ declare module 'react-native' {
         useWebKit?: boolean;
     }
 
+    interface RtlEventNativePayload {
+        isRTL:  boolean;
+    }
+
     abstract class ReactNativeBaseComponent<P, S> extends React.Component<P, S> {
         setNativeProps(nativeProps: P): void;
         focus(): void;


### PR DESCRIPTION
Existing RN (Android/iOS,UWP) implementations of i18nManager expose "isRTL" as a constant since it's not expected to change until the app ends.
Any change of forceRTL/allowRTL/<default OS behavior> requires an app restart.

We're adding support for on the fly changes of settings in UWP, so an optional event can be raised by i18nManager to update whatever was returned by isRTL originally.
This keeps RXP.International.isRTL in sync (with some async related delay).