### PR TITLE
Fix RXPTest dependencies and UWP build

### DIFF
--- a/samples/RXPTest/ios/RXPTest.xcodeproj/project.pbxproj
+++ b/samples/RXPTest/ios/RXPTest.xcodeproj/project.pbxproj
@@ -228,6 +228,20 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
+		8CCE8B8F2182ACCF00855E24 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EBF21BDC1FC498900052F4D5;
+			remoteInfo = jsinspector;
+		};
+		8CCE8B912182ACCF00855E24 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EBF21BFA1FC4989A0052F4D5;
+			remoteInfo = "jsinspector-tvOS";
+		};
 		D4A8C3B020247A9D008BE855 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
@@ -389,6 +403,8 @@
 				07C03E391EC4EB8600E549B0 /* libcxxreact.a */,
 				3DAD3EAD1DF850E9000B6D8A /* libjschelpers.a */,
 				07C03E3B1EC4EB8600E549B0 /* libjschelpers.a */,
+				8CCE8B902182ACCF00855E24 /* libjsinspector.a */,
+				8CCE8B922182ACCF00855E24 /* libjsinspector-tvOS.a */,
 				07AE0CFB1F74268D0035D6C1 /* libthird-party.a */,
 				07AE0CFD1F74268D0035D6C1 /* libthird-party.a */,
 				07AE0CFF1F74268D0035D6C1 /* libdouble-conversion.a */,
@@ -490,7 +506,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 830;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
@@ -766,6 +782,20 @@
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		8CCE8B902182ACCF00855E24 /* libjsinspector.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjsinspector.a;
+			remoteRef = 8CCE8B8F2182ACCF00855E24 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8CCE8B922182ACCF00855E24 /* libjsinspector-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libjsinspector-tvOS.a";
+			remoteRef = 8CCE8B912182ACCF00855E24 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		D4A8C3B120247A9D008BE855 /* libfishhook.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -899,14 +929,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -944,14 +982,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;

--- a/samples/RXPTest/ios/RXPTest.xcodeproj/xcshareddata/xcschemes/RXPTest-tvOS.xcscheme
+++ b/samples/RXPTest/ios/RXPTest.xcodeproj/xcshareddata/xcschemes/RXPTest-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/samples/RXPTest/ios/RXPTest.xcodeproj/xcshareddata/xcschemes/RXPTest.xcscheme
+++ b/samples/RXPTest/ios/RXPTest.xcodeproj/xcshareddata/xcschemes/RXPTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -54,7 +54,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -84,7 +83,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/samples/RXPTest/package.json
+++ b/samples/RXPTest/package.json
@@ -26,10 +26,10 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2",
-    "react-native": "^0.56.1",
-    "react-native-windows": "^0.55.0-rc.0",
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0",
+    "react-native": "^0.57.3",
+    "react-native-windows": "^0.57.0-rc.0",
     "reactxp": "^1.4.0"
   }
 }

--- a/samples/RXPTest/src/Tests/ScrollViewEventTest.tsx
+++ b/samples/RXPTest/src/Tests/ScrollViewEventTest.tsx
@@ -150,7 +150,9 @@ class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
                     </RX.ScrollView>
                 </RX.View>
                 <RX.Animated.View style={ this._coupledAnimStyle }>
-                    This should move left and go translucent as you scroll.
+                    <RX.Text style={ _styles.labelText }>
+                        { 'This should move left and go translucent as you scroll.' }
+                    </RX.Text>
                 </RX.Animated.View>
                 <RX.View>
                     <RX.Text style={ _styles.labelText }>

--- a/samples/RXPTest/src/Tests/TextInputApiTest.tsx
+++ b/samples/RXPTest/src/Tests/TextInputApiTest.tsx
@@ -150,6 +150,12 @@ class TextInputView extends RX.Component<RX.CommonProps, TextInputViewState> {
         this._testResult = new TestResult();
         this._testCompletion = complete;
 
+        if (RX.Platform.getType() === 'windows') {
+            this._testResult!.errors.push('Test disabled and failed by default due to RNW 0.57.0-rc.0 crashing bug');
+            this._testCompletion!(this._testResult!);
+            return;
+        }
+
         // Kick off the first stage.
         this._executeNextStage();
     }

--- a/samples/RXPTest/src/Tests/TextTest.tsx
+++ b/samples/RXPTest/src/Tests/TextTest.tsx
@@ -91,6 +91,9 @@ const _styles = {
         padding: 12,
         borderRadius: 8,
         borderColor: 'black'
+    }),
+    testWarnText: RX.Styles.createTextStyle({
+        color: 'red'
     })
 };
 
@@ -252,21 +255,27 @@ class TextView extends RX.Component<RX.CommonProps, TextViewState> {
                     </RX.Text>
                 </RX.View>
                 <RX.View style={ _styles.resultContainer }>
-                    <RX.Text style={ _styles.test7Text }>
-                        <RX.Text>
-                            { 'Do you have a bright ' }
+                    { RX.Platform.getType() !== 'web' ? (
+                        <RX.Text style={ _styles.testWarnText }>
+                            { 'Test disabled due to broken RN 0.57 support of inline views' } 
                         </RX.Text>
-                        <RX.View style={ _styles.inlineImageContainer }>
-                            <RX.Image
-                                source={ 'https://microsoft.github.io/reactxp/img/tests/bulb.jpg' }
-                                resizeMode={ 'contain' }
-                                style={ _styles.inlineImage }
-                            />
-                        </RX.View>
-                        <RX.Text>
-                            { ' to share?' }
+                    ) : ( 
+                        <RX.Text style={ _styles.test7Text }>
+                            <RX.Text>
+                                { 'Do you have a bright ' }
+                            </RX.Text>
+                            <RX.View style={ _styles.inlineImageContainer }>
+                                <RX.Image
+                                    source={ 'https://microsoft.github.io/reactxp/img/tests/bulb.jpg' }
+                                    resizeMode={ 'contain' }
+                                    style={ _styles.inlineImage }
+                                />
+                            </RX.View>
+                            <RX.Text>
+                                { ' to share?' }
+                            </RX.Text>
                         </RX.Text>
-                    </RX.Text>
+                    )}
                 </RX.View>
 
                 <RX.View style={ _styles.explainTextContainer } key={ 'explanation8' }>
@@ -275,22 +284,28 @@ class TextView extends RX.Component<RX.CommonProps, TextViewState> {
                     </RX.Text>
                 </RX.View>
                 <RX.View style={ _styles.resultContainer }>
-                    <RX.Text style={ _styles.test8Text }>
-                        <RX.Text>
-                            { 'This is a really long string with a ' }
+                    { RX.Platform.getType() !== 'web' ? (
+                        <RX.Text style={ _styles.testWarnText }>
+                            { 'Test disabled due to broken RN 0.57 support of inline views' } 
                         </RX.Text>
-                        <RX.View style={ [_styles.inlineImageContainer, _styles.inlineImageContainerOffset] }>
-                            <RX.Image
-                                source={ 'https://microsoft.github.io/reactxp/img/tests/bulb.jpg' }
-                                resizeMode={ 'contain' }
-                                style={ _styles.inlineImage }
-                            />
-                        </RX.View>
-                        <RX.Text>
-                            { ' light bulb inlined within it. It is meant to demonstrate a' +
-                              ' larger-than-normal line height.' }
+                    ) : ( 
+                        <RX.Text style={ _styles.test8Text }>
+                            <RX.Text>
+                                { 'This is a really long string with a ' }
+                            </RX.Text>
+                            <RX.View style={ [_styles.inlineImageContainer, _styles.inlineImageContainerOffset] }>
+                                <RX.Image
+                                    source={ 'https://microsoft.github.io/reactxp/img/tests/bulb.jpg' }
+                                    resizeMode={ 'contain' }
+                                    style={ _styles.inlineImage }
+                                />
+                            </RX.View>
+                            <RX.Text>
+                                { ' light bulb inlined within it. It is meant to demonstrate a' +
+                                ' larger-than-normal line height.' }
+                            </RX.Text>
                         </RX.Text>
-                    </RX.Text>
+                    )}
                 </RX.View>
 
                 <RX.View style={ _styles.explainTextContainer } key={ 'explanation9' }>

--- a/samples/RXPTest/windows/rxptest/rxptest.csproj
+++ b/samples/RXPTest/windows/rxptest/rxptest.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
1. Update dependencies to latest React (16.6.0), RN (0.57.3), and RNW (0.57.0-rc.0). This goes beyond what ReactXP advertises as peer dependencies and is in sync with the changes made to hello-world-js project.
2. Changed UWP SDK minTarget to RS1, aligned with the changes in RNW
3. Update Xcode project to build under Xcode 10
4. RN 0.56+ messed up inline views inside text by disabling support completely due to what RN perceives as inconsistency between iOS (supporting it) & Android (which doesn't).
Until the in-house Skype support for Android makes it to public we may remain in this state.
I disabled the relevant tests
5. Disabled a TextInput text due to a crashing bug in RNW.

I tested in UWP, Web & iOS.
I think I removed all the crashes. Tests do still fail on various platforms, the issues will have to be addressed one by one.

(ts compilation has some lingering issues: one due to the published RXP not being "the latest", and some other Alert related thing)