### PR TITLE
Update VirtualListview dependencies

### DIFF
--- a/extensions/virtuallistview/package.json
+++ b/extensions/virtuallistview/package.json
@@ -9,17 +9,17 @@
     "tslint": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
   },
   "dependencies": {
-    "assert": "1.4.1",
-    "lodash": "4.17.10"
+    "assert": "^1.4.1",
+    "lodash": "^4.17.10"
   },
   "peerDependencies": {
-    "reactxp": "^1.3.0"
+    "reactxp": "^1.5.0"
   },
   "devDependencies": {
-    "reactxp": "^1.3.0",
+    "reactxp": "^1.5.0-rc.2",
     "tslint": "5.10.0",
     "tslint-microsoft-contrib": "5.0.3",
-    "typescript": "2.9.2"
+    "typescript": "3.1.6"
   },
   "homepage": "https://microsoft.github.io/reactxp/docs/extensions/virtuallistview.html",
   "repository": {


### PR DESCRIPTION
1) Explicit version of lodash could cause double-bundling in downstream modules
2) ReactXP was pointing to a min version that was un-supported (missing scrollXAnimatedValue prop on RX.ScrollView until 1.5.0)