### PR TITLE
Only apply allowDrag=true flag on View if handler is specified

### DIFF
--- a/src/macos/View.tsx
+++ b/src/macos/View.tsx
@@ -35,11 +35,11 @@ export class View extends ViewCommon {
         for (const name of ['onDragStart', 'onDrag', 'onDragEnd']) {
             const handler = this._internalProps[name];
 
-            if (name === 'onDragStart') {
-                this._internalProps.allowDrag = true;
-            }
-
             if (handler) {
+                if (name === 'onDragStart') {
+                    this._internalProps.allowDrag = true;
+                }
+                
                 this._internalProps[name] = (e: React.SyntheticEvent<View>) => {
                     const dndEvent = EventHelpers.toDragEvent(e);
                     handler(dndEvent);


### PR DESCRIPTION
Currently all view on RN Mac have the allowDrag=true flag regardless of handler existing or not