### PR TITLE
VirtualListView: Turn on Strict flag in Typescript compiler

### DIFF
--- a/extensions/virtuallistview/package.json
+++ b/extensions/virtuallistview/package.json
@@ -16,6 +16,7 @@
     "reactxp": "^1.5.0"
   },
   "devDependencies": {
+    "@types/assert": "^1.4.0",
     "reactxp": "^1.5.0-rc.2",
     "tslint": "5.10.0",
     "tslint-microsoft-contrib": "5.0.3",

--- a/extensions/virtuallistview/src/VirtualListCell.tsx
+++ b/extensions/virtuallistview/src/VirtualListCell.tsx
@@ -14,15 +14,15 @@ export interface VirtualListCellInfo {
     key: string;
 }
 
-export interface VirtualListCellProps extends RX.CommonProps {
+export interface VirtualListCellProps<ItemInfo extends VirtualListCellInfo> extends RX.CommonProps {
     // All callbacks should be prebound to optimize performance.
-    onLayout: (itemKey: string, height: number) => void;
+    onLayout?: (itemKey: string, height: number) => void;
     onAnimateStartStop?: (itemKey: string, start: boolean) => void;
-    onCellFocus?: (itemKey: string) => void;
-    renderItem: (item: VirtualListCellInfo, focused: boolean) => JSX.Element | JSX.Element[];
+    onCellFocus?: (itemKey: string|undefined) => void;
+    renderItem: (item: ItemInfo|undefined, focused?: boolean) => JSX.Element | JSX.Element[];
 
     // Props that do not impact render (position is set by animated style).
-    itemKey: string;
+    itemKey: string|undefined;
     left: number;
     top: number;
     width: number;
@@ -38,15 +38,15 @@ export interface VirtualListCellProps extends RX.CommonProps {
     isFocused: boolean;
     tabIndex?: number;
     shouldUpdate: boolean;
-    item: VirtualListCellInfo;
+    item: ItemInfo|undefined;
 }
 
-interface StaticRendererProps extends RX.CommonProps {
+interface StaticRendererProps<ItemInfo extends VirtualListCellInfo> extends RX.CommonProps {
     shouldUpdate: boolean;
     isFocused: boolean;
     style: RX.Types.StyleRuleSetRecursive<RX.Types.AnimatedViewStyleRuleSet | RX.Types.ViewStyleRuleSet>;
-    item: VirtualListCellInfo;
-    renderItem: (item: VirtualListCellInfo, focused: boolean) => JSX.Element | JSX.Element[];
+    item: ItemInfo|undefined;
+    renderItem: (item: ItemInfo|undefined, focused: boolean) => JSX.Element | JSX.Element[];
 }
 
 const _styles = {
@@ -66,16 +66,17 @@ const _skypeEaseInAnimationCurve = RX.Animated.Easing.CubicBezier(1, 0, 0.78, 1)
 const _skypeEaseOutAnimationCurve = RX.Animated.Easing.CubicBezier(0.33, 0, 0, 1);
 const _virtualCellRef = 'virtualCell';
 
-export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
+export class VirtualListCell<ItemInfo extends VirtualListCellInfo> extends RX.Component<VirtualListCellProps<ItemInfo>, RX.Stateless> {
     // Helper class used to render child elements inside RX.Animated.View only when parent
     // allows that. If we know that none of the children changed - we would like to skip
     // the render completely, to improve performance.
-    private static StaticRenderer = class extends RX.Component<StaticRendererProps, null> {
-        constructor(props?: StaticRendererProps) {
+    private static StaticRenderer = class <CellItemInfo extends VirtualListCellInfo> extends
+            RX.Component<StaticRendererProps<CellItemInfo>, RX.Stateless> {
+        constructor(props: StaticRendererProps<CellItemInfo>) {
             super(props);
         }
 
-        shouldComponentUpdate(nextProps: StaticRendererProps): boolean {
+        shouldComponentUpdate(nextProps: StaticRendererProps<CellItemInfo>): boolean {
             return nextProps.shouldUpdate || this.props.isFocused !== nextProps.isFocused;
         }
 
@@ -104,11 +105,11 @@ export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
     // but native driver doesnt support width
     private _animatedStylePosition: RX.Types.AnimatedViewStyleRuleSet;
     private _animatedStyleWidth: RX.Types.AnimatedViewStyleRuleSet;
-    private _topAnimation: RX.Types.Animated.CompositeAnimation;
+    private _topAnimation: RX.Types.Animated.CompositeAnimation|undefined;
 
-    private _itemKey = '';
+    private _itemKey: string|undefined;
 
-    constructor(props?: VirtualListCellProps) {
+    constructor(props: VirtualListCellProps<ItemInfo>) {
         super(props);
 
         this._isVisible = props.isVisible;
@@ -146,7 +147,7 @@ export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
         });
     }
 
-    componentWillReceiveProps(nextProps: VirtualListCellProps) {
+    componentWillReceiveProps(nextProps: VirtualListCellProps<ItemInfo>) {
         // If it's inactive, it had better be invisible.
         assert.ok(nextProps.isActive || !nextProps.isVisible);
 
@@ -178,7 +179,7 @@ export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
         }
     }
 
-    shouldComponentUpdate(nextProps: VirtualListCellProps): boolean {
+    shouldComponentUpdate(nextProps: VirtualListCellProps<ItemInfo>): boolean {
         // No need to update inactive (recycled) cells.
         if (!nextProps.isActive) {
             return false;
@@ -194,10 +195,10 @@ export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
         return nextProps.shouldUpdate;
     }
 
-    componentDidUpdate(prevProps: VirtualListCellProps) {
+    componentDidUpdate(prevProps: VirtualListCellProps<ItemInfo>) {
         // We need to simulate a layout event here because recycled cells may not
         // generate a layout event if the cell contents haven't changed.
-        if (this.props.onLayout && this.props.isActive && this._calculatedHeight) {
+        if (this.props.onLayout && this.props.isActive && this._calculatedHeight && this._itemKey) {
             this.props.onLayout(this._itemKey, this._calculatedHeight);
         }
     }
@@ -242,7 +243,7 @@ export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
                     // times. If we're not replacing the animation with another animation,
                     // allow the onAnimateStartStop to proceed.
                     if (animate) {
-                        this._topAnimation = null;
+                        this._topAnimation = undefined;
                     }
                     animationToCancel.stop();
                     isReplacingPendingAnimation = true;
@@ -272,14 +273,14 @@ export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
                         });
                     }
 
-                    if (!isReplacingPendingAnimation) {
+                    if (!isReplacingPendingAnimation && this.props.onAnimateStartStop && this._itemKey) {
                         this.props.onAnimateStartStop(this._itemKey, true);
                     }
                     this._topAnimation.start(() => {
                         // Has the animation been canceled?
                         if (this._topAnimation) {
-                            this._topAnimation = null;
-                            if (this.props.onAnimateStartStop) {
+                            this._topAnimation = undefined;
+                            if (this.props.onAnimateStartStop && this._itemKey) {
                                 this.props.onAnimateStartStop(this._itemKey, false);
                             }
                         }
@@ -297,7 +298,7 @@ export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
         }
     }
 
-    setItemKey(key: string) {
+    setItemKey(key: string|undefined) {
         this._itemKey = key;
     }
 
@@ -343,12 +344,12 @@ export class VirtualListCell extends RX.Component<VirtualListCellProps, null> {
 
     private _onBlur = (e: RX.Types.FocusEvent) => {
         if (this.props.onCellFocus) {
-            this.props.onCellFocus(null);
+            this.props.onCellFocus(undefined);
         }
     }
 
     private _onLayout = (layoutInfo: RX.Types.ViewOnLayoutEvent) => {
-        if (this.props.onLayout && this.props.isActive) {
+        if (this.props.onLayout && this.props.isActive && this._itemKey) {
             this._calculatedHeight = layoutInfo.height;
             this.props.onLayout(this._itemKey, layoutInfo.height);
         }

--- a/extensions/virtuallistview/src/VirtualListView.tsx
+++ b/extensions/virtuallistview/src/VirtualListView.tsx
@@ -70,7 +70,7 @@ export interface VirtualListViewProps<ItemInfo extends VirtualListViewItemInfo> 
     itemList: ItemInfo[];
 
     // Callback for rendering item when it becomes visible within view port.
-    renderItem: (item: ItemInfo, hasFocus?: boolean) => JSX.Element | JSX.Element[];
+    renderItem: (item: ItemInfo|undefined, hasFocus?: boolean) => JSX.Element | JSX.Element[];
 
     // Optional padding around the scrolling content within the list.
     padding?: number;
@@ -224,9 +224,9 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
     private _recycledCells: VirtualCellInfo[] = [];
 
     // List of cells that are rendered
-    private _navigatableItemsRendered: { key: string, vc_key: string }[];
+    private _navigatableItemsRendered: { key: string, vc_key: string }[] = [];
 
-    private _pendingFocusDirection: FocusDirection = null;
+    private _pendingFocusDirection: FocusDirection|undefined;
 
     // Recycled cells remain mounted to reduce the allocations and deallocations.
     // This value controls how many we maintain before culling.
@@ -243,11 +243,11 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
     private _cullFraction = 1.0;
     private _minCullAmount = this._minOverdrawAmount * 2;
 
-    constructor(props?: VirtualListViewProps<ItemInfo>) {
+    constructor(props: VirtualListViewProps<ItemInfo>) {
         super(props);
 
         this._updateStateFromProps(props, true);
-        this.state = { lastFocusedItemKey: null };
+        this.state = { lastFocusedItemKey: undefined };
     }
 
     componentWillReceiveProps(nextProps: VirtualListViewProps<ItemInfo>): void {
@@ -392,7 +392,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
 
                     if (this._activeCells[item.key]) {
                         this._setCellTopAndVisibility(item.key, this._shouldShowItem(item, props),
-                            yPosition - itemHeight, props.animateChanges);
+                            yPosition - itemHeight, !!props.animateChanges);
                     } else {
                         this._allocateCell(item.key, item.template, i, !item.measureHeight, item.height,
                             yPosition - itemHeight, this._shouldShowItem(item, props));
@@ -733,7 +733,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
             const item = props.itemList[itemIndex];
 
             this._setCellTopAndVisibility(item.key, this._shouldShowItem(item, props),
-                yPosition, this.props.animateChanges);
+                yPosition, !!this.props.animateChanges);
 
             const height = this._getHeightOfItem(item);
             yPosition += height;
@@ -908,7 +908,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
 
     private _allocateCell(itemKey: string, itemTemplate: string, itemIndex: number, isHeightConstant: boolean,
         height: number, top: number, isVisible: boolean): VirtualCellInfo {
-        let newCell: VirtualCellInfo = null;
+        let newCell: VirtualCellInfo|null = null;
 
         if (this._activeCells[itemKey]) {
             newCell = this._activeCells[itemKey];
@@ -942,7 +942,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
             assert.ok(newCell.isHeightConstant === isHeightConstant, 'isHeightConstant assumed to not change');
             assert.ok(newCell.itemTemplate === itemTemplate, 'itemTemplate assumed to not change');
 
-            let mountedCell = this.refs[newCell.virtualKey] as VirtualListCell;
+            let mountedCell = this.refs[newCell.virtualKey] as VirtualListCell<ItemInfo>;
             if (mountedCell) {
                 mountedCell.setVisibility(isVisible);
                 mountedCell.setTop(top);
@@ -1012,7 +1012,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
         cellInfo.top = top;
 
         // Set the "live" values as well.
-        let cell = this.refs[cellInfo.virtualKey] as VirtualListCell;
+        let cell = this.refs[cellInfo.virtualKey] as VirtualListCell<ItemInfo>;
         if (cell) {
             cell.setVisibility(isVisibile);
             cell.setTop(top, animate);
@@ -1041,7 +1041,11 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
 
         // Build a list of all the cells we're going to render. This includes all of the active
         // cells plus any recycled (offscreen) cells.
-        let cellList: { cellInfo: VirtualCellInfo, item: VirtualListViewItemInfo, itemIndex: number }[] = [];
+        let cellList: {
+            cellInfo: VirtualCellInfo,
+            item: ItemInfo | undefined,
+            itemIndex: number | undefined
+        }[] = [];
 
         for (let i = 0; i < this._itemsInRenderBlock; i++) {
             const itemIndex = this._itemsAboveRenderBlock + i;
@@ -1062,11 +1066,11 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
         }
 
         _.each(this._recycledCells, virtualCellInfo => {
-            assert.ok(virtualCellInfo, 'Recycled Cells array contains a null object');
+            assert.ok(virtualCellInfo, 'Recycled Cells array contains a null/undefined object');
             cellList.push({
                 cellInfo: virtualCellInfo,
-                item: null,
-                itemIndex: null
+                item: undefined,
+                itemIndex: undefined
             });
         });
 
@@ -1076,7 +1080,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
         cellList = cellList.sort((a, b) => a.cellInfo.virtualKey < b.cellInfo.virtualKey ? 1 : -1);
 
         _.each(cellList, cell => {
-            let tabIndexValue: number;
+            let tabIndexValue: number|undefined;
             let isFocused = false;
             if (cell.item) {
                 if (cell.item && cell.item.isNavigable) {
@@ -1086,7 +1090,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
                         tabIndexValue = cell.item.key === this.state.lastFocusedItemKey ? 0 : -1;
                     }
                 }
-                isFocused = this.state.isFocused && cell.item.key === this.state.lastFocusedItemKey;
+                isFocused = !!this.state.isFocused && cell.item.key === this.state.lastFocusedItemKey;
             }
 
             // We disable transform in Android because it creates problem for screen reader order.
@@ -1097,9 +1101,9 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
                     ref={ cell.cellInfo.virtualKey }
                     key={ this._isAndroidScreenReaderEnabled() ? _accessibilityVirtualKeyPrefix +
                         cell.cellInfo.virtualKey : cell.cellInfo.virtualKey }
-                    onLayout={ !cell.cellInfo.isHeightConstant ? this._onLayoutItem : null }
+                    onLayout={ !cell.cellInfo.isHeightConstant ? this._onLayoutItem : undefined }
                     onAnimateStartStop={ this._onAnimateStartStopItem }
-                    itemKey={ cell.item ? cell.item.key : null }
+                    itemKey={ cell.item ? cell.item.key : undefined }
                     item={ cell.item }
                     left={ 0 }
                     width={ this._contentWidth }
@@ -1167,7 +1171,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
         );
     }
 
-    private _onCellFocus = (itemKey: string) => {
+    private _onCellFocus = (itemKey: string|undefined) => {
         if (itemKey) {
             this.setState({
                 lastFocusedItemKey: itemKey,
@@ -1197,12 +1201,12 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
         let index = _.findIndex(this._navigatableItemsRendered, item => item.key === this.state.lastFocusedItemKey);
 
         if (index !== -1 && index + direction > -1 && index + direction < this._navigatableItemsRendered.length) {
-            let newElementForFocus = this.refs[this._navigatableItemsRendered[index + direction].vc_key] as VirtualListCell;
+            let newElementForFocus = this.refs[this._navigatableItemsRendered[index + direction].vc_key] as VirtualListCell<ItemInfo>;
             newElementForFocus.focus();
             return;
         }
 
-        if (index === -1 && retry) {
+        if (index === -1 && retry && this.state.lastFocusedItemKey !== undefined) {
             index = this._itemMap[this.state.lastFocusedItemKey];
 
             if (index === undefined) {
@@ -1275,7 +1279,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
     private _setFocusIfNeeded() {
         if (this._pendingFocusDirection) {
             this._selectSubsequentItem(this._pendingFocusDirection, false /* do not retry if this fails */);
-            this._pendingFocusDirection = null;
+            this._pendingFocusDirection = undefined;
         }
     }
 

--- a/extensions/virtuallistview/tsconfig.json
+++ b/extensions/virtuallistview/tsconfig.json
@@ -8,6 +8,7 @@
         "target": "es5",
         "outDir": "dist/",
         "skipLibCheck": true,
+        "strict": true,
         "lib": [
             "es5",
             "dom"


### PR DESCRIPTION
Fix all resulting compiler errors

Breaking Change: (Only in typings, not behaviour)
VirtualListView renderItem signature change from
(item: ItemInfo, hasFocus?: boolean) => JSX.Element | JSX.Element[];
TO
(item: ItemInfo|undefined, hasFocus?: boolean) => JSX.Element | JSX.Element[];
