### PR TITLE
Add zIndex support to ReactXP

### DIFF
--- a/docs/docs/styles.md
+++ b/docs/docs/styles.md
@@ -186,6 +186,7 @@ elevation: number; // Android only
 wordBreak: 'break-all' | 'break-word'; // Web only
 appRegion: 'drag' | 'no-drag'; // Web only
 cursor: 'pointer' | 'default'; // Web only
+zIndex: number;
 ```
 
 ## Transform Style Attributes

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -169,6 +169,7 @@ export interface ViewAndImageCommonStyle extends FlexboxStyle, TransformStyle {
 
     backgroundColor?: string;
     opacity?: number;
+    zIndex?: number;
 }
 
 export interface AnimatedViewAndImageCommonStyle extends AnimatedFlexboxStyle, AnimatedTransformStyle {


### PR DESCRIPTION
Facebook already supports this in React Native based on the CSS spec
https://facebook.github.io/react-native/docs/layout-props#zindex

This is useful in situations where component order must be maintained for accessibility but we want a component to appear in front of others.