### PR TITLE
Adding "context" mode to Popup handling, and consolidated popup code

### DIFF
--- a/docs/docs/apis/popup.md
+++ b/docs/docs/apis/popup.md
@@ -19,7 +19,9 @@ Popups are identified by a caller-specified ID that should be unique.
 
 ## Types
 ``` javascript
-type PopupPosition  = 'top' | 'right' | 'bottom' | 'left';
+// 'context' mode makes it attempt to behave like a context menu -- defaulting
+// to the lower right of the anchor element and working its way around.
+type PopupPosition  = 'top' | 'right' | 'bottom' | 'left' | 'context';
 
 interface PopupOptions {
     // Returns a mounted component instance that serves as the

--- a/docs/docs/apis/popup.md
+++ b/docs/docs/apis/popup.md
@@ -20,7 +20,8 @@ Popups are identified by a caller-specified ID that should be unique.
 ## Types
 ``` javascript
 // 'context' mode makes it attempt to behave like a context menu -- defaulting
-// to the lower right of the anchor element and working its way around.
+// to the lower right of the anchor element and working its way around.  It is not supported
+// with inner positioning and will throw an exception if used there.
 type PopupPosition  = 'top' | 'right' | 'bottom' | 'left' | 'context';
 
 interface PopupOptions {

--- a/samples/RXPTest/src/Tests/PopupTest.tsx
+++ b/samples/RXPTest/src/Tests/PopupTest.tsx
@@ -96,7 +96,17 @@ const _styles = {
     comboBoxText: RX.Styles.createTextStyle({
         fontSize: 14,
         color: '#666'
-    })
+    }),
+    popupAnchor6: RX.Styles.createViewStyle({
+        alignSelf: 'center',
+        borderRadius: 15,
+        height: 30,
+        width: 160,
+        marginTop: 40,
+        backgroundColor: '#eee',
+        alignItems: 'center',
+        justifyContent: 'center',
+    }),
 };
 
 const popup1Id = 'popup1';
@@ -104,6 +114,7 @@ const popup2Id = 'popup2';
 const popup3Id = 'popup3';
 const popup4Id = 'popup4';
 const popup5Id = 'popup5';
+const popup6Id = 'popup6';
 
 interface PopupBoxProps extends RX.CommonProps {
     text: string;
@@ -175,6 +186,7 @@ class PopupView extends RX.Component<RX.CommonProps, PopupViewState> {
     private _anchor3: RX.Button | undefined;
     private _anchor4: RX.Button | undefined;
     private _anchor5: RX.TextInput | undefined;
+    private _anchor6: RX.Button | undefined;
 
     constructor(props: RX.CommonProps) {
         super(props);
@@ -245,6 +257,15 @@ class PopupView extends RX.Component<RX.CommonProps, PopupViewState> {
                     value={ this.state.textInputValue || '' }
                     onChangeText={ this._onChangeTextInput }
                 />
+                <RX.Button
+                    style={ [_styles.popupAnchor6] }
+                    ref={ (comp: any) => { this._anchor6 = comp; } }
+                    onPress={ this._showPopup6 }
+                >
+                    <RX.Text style={ _styles.anchorText }>
+                        { `6: isDisplayed = ${RX.Popup.isDisplayed(popup6Id)}` }
+                    </RX.Text>
+                </RX.Button>
             </RX.View>
         );
     }
@@ -348,6 +369,33 @@ class PopupView extends RX.Component<RX.CommonProps, PopupViewState> {
                 );
             }
         }, popup4Id);
+    }
+
+    private _showPopup6 = () => {
+        RX.Popup.show({
+            dismissIfShown: true,
+            cacheable: true,
+            getAnchor: () => {
+                return this._anchor6!;
+            },
+            getElementTriggeringPopup: () => {
+                return this._anchor6!;
+            },
+            positionPriorities: ['context'],
+            renderPopup: (anchorPosition: RX.Types.PopupPosition, anchorOffset: number,
+                popupWidth: number, popupHeight: number) => {
+
+                return (
+                    <PopupBox
+                        text={ 'Context Menu Behavior' }
+                        anchorOffset={ anchorOffset }
+                        anchorPosition={ anchorPosition }
+                        popupWidth={ popupWidth }
+                        popupHeight={ popupHeight }
+                    />
+                );
+            }
+        }, popup6Id);
     }
 
     private _onChangeTextInput = (newText: string) => {

--- a/src/common/PopupContainerViewBase.tsx
+++ b/src/common/PopupContainerViewBase.tsx
@@ -146,6 +146,31 @@ export function recalcPositionFromLayoutData(windowDims: Dimensions, anchorRect:
                         constrainedWidth = anchorRect.left - ALLEY_WIDTH;
                     }
                     break;
+
+                case 'context':
+                    // Search for perfect fits on the LR, LL, TR, and TL corners.
+                    const fitsAbove = anchorRect.top - popupRect.height >= ALLEY_WIDTH;
+                    const fitsBelow = anchorRect.top + anchorRect.height + popupRect.height <= windowDims.height - ALLEY_WIDTH;
+                    const fitsLeft = anchorRect.left - popupRect.width >= ALLEY_WIDTH;
+                    const fitsRight = anchorRect.left + anchorRect.width + popupRect.width <= windowDims.width - ALLEY_WIDTH;
+                    if (fitsBelow && fitsRight) {
+                        foundPerfectFit = true;
+                        absX = anchorRect.left + anchorRect.width;
+                        absY = anchorRect.top + anchorRect.height;
+                    } else if (fitsBelow && fitsLeft) {
+                        foundPerfectFit = true;
+                        absX = anchorRect.left - popupRect.width;
+                        absY = anchorRect.top + anchorRect.height;
+                    } else if (fitsAbove && fitsRight) {
+                        foundPerfectFit = true;
+                        absX = anchorRect.left + anchorRect.width;
+                        absY = anchorRect.top - popupRect.height;
+                    } else if (fitsAbove && fitsLeft) {
+                        foundPerfectFit = true;
+                        absX = anchorRect.left - popupRect.width;
+                        absY = anchorRect.top - popupRect.height;
+                    }
+                    break;
             }
 
             const effectiveWidth = constrainedWidth || popupRect.width;

--- a/src/common/PopupContainerViewBase.tsx
+++ b/src/common/PopupContainerViewBase.tsx
@@ -70,6 +70,10 @@ export function recalcPositionFromLayoutData(windowDims: Dimensions, anchorRect:
     if (!positionsToTry || positionsToTry.length === 0) {
         positionsToTry = ['bottom', 'right', 'top', 'left'];
     }
+    if (positionsToTry.length === 1 && positionsToTry[0] === 'context') {
+        // Context only works with exact matches, so fall back to walking around the compass if it doesn't fit exactly.
+        positionsToTry.push('bottom', 'right', 'top', 'left');
+    }
 
     if (useInnerPositioning) {
         // If the popup is meant to be shown inside the anchor we need to recalculate
@@ -259,6 +263,9 @@ function recalcInnerPosition(anchorRect: ClientRect, positionToUse: PopupPositio
             popupX = anchorRect.left;
             anchorOffset = popupHeight / 2;
             break;
+
+        case 'context':
+            throw new Error('Context popup mode not allowed with inner positioning');
     }
 
     const result: RecalcResult = {

--- a/src/common/PopupContainerViewBase.tsx
+++ b/src/common/PopupContainerViewBase.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 
 import FocusManagerBase from './utils/FocusManager';
 import { Types } from './Interfaces';
+import { Dimensions, PopupPosition } from './Types';
 
 export interface PopupContainerViewBaseProps<C> extends Types.CommonProps<C> {
     hidden?: boolean;
@@ -26,6 +27,224 @@ export interface PopupContainerViewContext {
 export interface PopupComponent {
     onShow: () => void;
     onHide: () => void;
+}
+
+export interface RecalcResult {
+    // Absolute window location of the popup
+    popupY: number;
+    popupX: number;
+
+    // Top or left offset of the popup relative to the center of the anchor
+    anchorOffset: number;
+
+    // Position of popup relative to its anchor (top, bottom, left, right)
+    anchorPosition: PopupPosition;
+
+    // Constrained dimensions of the popup once it is placed
+    constrainedPopupWidth: number;
+    constrainedPopupHeight: number;
+}
+
+// Width of the "alley" around popups so they don't get too close to the boundary of the screen boundary.
+const ALLEY_WIDTH = 2;
+
+// How close to the edge of the popup should we allow the anchor offset to get before
+// attempting a different position?
+const MIN_ANCHOR_OFFSET = 16;
+
+// Undefined response means to dismiss the popup
+export function recalcPositionFromLayoutData(windowDims: Dimensions, anchorRect: ClientRect, popupRect: Dimensions,
+        positionPriorities?: PopupPosition[], useInnerPositioning?: boolean): RecalcResult | undefined {
+    // If the anchor has disappeared, dismiss the popup.
+    if (!(anchorRect.width > 0 && anchorRect.height > 0)) {
+        return undefined;
+    }
+
+    // If the anchor is no longer in the window's bounds, cancel the popup.
+    if (anchorRect.left >= windowDims.width || anchorRect.right <= 0 ||
+            anchorRect.bottom <= 0 || anchorRect.top >= windowDims.height) {
+        return undefined;
+    }
+
+    let positionsToTry = positionPriorities;
+    if (!positionsToTry || positionsToTry.length === 0) {
+        positionsToTry = ['bottom', 'right', 'top', 'left'];
+    }
+
+    if (useInnerPositioning) {
+        // If the popup is meant to be shown inside the anchor we need to recalculate
+        // the position differently.
+        return recalcInnerPosition(anchorRect, positionsToTry[0], popupRect.width, popupRect.height);
+    }
+
+    // Start by assuming that we'll be unconstrained.
+    const result: RecalcResult = {
+        popupX: 0,
+        popupY: 0,
+        anchorOffset: 0,
+        anchorPosition: 'top',
+        constrainedPopupWidth: popupRect.width,
+        constrainedPopupHeight: popupRect.height
+    };
+
+    let foundPerfectFit = false;
+    let foundPartialFit = false;
+
+    positionsToTry.forEach(pos => {
+        if (!foundPerfectFit) {
+            let absX = 0;
+            let absY = 0;
+            let anchorOffset = 0;
+            let constrainedWidth = 0;
+            let constrainedHeight = 0;
+
+            switch (pos) {
+                case 'bottom':
+                    absY = anchorRect.bottom;
+                    absX = anchorRect.left + (anchorRect.width - popupRect.width) / 2;
+                    anchorOffset = popupRect.width / 2;
+
+                    if (popupRect.height <= windowDims.height - ALLEY_WIDTH - anchorRect.bottom) {
+                        foundPerfectFit = true;
+                    } else if (!foundPartialFit) {
+                        constrainedHeight = windowDims.height - ALLEY_WIDTH - anchorRect.bottom;
+                    }
+                    break;
+
+                case 'top':
+                    absY = anchorRect.top - popupRect.height;
+                    absX = anchorRect.left + (anchorRect.width - popupRect.width) / 2;
+                    anchorOffset = popupRect.width / 2;
+
+                    if (popupRect.height <= anchorRect.top - ALLEY_WIDTH) {
+                        foundPerfectFit = true;
+                    } else if (!foundPartialFit) {
+                        constrainedHeight = anchorRect.top - ALLEY_WIDTH;
+                    }
+                    break;
+
+                case 'right':
+                    absX = anchorRect.right;
+                    absY = anchorRect.top + (anchorRect.height - popupRect.height) / 2;
+                    anchorOffset = popupRect.height / 2;
+
+                    if (popupRect.width <= windowDims.width - ALLEY_WIDTH - anchorRect.right) {
+                        foundPerfectFit = true;
+                    } else if (!foundPartialFit) {
+                        constrainedWidth = windowDims.width - ALLEY_WIDTH - anchorRect.right;
+                    }
+                    break;
+
+                case 'left':
+                    absX = anchorRect.left - popupRect.width;
+                    absY = anchorRect.top + (anchorRect.height - popupRect.height) / 2;
+                    anchorOffset = popupRect.height / 2;
+
+                    if (popupRect.width <= anchorRect.left - ALLEY_WIDTH) {
+                        foundPerfectFit = true;
+                    } else if (!foundPartialFit) {
+                        constrainedWidth = anchorRect.left - ALLEY_WIDTH;
+                    }
+                    break;
+            }
+
+            const effectiveWidth = constrainedWidth || popupRect.width;
+            const effectiveHeight = constrainedHeight || popupRect.height;
+
+            // Make sure we're not hanging off the bounds of the window.
+            if (absX < ALLEY_WIDTH) {
+                if (pos === 'top' || pos === 'bottom') {
+                    anchorOffset -= ALLEY_WIDTH - absX;
+                    if (anchorOffset < MIN_ANCHOR_OFFSET || anchorOffset > effectiveWidth - MIN_ANCHOR_OFFSET) {
+                        foundPerfectFit = false;
+                    }
+                }
+                absX = ALLEY_WIDTH;
+            } else if (absX > windowDims.width - ALLEY_WIDTH - effectiveWidth) {
+                if (pos === 'top' || pos === 'bottom') {
+                    anchorOffset -= (windowDims.width - ALLEY_WIDTH - effectiveWidth - absX);
+                    if (anchorOffset < MIN_ANCHOR_OFFSET || anchorOffset > effectiveWidth - MIN_ANCHOR_OFFSET) {
+                        foundPerfectFit = false;
+                    }
+                }
+                absX = windowDims.width - ALLEY_WIDTH - effectiveWidth;
+            }
+
+            if (absY < ALLEY_WIDTH) {
+                if (pos === 'right' || pos === 'left') {
+                    anchorOffset += absY - ALLEY_WIDTH;
+                    if (anchorOffset < MIN_ANCHOR_OFFSET || anchorOffset > effectiveHeight - MIN_ANCHOR_OFFSET) {
+                        foundPerfectFit = false;
+                    }
+                }
+                absY = ALLEY_WIDTH;
+            } else if (absY > windowDims.height - ALLEY_WIDTH - effectiveHeight) {
+                if (pos === 'right' || pos === 'left') {
+                    anchorOffset -= (windowDims.height - ALLEY_WIDTH - effectiveHeight - absY);
+                    if (anchorOffset < MIN_ANCHOR_OFFSET || anchorOffset > effectiveHeight - MIN_ANCHOR_OFFSET) {
+                        foundPerfectFit = false;
+                    }
+                }
+                absY = windowDims.height - ALLEY_WIDTH - effectiveHeight;
+            }
+
+            if (foundPerfectFit || effectiveHeight > 0 || effectiveWidth > 0) {
+                result.popupY = absY;
+                result.popupX = absX;
+                result.anchorOffset = anchorOffset;
+                result.anchorPosition = pos;
+                result.constrainedPopupWidth = effectiveWidth;
+                result.constrainedPopupHeight = effectiveHeight;
+
+                foundPartialFit = true;
+            }
+        }
+    });
+
+    return result;
+}
+
+function recalcInnerPosition(anchorRect: ClientRect, positionToUse: PopupPosition, popupWidth: number, popupHeight: number) {
+    // For inner popups we only accept the first position of the priorities since there
+    // should always be room for the bubble.
+    let popupX = 0;
+    let popupY = 0;
+    let anchorOffset = 0;
+    switch (positionToUse) {
+        case 'top':
+            popupY = anchorRect.top + anchorRect.height - popupHeight;
+            popupX = anchorRect.left + anchorRect.height / 2 - popupWidth / 2;
+            anchorOffset = popupWidth / 2;
+            break;
+
+        case 'bottom':
+            popupY = anchorRect.top + popupHeight;
+            popupX = anchorRect.left + anchorRect.height / 2 - popupWidth / 2;
+            anchorOffset = popupWidth / 2;
+            break;
+
+        case 'left':
+            popupY = anchorRect.top + anchorRect.height / 2 - popupHeight / 2;
+            popupX = anchorRect.left + anchorRect.width - popupWidth;
+            anchorOffset = popupHeight / 2;
+            break;
+
+        case 'right':
+            popupY = anchorRect.top + anchorRect.height / 2 - popupHeight / 2;
+            popupX = anchorRect.left;
+            anchorOffset = popupHeight / 2;
+            break;
+    }
+
+    const result: RecalcResult = {
+        popupX,
+        popupY,
+        anchorOffset,
+        anchorPosition: positionToUse,
+        constrainedPopupWidth: popupWidth,
+        constrainedPopupHeight: popupHeight
+    };
+    return result;
 }
 
 export abstract class PopupContainerViewBase<P extends PopupContainerViewBaseProps<C>, S, C> extends React.Component<P, S> {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1019,6 +1019,9 @@ export interface WebViewProps extends CommonStyledProps<WebViewStyleRuleSet, RX.
     sandbox?: WebViewSandboxMode;
 }
 
+// 'context' mode makes it attempt to behave like a context menu -- defaulting
+// to the lower right of the anchor element and working its way around.  It is not supported
+// with inner positioning and will throw an exception if used there.
 export type PopupPosition  = 'top' | 'right' | 'bottom' | 'left' | 'context';
 
 // Popup

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1019,7 +1019,7 @@ export interface WebViewProps extends CommonStyledProps<WebViewStyleRuleSet, RX.
     sandbox?: WebViewSandboxMode;
 }
 
-export type PopupPosition  = 'top' | 'right' | 'bottom' | 'left';
+export type PopupPosition  = 'top' | 'right' | 'bottom' | 'left' | 'context';
 
 // Popup
 export interface PopupOptions {

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -17,16 +17,10 @@ import assert from '../common/assert';
 import { Types } from '../common/Interfaces';
 import International from './International';
 import { extend, isEqual } from './utils/lodashMini';
-import { PopupContainerViewBase, PopupContainerViewBaseProps, PopupContainerViewContext } from '../common/PopupContainerViewBase';
+import { PopupContainerViewBase, PopupContainerViewBaseProps, PopupContainerViewContext,
+    recalcPositionFromLayoutData, RecalcResult } from '../common/PopupContainerViewBase';
 import Timers from '../common/utils/Timers';
 import UserInterface from './UserInterface';
-
-// Width of the "alley" around popups so they don't get too close to the boundary of the screen boundary.
-const ALLEY_WIDTH = 2;
-
-// How close to the edge of the popup should we allow the anchor offset to get before
-// attempting a different position?
-const MIN_ANCHOR_OFFSET = 16;
 
 export interface PopupContainerViewProps extends PopupContainerViewBaseProps<PopupContainerView> {
     popupOptions: Types.PopupOptions;
@@ -34,27 +28,13 @@ export interface PopupContainerViewProps extends PopupContainerViewBaseProps<Pop
     onDismissPopup?: () => void;
 }
 
-export interface PopupContainerViewState {
+export interface PopupContainerViewState extends RecalcResult {
     // We need to measure the popup before it can be positioned. This indicates that we're in the "measuring" phase.
     isMeasuringPopup: boolean;
 
     // Measured (unconstrained) dimensions of the popup; not valid if isMeasuringPopup is false.
     popupWidth: number;
     popupHeight: number;
-
-    // Position of popup relative to its anchor (top, bottom, left, right)
-    anchorPosition: Types.PopupPosition;
-
-    // Top or left offset of the popup relative to the center of the anchor
-    anchorOffset: number;
-
-    // Absolute window location of the popup
-    popupY: number;
-    popupX: number;
-
-    // Constrained dimensions of the popup once it is placed
-    constrainedPopupWidth: number;
-    constrainedPopupHeight: number;
 }
 
 export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, PopupContainerViewState, PopupContainerView> {
@@ -199,203 +179,32 @@ export class PopupContainerView extends PopupContainerViewBase<PopupContainerVie
         }
 
         // If the popup hasn't been rendered yet, skip.
-        if (popupRect.width > 0 && popupRect.height > 0) {
-            // Make a copy of the old state.
-            const newState: PopupContainerViewState = extend({}, this.state);
-
-            if (this.state.isMeasuringPopup) {
-                newState.isMeasuringPopup = false;
-                newState.popupWidth = popupRect.width;
-                newState.popupHeight = popupRect.height;
-            }
-
-            // If the anchor has disappeared, dismiss the popup.
-            if (!(anchorRect.width > 0 && anchorRect.height > 0)) {
-                this._dismissPopup();
-                return;
-            }
-
-            // Start by assuming that we'll be unconstrained.
-            newState.constrainedPopupHeight = newState.popupHeight;
-            newState.constrainedPopupWidth = newState.popupWidth;
-
-            // Get the width/height of root view window.
-            const window = UserInterface.measureWindow(this.props.popupOptions.rootViewId);
-
-            const windowWidth = window.width;
-            const windowHeight = window.height;
-
-            // If the anchor is no longer in the window's bounds, cancel the popup.
-            if (anchorRect.left >= windowWidth || anchorRect.right <= 0 ||
-                    anchorRect.bottom <= 0 || anchorRect.top >= windowHeight) {
-                this._dismissPopup();
-                return;
-            }
-
-            let positionsToTry = this.props.popupOptions.positionPriorities;
-            if (!positionsToTry || positionsToTry.length === 0) {
-                positionsToTry = ['bottom', 'right', 'top', 'left'];
-            }
-
-            if (this.props.popupOptions.useInnerPositioning) {
-                // If the popup is meant to be shown inside the anchor we need to recalculate
-                // the position differently.
-                this._recalcInnerPosition(anchorRect, newState);
-                return;
-            }
-
-            let foundPerfectFit = false;
-            let foundPartialFit = false;
-
-            positionsToTry.forEach(pos => {
-                if (!foundPerfectFit) {
-                    let absX = 0;
-                    let absY = 0;
-                    let anchorOffset = 0;
-                    let constrainedWidth = 0;
-                    let constrainedHeight = 0;
-
-                    switch (pos) {
-                        case 'bottom':
-                            absY = anchorRect.bottom;
-                            absX = anchorRect.left + (anchorRect.width - newState.popupWidth) / 2;
-                            anchorOffset = newState.popupWidth / 2;
-
-                            if (newState.popupHeight <= windowHeight - ALLEY_WIDTH - anchorRect.bottom) {
-                                foundPerfectFit = true;
-                            } else if (!foundPartialFit) {
-                                constrainedHeight = windowHeight - ALLEY_WIDTH - anchorRect.bottom;
-                            }
-                            break;
-
-                        case 'top':
-                            absY = anchorRect.top - newState.popupHeight;
-                            absX = anchorRect.left + (anchorRect.width - newState.popupWidth) / 2;
-                            anchorOffset = newState.popupWidth / 2;
-
-                            if (newState.popupHeight <= anchorRect.top - ALLEY_WIDTH) {
-                                foundPerfectFit = true;
-                            } else if (!foundPartialFit) {
-                                constrainedHeight = anchorRect.top - ALLEY_WIDTH;
-                            }
-                            break;
-
-                        case 'right':
-                            absX = anchorRect.right;
-                            absY = anchorRect.top + (anchorRect.height - newState.popupHeight) / 2;
-                            anchorOffset = newState.popupHeight / 2;
-
-                            if (newState.popupWidth <= windowWidth - ALLEY_WIDTH - anchorRect.right) {
-                                foundPerfectFit = true;
-                            } else if (!foundPartialFit) {
-                                constrainedWidth = windowWidth - ALLEY_WIDTH - anchorRect.right;
-                            }
-                            break;
-
-                        case 'left':
-                            absX = anchorRect.left - newState.popupWidth;
-                            absY = anchorRect.top + (anchorRect.height - newState.popupHeight) / 2;
-                            anchorOffset = newState.popupHeight / 2;
-
-                            if (newState.popupWidth <= anchorRect.left - ALLEY_WIDTH) {
-                                foundPerfectFit = true;
-                            } else if (!foundPartialFit) {
-                                constrainedWidth = anchorRect.left - ALLEY_WIDTH;
-                            }
-                            break;
-                    }
-
-                    const effectiveWidth = constrainedWidth || newState.popupWidth;
-                    const effectiveHeight = constrainedHeight || newState.popupHeight;
-
-                    // Make sure we're not hanging off the bounds of the window.
-                    if (absX < ALLEY_WIDTH) {
-                        if (pos === 'top' || pos === 'bottom') {
-                            anchorOffset -= ALLEY_WIDTH - absX;
-                            if (anchorOffset < MIN_ANCHOR_OFFSET || anchorOffset > effectiveWidth - MIN_ANCHOR_OFFSET) {
-                                foundPerfectFit = false;
-                            }
-                        }
-                        absX = ALLEY_WIDTH;
-                    } else if (absX > windowWidth - ALLEY_WIDTH - effectiveWidth) {
-                        if (pos === 'top' || pos === 'bottom') {
-                            anchorOffset -= (windowWidth - ALLEY_WIDTH - effectiveWidth - absX);
-                            if (anchorOffset < MIN_ANCHOR_OFFSET || anchorOffset > effectiveWidth - MIN_ANCHOR_OFFSET) {
-                                foundPerfectFit = false;
-                            }
-                        }
-                        absX = windowWidth - ALLEY_WIDTH - effectiveWidth;
-                    }
-
-                    if (absY < ALLEY_WIDTH) {
-                        if (pos === 'right' || pos === 'left') {
-                            anchorOffset += absY - ALLEY_WIDTH;
-                            if (anchorOffset < MIN_ANCHOR_OFFSET || anchorOffset > effectiveHeight - MIN_ANCHOR_OFFSET) {
-                                foundPerfectFit = false;
-                            }
-                        }
-                        absY = ALLEY_WIDTH;
-                    } else if (absY > windowHeight - ALLEY_WIDTH - effectiveHeight) {
-                        if (pos === 'right' || pos === 'left') {
-                            anchorOffset -= (windowHeight - ALLEY_WIDTH - effectiveHeight - absY);
-                            if (anchorOffset < MIN_ANCHOR_OFFSET || anchorOffset > effectiveHeight - MIN_ANCHOR_OFFSET) {
-                                foundPerfectFit = false;
-                            }
-                        }
-                        absY = windowHeight - ALLEY_WIDTH - effectiveHeight;
-                    }
-
-                    if (foundPerfectFit || effectiveHeight > 0 || effectiveWidth > 0) {
-                        newState.popupY = absY;
-                        newState.popupX = absX;
-                        newState.anchorOffset = anchorOffset;
-                        newState.anchorPosition = pos;
-                        newState.constrainedPopupWidth = effectiveWidth;
-                        newState.constrainedPopupHeight = effectiveHeight;
-
-                        foundPartialFit = true;
-                    }
-                }
-            });
-
-            if (!isEqual(newState, this.state)) {
-                this.setState(newState);
-            }
-        }
-    }
-
-    private _recalcInnerPosition(anchorRect: ClientRect, newState: PopupContainerViewState) {
-        // For inner popups we only accept the first position of the priorities since there
-        // should always be room for the bubble.
-        const pos = this.props.popupOptions.positionPriorities![0];
-
-        switch (pos) {
-            case 'top':
-                newState.popupY = anchorRect.top + anchorRect.height - newState.constrainedPopupHeight;
-                newState.popupX = anchorRect.left + anchorRect.height / 2 - newState.constrainedPopupWidth / 2;
-                newState.anchorOffset = newState.popupWidth / 2;
-                break;
-
-            case 'bottom':
-                newState.popupY = anchorRect.top + newState.constrainedPopupHeight;
-                newState.popupX = anchorRect.left + anchorRect.height / 2 - newState.constrainedPopupWidth / 2;
-                newState.anchorOffset = newState.popupWidth / 2;
-                break;
-
-            case 'left':
-                newState.popupY = anchorRect.top + anchorRect.height / 2 - newState.constrainedPopupHeight / 2;
-                newState.popupX = anchorRect.left + anchorRect.width - newState.constrainedPopupWidth;
-                newState.anchorOffset = newState.popupHeight / 2;
-                break;
-
-            case 'right':
-                newState.popupY = anchorRect.top + anchorRect.height / 2 - newState.constrainedPopupHeight / 2;
-                newState.popupX = anchorRect.left;
-                newState.anchorOffset = newState.popupHeight / 2;
-                break;
+        if (popupRect.width <= 0 || popupRect.height <= 0) {
+            return;
         }
 
-        newState.anchorPosition = pos;
+        // Make a copy of the old state.
+        const newState: PopupContainerViewState = extend({}, this.state);
+
+        if (this.state.isMeasuringPopup) {
+            newState.isMeasuringPopup = false;
+            newState.popupWidth = popupRect.width;
+            newState.popupHeight = popupRect.height;
+        }
+
+        // Get the width/height of root view window.
+        const window = UserInterface.measureWindow(this.props.popupOptions.rootViewId);
+        const windowDims = { width: window.width, height: window.height };
+
+        // Run the common recalc function and see what magic it spits out.
+        const result = recalcPositionFromLayoutData(windowDims, anchorRect, popupRect, this.props.popupOptions.positionPriorities,
+            this.props.popupOptions.useInnerPositioning);
+        if (!result) {
+            this._dismissPopup();
+            return;
+        }
+
+        extend(newState, result);
 
         if (!isEqual(newState, this.state)) {
             this.setState(newState);


### PR DESCRIPTION
To add support for context menus using that reuse the RX.Popup handling support, I added a new positioning type, 'context'.

To make this change easier, I extracted a common set of nearly identical duplicate functions/constants from native-common/PopupContainerView and web/RootView into a single implementation in common/PopupContainerViewBase.