### PR TITLE
Catch localStorage setItem() exception.

### DIFF
--- a/src/web/Storage.ts
+++ b/src/web/Storage.ts
@@ -18,7 +18,11 @@ export class Storage extends RX.Storage {
     }
 
     setItem(key: string, value: string): SyncTasks.Promise<void> {
-        window.localStorage.setItem(key, value);
+        try { 
+            window.localStorage.setItem(key, value);
+        } catch (e) {
+            return SyncTasks.Rejected(e);
+        }
         return SyncTasks.Resolved<void>();
     }
 

--- a/src/web/Storage.ts
+++ b/src/web/Storage.ts
@@ -18,7 +18,7 @@ export class Storage extends RX.Storage {
     }
 
     setItem(key: string, value: string): SyncTasks.Promise<void> {
-        try { 
+        try {
             window.localStorage.setItem(key, value);
         } catch (e) {
             return SyncTasks.Rejected(e);


### PR DESCRIPTION
setItem() may throw an exception if the storage is full.