### PR TITLE
Removed draggable="false" from source code, as it is default value

### DIFF
--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -354,7 +354,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
             onMouseLeave: this.props.onMouseLeave,
             onMouseOver: this.props.onMouseOver,
             onMouseMove: this.props.onMouseMove,
-            draggable: this.props.onDragStart ? true : false,
+            draggable: this.props.onDragStart ? true : undefined,
             onDragStart: this.props.onDragStart,
             onDrag: this.props.onDrag,
             onDragEnd: this.props.onDragEnd,


### PR DESCRIPTION
By setting draggable property to false, every div in the html source was populated with draggable="false". If we set this to undefined, then this property will not show up in the html source, but it will keep it's false value.