### PR TITLE
Use native Array.isArray instead of _.isArray

### DIFF
--- a/src/native-common/AccessibilityUtil.ts
+++ b/src/native-common/AccessibilityUtil.ts
@@ -86,13 +86,13 @@ export class AccessibilityUtil extends CommonAccessibilityUtil {
 
         let traits : (Types.AccessibilityTrait | undefined)[];
         if (defaultTrait && ensureDefaultTrait) {
-            if (_.isArray(overrideTraits)) {
+            if (Array.isArray(overrideTraits)) {
                 traits = overrideTraits.indexOf(defaultTrait) === -1 ? overrideTraits.concat([defaultTrait]) : overrideTraits;
             } else {
                 traits = overrideTraits === defaultTrait ? [overrideTraits] : [overrideTraits, defaultTrait];
             }
         } else {
-            traits = _.isArray(overrideTraits) ? overrideTraits : [overrideTraits || defaultTrait];
+            traits = Array.isArray(overrideTraits) ? overrideTraits : [overrideTraits || defaultTrait];
         }
         return _.compact(_.map(traits, t  => t ? traitsMap[t] : undefined)) as RN.AccessibilityTrait[];
     }
@@ -107,7 +107,7 @@ export class AccessibilityUtil extends CommonAccessibilityUtil {
             return undefined;
         }
 
-        const combinedTraits = _.isArray(overrideTraits) ? overrideTraits : [overrideTraits || defaultTrait];
+        const combinedTraits = Array.isArray(overrideTraits) ? overrideTraits : [overrideTraits || defaultTrait];
         const maxTrait = _.max(_.filter(combinedTraits, t => componentTypeMap.hasOwnProperty(t as any)));
         return maxTrait ? componentTypeMap[maxTrait] : undefined;
     }

--- a/src/native-common/utils/lodashMini.ts
+++ b/src/native-common/utils/lodashMini.ts
@@ -13,7 +13,6 @@ import extend = require('lodash/extend');
 import filter = require('lodash/filter');
 import findIndex = require('lodash/findIndex');
 import findLast = require('lodash/findLast');
-import isArray = require('lodash/isArray');
 import isEqual = require('lodash/isEqual');
 import isUndefined = require('lodash/isUndefined');
 import last = require('lodash/last');
@@ -29,7 +28,6 @@ export {
     filter,
     findIndex,
     findLast,
-    isArray,
     isEqual,
     isUndefined,
     last,

--- a/src/web/AccessibilityUtil.ts
+++ b/src/web/AccessibilityUtil.ts
@@ -64,7 +64,7 @@ export class AccessibilityUtil extends CommonAccessibiltiyUtil {
         let combinedTraits: Types.AccessibilityTrait[] = defaultTrait ? [defaultTrait] : [];
 
         if (traits) {
-            combinedTraits = _.union(combinedTraits, _.isArray(traits) ? traits : [traits]);
+            combinedTraits = _.union(combinedTraits, Array.isArray(traits) ? traits : [traits]);
         }
 
         // Max enum value in this array of traits is role for web. Return corresponding
@@ -76,7 +76,7 @@ export class AccessibilityUtil extends CommonAccessibiltiyUtil {
 
     accessibilityTraitToAriaSelected(traits: Types.AccessibilityTrait | Types.AccessibilityTrait[] | undefined) {
         // Walk through each trait and check if there's a selected trait. Return if one is found.
-        if (traits && _.isArray(traits) && traits.indexOf(Types.AccessibilityTrait.Tab) !== -1) {
+        if (traits && Array.isArray(traits) && traits.indexOf(Types.AccessibilityTrait.Tab) !== -1) {
             return traits.indexOf(Types.AccessibilityTrait.Selected) !== -1;
         }
 
@@ -87,7 +87,7 @@ export class AccessibilityUtil extends CommonAccessibiltiyUtil {
 
     accessibilityTraitToAriaChecked(traits: Types.AccessibilityTrait | Types.AccessibilityTrait[] | undefined) {
         // Walk through each trait and check if there's a checked trait. Return if one is found.
-        if (traits && _.isArray(traits) && traits.indexOf(Types.AccessibilityTrait.CheckBox) !== -1) {
+        if (traits && Array.isArray(traits) && traits.indexOf(Types.AccessibilityTrait.CheckBox) !== -1) {
             return traits.indexOf(Types.AccessibilityTrait.Checked) !== -1;
         }
 
@@ -98,7 +98,7 @@ export class AccessibilityUtil extends CommonAccessibiltiyUtil {
 
     accessibilityTraitToAriaHasPopup(traits: Types.AccessibilityTrait | Types.AccessibilityTrait[] | undefined) {
         // Walk through each trait and check if there's a hasPopup trait. Return if one is found.
-        if (traits && _.isArray(traits) && traits.indexOf(Types.AccessibilityTrait.HasPopup) !== -1) {
+        if (traits && Array.isArray(traits) && traits.indexOf(Types.AccessibilityTrait.HasPopup) !== -1) {
             return traits.indexOf(Types.AccessibilityTrait.HasPopup) !== -1;
         }
 

--- a/src/web/utils/lodashMini.ts
+++ b/src/web/utils/lodashMini.ts
@@ -19,7 +19,6 @@ import findIndex = require('lodash/findIndex');
 import findLast = require('lodash/findLast');
 import flatten = require('lodash/flatten');
 import get = require('lodash/get');
-import isArray = require('lodash/isArray');
 import isEmpty = require('lodash/isEmpty');
 import isEqual = require('lodash/isEqual');
 import isNumber = require('lodash/isNumber');
@@ -50,7 +49,6 @@ export {
     findLast,
     flatten,
     get,
-    isArray,
     isEmpty,
     isEqual,
     isNumber,

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -168,7 +168,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     }
 
     private _hasTrait(trait: Types.AccessibilityTrait, traits: Types.AccessibilityTrait | Types.AccessibilityTrait[] | undefined) {
-        return traits === trait || (_.isArray(traits) && traits.indexOf(trait) !== -1);
+        return traits === trait || (Array.isArray(traits) && traits.indexOf(trait) !== -1);
     }
 
     private _showContextMenu(keyEvent: Types.KeyboardEvent) {


### PR DESCRIPTION
LoDash `isArray` implementation relies on ES5 `Array.isArray`

```javascript
var isArray = Array.isArray;
module.exports = isArray;
```

seems doesn't make sense to use external dependency. 
