### PR TITLE
Add typesafety to onRef callbacks in RX

### DIFF
--- a/src/native-common/Animated.tsx
+++ b/src/native-common/Animated.tsx
@@ -34,7 +34,7 @@ export const CommonAnimatedClasses: AnimatedClasses = {
 let animatedClasses: AnimatedClasses = CommonAnimatedClasses;
 
 class AnimatedWrapper<P, T> extends RX.AnimatedComponent<P, T> {
-    protected _mountedComponent: RN.ReactNativeBaseComponent<any, any> | null | undefined;
+    protected _mountedComponent: RN.ReactNativeBaseComponent<any, any> | undefined;
 
     setNativeProps(props: P) {
         if (this._mountedComponent && this._mountedComponent.setNativeProps) {
@@ -64,7 +64,7 @@ class AnimatedWrapper<P, T> extends RX.AnimatedComponent<P, T> {
     }
 
     protected _onMount = (component: RN.ReactNativeBaseComponent<any, any> | null) => {
-        this._mountedComponent = component;
+        this._mountedComponent = component || undefined;
     }
 }
 

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -95,7 +95,7 @@ export class Button extends ButtonBase {
     protected _isMounted = false;
     protected _isMouseOver = false;
     protected _isHoverStarted = false;
-    protected _buttonElement: any = null;
+    protected _buttonElement: RN.View | undefined;
 
     private _hideTimeout: number | undefined;
     private _defaultOpacityValue: number | undefined;
@@ -120,7 +120,7 @@ export class Button extends ButtonBase {
         }
     }
 
-    protected _render(internalProps: RN.ViewProps, onMount: (btn: any) => void): JSX.Element {
+    protected _render(internalProps: RN.ViewProps, onMount: (btn: RN.View | null) => void): JSX.Element {
         return (
             <RN.Animated.View { ...internalProps } ref={ onMount }>
                 { this.props.children }
@@ -138,7 +138,7 @@ export class Button extends ButtonBase {
             _defaultAccessibilityTrait);
 
         const opacityStyle = !this.props.disableTouchOpacityAnimation && this._opacityAnimatedStyle;
-        let disabledStyle = this.props.disabled && _styles.disabled;
+        let disabledStyle = this.props.disabled ? _styles.disabled : undefined;
 
         if (this.props.disabled && this.props.disabledOpacity !== undefined) {
             disabledStyle = Styles.createButtonStyle({
@@ -306,8 +306,8 @@ export class Button extends ButtonBase {
         }
     }
 
-    private _onMount = (btn: any): void => {
-        this._buttonElement = btn;
+    private _onMount = (btn: RN.View | null): void => {
+        this._buttonElement = btn || undefined;
     }
 
     private _isTouchFeedbackApplicable() {

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -62,7 +62,7 @@ export class Image extends React.Component<Types.ImageProps, ImageState> impleme
         });
     }
 
-    protected _mountedComponent: RN.Image | null = null;
+    protected _mountedComponent: RN.Image | undefined;
     private _nativeImageWidth: number | undefined;
     private _nativeImageHeight: number | undefined;
     readonly state: ImageState = { forceCache: false, lastNativeError: undefined, headers: this._buildHeaders() };
@@ -127,7 +127,7 @@ export class Image extends React.Component<Types.ImageProps, ImageState> impleme
     }
 
     protected _onMount = (component: RN.Image | null) => {
-        this._mountedComponent = component;
+        this._mountedComponent = component || undefined;
     }
 
     setNativeProps(nativeProps: RN.ImageProps) {

--- a/src/native-common/Link.tsx
+++ b/src/native-common/Link.tsx
@@ -30,7 +30,7 @@ export class LinkBase<S> extends React.Component<RX.Types.LinkProps, S> {
 
     context!: LinkContext;
 
-    protected _mountedComponent: RN.ReactNativeBaseComponent<any, any> | null = null;
+    protected _mountedComponent: RN.Text | undefined;
     protected _isMounted = false;
 
     // To be able to use Link inside TouchableHighlight/TouchableOpacity
@@ -68,14 +68,14 @@ export class LinkBase<S> extends React.Component<RX.Types.LinkProps, S> {
         this._isMounted = false;
     }
 
-    protected _render(internalProps: RN.TextProps, onMount: (text: any) => void) {
+    protected _render(internalProps: RN.TextProps, onMount: (text: RN.Text | null) => void) {
         return (
             <RN.Text { ...internalProps } ref={ onMount }/>
         );
     }
 
-    protected _onMount = (component: any) => {
-        this._mountedComponent = component;
+    protected _onMount = (component: RN.Text | null) => {
+        this._mountedComponent = component || undefined;
     }
 
     protected _onPress = (e: RX.Types.SyntheticEvent) => {

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -58,7 +58,7 @@ export interface PopupContainerViewState {
 }
 
 export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, PopupContainerViewState> {
-    private _mountedComponent: any;
+    private _mountedComponent: RN.View | undefined;
     private _viewHandle: number | null = null;
     private _respositionPopupTimer: number | undefined;
 
@@ -103,7 +103,9 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
     }
 
     componentDidMount() {
-        this._viewHandle = RN.findNodeHandle(this._mountedComponent);
+        if (this._mountedComponent) {
+            this._viewHandle = RN.findNodeHandle(this._mountedComponent);
+        }
 
         if (this.props.popupOptions && !this.props.hidden) {
             this._recalcPosition();
@@ -144,7 +146,7 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
         return (
             <RN.View
                 style={ style as RN.StyleProp<RN.ViewStyle> }
-                ref={ this._onMount as any }
+                ref={ this._onMount }
                 importantForAccessibility={ importantForAccessibility }
             >
                 { popupView }
@@ -152,8 +154,8 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
         );
     }
 
-    protected _onMount = (component: RN.ReactNativeBaseComponent<any, any> | null) => {
-        this._mountedComponent = component;
+    protected _onMount = (component: RN.View | null) => {
+        this._mountedComponent = component || undefined;
     }
 
     private _recalcPosition() {

--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -17,10 +17,9 @@ import ViewBase from './ViewBase';
 //   causes you to have to click twice instead of once on some pieces of UI in
 //   order for the UI to acknowledge your interaction.
 const overrideKeyboardShouldPersistTaps = RN.Platform.OS === 'macos' || RN.Platform.OS === 'windows';
-export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stateless> implements RX.ScrollView {
+export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stateless, RN.ScrollView> implements RX.ScrollView {
     private _scrollTop = 0;
     private _scrollLeft = 0;
-    protected _nativeView: any;
 
     protected _render(nativeProps: RN.ScrollViewProps & React.Props<RN.ScrollView>): JSX.Element {
         if (this.props.scrollXAnimatedValue || this.props.scrollYAnimatedValue) {
@@ -95,7 +94,7 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
         // we use are virtualized anyway.
 
         const internalProps: RN.ScrollViewProps & React.Props<RN.ScrollView> = {
-            ref: this._setNativeView,
+            ref: this._setNativeComponent,
             // Bug in react-native.d.ts.  style should be "style?: StyleProp<ScrollViewStyle>;" but instead is ViewStyle.
             style: this.props.style as any,
             onScroll: scrollHandler,
@@ -138,15 +137,15 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
     }
 
     setScrollTop(scrollTop: number, animate?: boolean): void {
-        if (this._nativeView) {
-            this._nativeView.scrollTo(
+        if (this._nativeComponent) {
+            this._nativeComponent.scrollTo(
                 { x: this._scrollLeft, y: scrollTop, animated: animate });
         }
     }
 
     setScrollLeft(scrollLeft: number, animate?: boolean): void {
-        if (this._nativeView) {
-            this._nativeView.scrollTo(
+        if (this._nativeComponent) {
+            this._nativeComponent.scrollTo(
                 { x: scrollLeft, y: this._scrollTop, animated: animate });
         }
     }

--- a/src/native-common/Text.tsx
+++ b/src/native-common/Text.tsx
@@ -42,7 +42,7 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
         isRxParentAText: PropTypes.bool.isRequired
     };
 
-    protected _mountedComponent: RN.ReactNativeBaseComponent<any, any> | null = null;
+    protected _mountedComponent: RN.Text | undefined;
 
     // To be able to use Text inside TouchableHighlight/TouchableOpacity
     setNativeProps(nativeProps: RN.TextProps) {
@@ -60,7 +60,7 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
         return (
             <RN.Text
                 style={ this._getStyles() as RN.StyleProp<RN.TextStyle> }
-                ref={ this._onMount as any }
+                ref={ this._onMount }
                 importantForAccessibility={ importantForAccessibility }
                 numberOfLines={ this.props.numberOfLines }
                 allowFontScaling={ this.props.allowFontScaling }
@@ -82,8 +82,8 @@ export class Text extends React.Component<Types.TextProps, Types.Stateless> impl
         }
     }
 
-    protected _onMount = (component: any) => {
-        this._mountedComponent = component;
+    protected _onMount = (component: RN.Text | null) => {
+        this._mountedComponent = component || undefined;
     }
 
     protected _getExtendedProperties(): RN.ExtendedTextProps {

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -46,7 +46,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
 
     private _selectionToSet: Selection | undefined;
     private _selection: Selection = { start: 0, end: 0 };
-    protected _mountedComponent: RN.ReactNativeBaseComponent<any, any> | null = null;
+    protected _mountedComponent: RN.TextInput | undefined;
 
     constructor(props: Types.TextInputProps, context: TextInputContext) {
         super(props, context);
@@ -71,7 +71,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
         }
     }
 
-    protected _render(props: RN.TextInputProps, onMount: (textInput: any) => void): JSX.Element {
+    protected _render(props: RN.TextInputProps, onMount: (textInput: RN.TextInput | null) => void): JSX.Element {
         return (
             <RN.TextInput { ...props } ref={ onMount } />
         );
@@ -125,8 +125,8 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
         return this._render(internalProps, this._onMount);
     }
 
-    protected _onMount = (component: RN.ReactNativeBaseComponent<any, any> | null) => {
-        this._mountedComponent = component;
+    protected _onMount = (component: RN.TextInput | null) => {
+        this._mountedComponent = component || undefined;
     }
 
     private _onFocus = (e: Types.FocusEvent) => {

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -128,7 +128,7 @@ export interface ViewContext {
     focusArbitrator?: FocusArbitratorProvider;
 }
 
-export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
+export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
     static contextTypes: React.ValidationMap<any> = {
         focusArbitrator: PropTypes.object
     };
@@ -325,7 +325,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
      */
     protected _buildInternalProps(props: Types.ViewProps) {
         this._internalProps = clone(props) as any;
-        this._internalProps.ref = this._setNativeView;
+        this._internalProps.ref = this._setNativeComponent;
 
         if (props.testId) {
             // Convert from testId to testID.
@@ -401,7 +401,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
         }
     }
     private _isTouchFeedbackApplicable() {
-        return this._isMounted && this._mixinIsApplied && this._nativeView;
+        return this._isMounted && this._mixinIsApplied && !!this._nativeComponent;
     }
 
     private _opacityActive(duration: number) {
@@ -433,11 +433,11 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
     }
 
     private _showUnderlay() {
-        if (!this._nativeView) {
+        if (!this._nativeComponent) {
             return;
         }
 
-        this._nativeView.setNativeProps({
+        this._nativeComponent.setNativeProps({
             style: {
                 backgroundColor: this.props.underlayColor
             }
@@ -445,11 +445,11 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
     }
 
     private _hideUnderlay = () => {
-        if (!this._isMounted || !this._nativeView) {
+        if (!this._isMounted || !this._nativeComponent) {
             return;
         }
 
-        this._nativeView.setNativeProps({
+        this._nativeComponent.setNativeProps({
             style: [{
                 backgroundColor: _underlayInactive
             }, this.props.style]

--- a/src/native-common/ViewBase.tsx
+++ b/src/native-common/ViewBase.tsx
@@ -12,12 +12,12 @@ import * as RN from 'react-native';
 import * as RX from '../common/Interfaces';
 import { isEqual } from './utils/lodashMini';
 
-export abstract class ViewBase<P extends RX.Types.ViewProps, S> extends RX.ViewBase<P, S> {
+export abstract class ViewBase<P extends RX.Types.ViewProps, S, T extends RN.View | RN.ScrollView> extends RX.ViewBase<P, S> {
     private static _defaultViewStyle: RX.Types.ViewStyleRuleSet | undefined;
     private _layoutEventValues: RX.Types.ViewOnLayoutEvent | undefined;
 
     abstract render(): JSX.Element;
-    protected _nativeView: RN.View | undefined;
+    protected _nativeComponent: T | undefined;
 
     static setDefaultViewStyle(defaultViewStyle: RX.Types.ViewStyleRuleSet) {
         ViewBase._defaultViewStyle = defaultViewStyle;
@@ -29,13 +29,15 @@ export abstract class ViewBase<P extends RX.Types.ViewProps, S> extends RX.ViewB
 
     // To be able to use View inside TouchableHighlight/TouchableOpacity
     setNativeProps(nativeProps: RN.ViewProps) {
-        if (this._nativeView) {
-            this._nativeView.setNativeProps(nativeProps);
+        // We know that View and ScrollView both has setNative props even if the typings don't exist
+        const nativeComponent = this._nativeComponent as any as RN.ReactNativeBaseComponent<any, any> | null;
+        if (nativeComponent && nativeComponent.setNativeProps) {
+            nativeComponent.setNativeProps(nativeProps);
         }
     }
 
-    protected _setNativeView = (view: any | undefined) => {
-        this._nativeView = view;
+    protected _setNativeComponent = (view: T | null) => {
+        this._nativeComponent = view || undefined;
     }
 
     protected _getStyles(props: RX.Types.ViewProps) {

--- a/src/native-common/WebView.tsx
+++ b/src/native-common/WebView.tsx
@@ -23,7 +23,7 @@ const _styles = {
 type MixedContentMode = 'never' | 'always' | 'compatibility' | undefined;
 
 export class WebView extends React.Component<RX.Types.WebViewProps, RX.Types.Stateless> implements RX.WebView {
-    private _mountedComponent: RN.WebView | null = null;
+    private _mountedComponent: RN.WebView | undefined;
 
     render() {
         const styles = [_styles.webViewDefault, this.props.style] as RN.StyleProp<RN.ViewStyle>;
@@ -70,8 +70,8 @@ export class WebView extends React.Component<RX.Types.WebViewProps, RX.Types.Sta
         return 'never';
     }
 
-    protected _onMount = (component: RN.WebView) => {
-        this._mountedComponent = component;
+    protected _onMount = (component: RN.WebView | null) => {
+        this._mountedComponent = component || undefined;
     }
 
     protected _onMessage = (e: RN.NativeSyntheticEvent<RN.WebViewMessageEventData>) => {

--- a/src/web/listAnimations/MonitorListEdits.tsx
+++ b/src/web/listAnimations/MonitorListEdits.tsx
@@ -327,7 +327,7 @@ export class MonitorListEdits extends React.Component<MonitorListEditsProps, Typ
         }
     }
 
-    private _saveRef(reactElement: any, refValue: React.Component<any, any>) {
+    private _saveRef(reactElement: any, refValue: React.Component<any, any> | null) {
         if (refValue === null) {
             delete this._itemRefs[reactElement.key];
         } else {


### PR DESCRIPTION
Update component refs to be component|undefined instead of component|null. This allows us to skip initialization to null
Fix a couple bugs along the way