### PR TITLE
Removing updates from focus manager when component does'nt have to focusable

### DIFF
--- a/src/common/utils/FocusManager.ts
+++ b/src/common/utils/FocusManager.ts
@@ -423,13 +423,16 @@ export function applyFocusableComponentMixin(Component: any, isConditionallyFocu
         let origCallback = Component.prototype[methodName];
 
         Component.prototype[methodName] = function () {
-            let focusManager: FocusManager = this._focusManager || (this.context && this.context.focusManager);
+            if (!isConditionallyFocusable || isConditionallyFocusable.call(this)) {
 
-            if (focusManager) {
-                action.call(this, focusManager, arguments);
-            } else {
-                if (AppConfig.isDevelopmentMode()) {
-                    console.error('FocusableComponentMixin: context error!');
+                let focusManager: FocusManager = this._focusManager || (this.context && this.context.focusManager);
+
+                if (focusManager) {
+                    action.call(this, focusManager, arguments);
+                } else {
+                    if (AppConfig.isDevelopmentMode()) {
+                        console.error('FocusableComponentMixin: context error!');
+                    }
                 }
             }
 


### PR DESCRIPTION
Every component has a check to determine if it focusable or not. But we end up requiring the context object to contain focus manager and call methods in the focus manager as well. 

This is not necessary. Removing this by adding a conditional check. 
