### PR TITLE
Apply ScrollView focus workaround to MacOS

### DIFF
--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -13,6 +13,10 @@ import * as RN from 'react-native';
 import * as RX from '../common/Interfaces';
 import ViewBase from './ViewBase';
 
+// TODO: #737970 Remove special case for UWP/MacOS when this bug is fixed. The bug
+//   causes you to have to click twice instead of once on some pieces of UI in
+//   order for the UI to acknowledge your interaction.
+const overrideKeyboardShouldPersistTaps = RN.Platform.OS === 'macos' || RN.Platform.OS === 'windows'; 
 export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stateless> implements RX.ScrollView {
     private _scrollTop = 0;
     private _scrollLeft = 0;
@@ -77,7 +81,7 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
             scrollHandler = undefined;
         }
 
-        const keyboardShouldPersistTaps = (this.props.keyboardShouldPersistTaps ? 'always' : 'never');
+        const keyboardShouldPersistTaps = (overrideKeyboardShouldPersistTaps || this.props.keyboardShouldPersistTaps ? 'always' : 'never');
 
         // NOTE: We are setting `automaticallyAdjustContentInsets` to false
         // (http://facebook.github.io/react-native/docs/scrollview.html#automaticallyadjustcontentinsets). The

--- a/src/windows/ScrollView.tsx
+++ b/src/windows/ScrollView.tsx
@@ -18,16 +18,10 @@ export class ScrollView extends ScrollViewBase {
     protected _render(nativeProps: RN.ScrollViewProps & React.Props<RN.ScrollView>): JSX.Element {
         var onKeyDownCallback = this.props.onKeyPress ? this._onKeyDown : undefined;
 
-        // TODO: #737970 Remove special case for UWP when this bug is fixed. The bug
-        //   causes you to have to click twice instead of once on some pieces of UI in
-        //   order for the UI to acknowledge your interaction.
-        const keyboardShouldPersistTaps = 'always';
-
         // Have to hack the windows-specific onKeyDown into the props here.
         const updatedNativeProps: any = {
             ...nativeProps,
             onKeyDown: onKeyDownCallback,
-            keyboardShouldPersistTaps: keyboardShouldPersistTaps,
             tabNavigation: this.props.tabNavigation,
             disableKeyboardBasedScrolling: true,
         };


### PR DESCRIPTION
If a TextInput is located inside a ScrollView on RN MacOS, and the 'keyboardShouldPersistTaps' flag is false, the user will be unable to click on any other elements inside any ScrollView in the app.  Only once they finish editing (submit text via Enter or tab away) will clicks stop being swallowed by the scrollview.
Setting the keyboardShouldPersistTaps flag to true stops the ScrollView from swallowing these clicks  