### PR TITLE
Fixed RX.GestureViews onLongPress implementation (Web)

### DIFF
--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -395,7 +395,9 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
     }
 
     private _startLongPressTimer(event: React.MouseEvent<any>) {
-		event.persist();
+        
+        event.persist();
+        
         this._pendingLongPressEvent = event;
 
         this._longPressTimer = Timers.setTimeout(() => {

--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -395,6 +395,7 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
     }
 
     private _startLongPressTimer(event: React.MouseEvent<any>) {
+		event.persist();
         this._pendingLongPressEvent = event;
 
         this._longPressTimer = Timers.setTimeout(() => {

--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -395,9 +395,8 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
     }
 
     private _startLongPressTimer(event: React.MouseEvent<any>) {
-        
         event.persist();
-        
+
         this._pendingLongPressEvent = event;
 
         this._longPressTimer = Timers.setTimeout(() => {


### PR DESCRIPTION
Fixed React-error, for onLongPress (Web):

![bildschirmfoto 2018-12-19 um 16 39 16](https://user-images.githubusercontent.com/98413/50231453-22d42780-03af-11e9-9bcb-e91c55a86d9b.png)


![bildschirmfoto 2018-12-19 um 16 41 06](https://user-images.githubusercontent.com/98413/50231476-2e275300-03af-11e9-86b2-3c8cf24a31ff.png)

Can be tested, by adding an empty `onLongPress`-handler on `RX.GestureView` and do a long press.

Regards,
Sascha