### PR TITLE
Emulate Cache-Control: max-stale on iOS

### DIFF
--- a/docs/docs/components/image.md
+++ b/docs/docs/components/image.md
@@ -11,6 +11,8 @@ This component displays an image, which can come from a local source or from the
 
 If child elements are specified, the image acts as a background, and the children are rendered on top of it.
 
+If headers contains 'Cache-Control: max-stale' with no value specified and the image fails to load, the component tries again passing cache: 'only-if-cached' to the underlying native Image (iOS only). This way the app can render otherwise inaccessible stale cached images.
+
 ## Props
 ``` javascript
 // Alternate text to display if the image cannot be loaded

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -181,7 +181,7 @@ export class Image extends React.Component<Types.ImageProps, ImageState> impleme
 
         if (!this.state.forceCache && this._shouldForceCacheOnError()) {
             // Some platforms will not use expired cache data unless explicitly told so.
-            // Let's try again with cache: 'force-cache'.
+            // Let's try again with cache: 'only-if-cached'.
             this.setState({ forceCache: true, lastNativeError: e.nativeEvent.error });
         } else if (this.props.onError) {
             if (this.state.forceCache) {

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -31,7 +31,12 @@ export interface ImageContext {
     isRxParentAText?: boolean;
 }
 
-export class Image extends React.Component<Types.ImageProps, Types.Stateless> implements React.ChildContextProvider<ImageContext> {
+export interface ImageState {
+    forceCache?: boolean;
+    lastNativeError?: any;
+}
+
+export class Image extends React.Component<Types.ImageProps, ImageState> implements React.ChildContextProvider<ImageContext> {
     static childContextTypes: React.ValidationMap<any> = {
         isRxParentAText: PropTypes.bool.isRequired,
     };
@@ -59,7 +64,6 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
     protected _mountedComponent: RN.Image | null = null;
     private _nativeImageWidth: number | undefined;
     private _nativeImageHeight: number | undefined;
-    private _forceCache = false;
 
     protected _getAdditionalProps(): RN.ImageProperties | {} {
         return {};
@@ -116,7 +120,7 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
         const sourceOrHeaderChanged = (nextProps.source !== this.props.source ||
             !_.isEqual(nextProps.headers || {}, this.props.headers || {}));
         if (sourceOrHeaderChanged) {
-            this._forceCache = false;
+            this.setState({ forceCache: false, lastNativeError: undefined });
         }
     }
 
@@ -175,13 +179,17 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
             return;
         }
 
-        if (!this._forceCache && this._shouldForceCacheOnError()) {
+        if (!this.state.forceCache && this._shouldForceCacheOnError()) {
             // Some platforms will not use expired cache data unless explicitly told so.
             // Let's try again with cache: 'force-cache'.
-            this._forceCache = true;
-            this.forceUpdate();
+            this.setState({ forceCache: true, lastNativeError: e.nativeEvent.error });
         } else if (this.props.onError) {
-            this.props.onError(new Error(e.nativeEvent.error));
+            if (this.state.forceCache) {
+                // Fire the callback with the error we got when we failed without forceCache.
+                this.props.onError(new Error(this.state.lastNativeError));
+            } else {
+                this.props.onError(new Error(e.nativeEvent.error));
+            }
         }
     }
 
@@ -195,8 +203,8 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
         if (this.props.headers) {
             source.headers = this.props.headers;
         }
-        if (this._forceCache) {
-            source.cache = 'force-cache';
+        if (this.state.forceCache) {
+            source.cache = 'only-if-cached';
         }
 
         return source;
@@ -208,6 +216,8 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
         }
         if (this.props.headers) {
             for (let key in this.props.headers) {
+                // We don't know how stale the cached data is so we're matching only the simple 'max-stale' attribute
+                // without a value.
                 if (key.toLowerCase() === 'cache-control' && this.props.headers[key].toLowerCase() === 'max-stale') {
                     return true;
                 }

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -12,6 +12,7 @@ import * as React from 'react';
 import * as RN from 'react-native';
 import * as SyncTasks from 'synctasks';
 
+import * as _ from './utils/lodashMini';
 import { Types } from '../common/Interfaces';
 import { DEFAULT_RESIZE_MODE } from '../common/Image';
 import Platform from './Platform';
@@ -109,6 +110,12 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
                 { ...props }
             />
         );
+    }
+
+    componentWillReceiveProps(nextProps: Types.ImageProps) {
+        if (!_.isEqual(this.props, nextProps)) {
+            this._forceCache = false;
+        }
     }
 
     protected _onMount = (component: RN.Image | null) => {

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -113,7 +113,9 @@ export class Image extends React.Component<Types.ImageProps, Types.Stateless> im
     }
 
     componentWillReceiveProps(nextProps: Types.ImageProps) {
-        if (!_.isEqual(this.props, nextProps)) {
+        const sourceOrHeaderChanged = (nextProps.source !== this.props.source ||
+            !_.isEqual(nextProps.headers || {}, this.props.headers || {}));
+        if (sourceOrHeaderChanged) {
             this._forceCache = false;
         }
     }

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -64,15 +64,7 @@ export class Image extends React.Component<Types.ImageProps, ImageState> impleme
     protected _mountedComponent: RN.Image | null = null;
     private _nativeImageWidth: number | undefined;
     private _nativeImageHeight: number | undefined;
-
-    constructor(props: Types.ImageProps, context: ImageContext) {
-        super(props, context);
-
-        this.state = {
-            forceCache: false,
-            lastNativeError: undefined
-        };
-    }
+    readonly state: ImageState = { forceCache: false, lastNativeError: undefined };
 
     protected _getAdditionalProps(): RN.ImageProperties | {} {
         return {};

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -65,6 +65,15 @@ export class Image extends React.Component<Types.ImageProps, ImageState> impleme
     private _nativeImageWidth: number | undefined;
     private _nativeImageHeight: number | undefined;
 
+    constructor(props: Types.ImageProps, context: ImageContext) {
+        super(props, context);
+
+        this.state = {
+            forceCache: false,
+            lastNativeError: undefined
+        };
+    }
+
     protected _getAdditionalProps(): RN.ImageProperties | {} {
         return {};
     }


### PR DESCRIPTION
iOS does not seem to respect the max-stale header. It does not load
expired images from the cache unless the force-cache option (internally
NSURLRequestReturnCacheDataElseLoad) is passed.

We can't use force-cache always because it has the opposite problem of
loading only from the cache and using stale data even when the app is
online and the data served under the URL has changed.

The proposed solution is to fall back to force-cache only on encountering
the first error.