### PR TITLE
Fix a crash when calling setScrollTop/Left on ScrollView

### DIFF
--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -138,15 +138,31 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
 
     setScrollTop(scrollTop: number, animate?: boolean): void {
         if (this._nativeComponent) {
-            this._nativeComponent.scrollTo(
-                { x: this._scrollLeft, y: scrollTop, animated: animate });
+            const scrollParams = { x: this._scrollLeft, y: scrollTop, animated: animate };
+            if (this._nativeComponent.scrollTo) {
+                this._nativeComponent.scrollTo(scrollParams);
+            } else if ((this._nativeComponent as any)._component) {
+                // Components can be wrapped by RN.Animated implementation, peek at the inner workings here
+                const innerComponent = (this._nativeComponent as any)._component;
+                if (innerComponent && innerComponent.scrollTo) {
+                    innerComponent.scrollTo(scrollParams);
+                }
+            }
         }
     }
 
     setScrollLeft(scrollLeft: number, animate?: boolean): void {
         if (this._nativeComponent) {
-            this._nativeComponent.scrollTo(
-                { x: scrollLeft, y: this._scrollTop, animated: animate });
+            const scrollParams = { x: scrollLeft, y: this._scrollTop, animated: animate };
+            if (this._nativeComponent.scrollTo) {
+                this._nativeComponent.scrollTo(scrollParams);
+            } else if ((this._nativeComponent as any)._component) {
+                // Components can be wrapped by RN.Animated implementation, peek at the inner workings here
+                const innerComponent = (this._nativeComponent as any)._component;
+                if (innerComponent && innerComponent.scrollTo) {
+                    innerComponent.scrollTo(scrollParams);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The animated implementation of ScrollView in RN doens't have scrollTop/scrollLeft defined