### PR TITLE
Update RX to provide stronger typings on ref callbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,33 +9,34 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
       "integrity": "sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw=="
     },
-    "@types/node": {
-      "version": "10.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.11.tgz",
-      "integrity": "sha512-3iIOhNiPGTdcUNVCv9e5G7GotfvJJe2pc9w2UgDXlUwnxSZ3RgcUocIU+xYm+rTU54jIKih998QE4dMOyMN1NQ=="
+    "@types/prop-types": {
+      "version": "15.5.8",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
+      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw=="
     },
     "@types/react": {
-      "version": "16.3.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.18.tgz",
-      "integrity": "sha512-aWTvLHzKqbVWCiee8huwf5x7Ob4n4gxDwgJT/X31HqjGVZpeUeFeSFYH5Gvi5Dmm5HKF+s+dQkwa/nnEVVzzzg==",
+      "version": "16.7.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.20.tgz",
+      "integrity": "sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==",
       "requires": {
+        "@types/prop-types": "*",
         "csstype": "^2.2.0"
       }
     },
     "@types/react-dom": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.7.tgz",
-      "integrity": "sha512-vaq4vMaJOaNgFff1t3LnHYr6vRa09vRspMkmLdXtFZmO1fwDI2snP+dpOkwrtlU8UC8qsqemCu4RmVM2OLq/fA==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.11.tgz",
+      "integrity": "sha512-x6zUx9/42B5Kl2Vl9HlopV8JF64wLpX3c+Pst9kc1HgzrsH+mkehe/zmHMQTplIrR48H2gpU7ZqurQolYu8XBA==",
       "requires": {
-        "@types/node": "*",
         "@types/react": "*"
       }
     },
     "@types/react-native": {
-      "version": "0.56.12",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.56.12.tgz",
-      "integrity": "sha512-LrxtjunNc3p2hb3yPo4KCrzB4xxP14yqgrIhBIcHs+EK7w0m1mUqPKXUhQMbe0l/obZc4P+8q+ulXCWE47x0jw==",
+      "version": "0.57.28",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.28.tgz",
+      "integrity": "sha512-HfdwfjLXvU92JJNBo2Ytd+w3Ok04cWns6hCfKO3UBIWBVsySwbXVZRln/MHSetKak9O8+/kZaAcsdgDNLyRaqg==",
       "requires": {
+        "@types/prop-types": "*",
         "@types/react": "*"
       }
     },
@@ -173,9 +174,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
-      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.0.tgz",
+      "integrity": "sha512-by8hi8BlLbowQq0qtkx54d9aN73R9oUW20HISpka5kmgsR9F7nnxgfsemuR2sdCKZh+CDNf5egW9UZMm4mgJRg=="
     },
     "diff": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "tslint-release": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib"
   },
   "dependencies": {
-    "@types/react": "16.3.18",
+    "@types/react": "16.7.20",
     "@types/lodash": "4.14.118",
-    "@types/react-dom": "16.0.7",
-    "@types/react-native": "0.56.12",
+    "@types/react-dom": "16.0.11",
+    "@types/react-native": "0.57.28",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.2",
     "rebound": "^0.1.0",

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -24,20 +24,21 @@ export abstract class Alert {
         options?: Types.AlertOptions): void;
 }
 
-export abstract class AnimatedComponent<P extends Types.CommonProps, T> extends React.Component<P, T> {
+export abstract class AnimatedComponent<P extends Types.CommonProps<C>, T, C> extends React.Component<P, T> {
     abstract setNativeProps(props: P): void;
 }
 
-export abstract class AnimatedImage extends AnimatedComponent<Types.AnimatedImageProps, Types.Stateless> {
+export abstract class AnimatedImage extends AnimatedComponent<Types.AnimatedImageProps, Types.Stateless, AnimatedImage> {
 }
 
-export abstract class AnimatedText extends AnimatedComponent<Types.AnimatedTextProps, Types.Stateless> {
+export abstract class AnimatedText extends AnimatedComponent<Types.AnimatedTextProps, Types.Stateless, AnimatedText> {
 }
 
-export abstract class AnimatedTextInput extends AnimatedComponent<Types.AnimatedTextInputProps, Types.Stateless> {
+export abstract class AnimatedTextInput extends AnimatedComponent<Types.AnimatedTextInputProps, Types.Stateless, AnimatedTextInput> {
 }
 
-export abstract class AnimatedView extends AnimatedComponent<Types.AnimatedViewProps, Types.Stateless> implements FocusableComponent {
+export abstract class AnimatedView extends AnimatedComponent<Types.AnimatedViewProps, Types.Stateless, AnimatedView>
+        implements FocusableComponent {
     abstract setFocusRestricted(restricted: boolean): void;
     abstract setFocusLimited(limited: boolean): void;
     abstract focus(): void;

--- a/src/common/PopupContainerViewBase.tsx
+++ b/src/common/PopupContainerViewBase.tsx
@@ -15,7 +15,7 @@ import * as React from 'react';
 import FocusManagerBase from './utils/FocusManager';
 import { Types } from './Interfaces';
 
-export interface PopupContainerViewBaseProps extends Types.CommonProps {
+export interface PopupContainerViewBaseProps<C> extends Types.CommonProps<C> {
     hidden?: boolean;
 }
 
@@ -28,7 +28,7 @@ export interface PopupComponent {
     onHide: () => void;
 }
 
-export abstract class PopupContainerViewBase<P extends PopupContainerViewBaseProps, S> extends React.Component<P, S> {
+export abstract class PopupContainerViewBase<P extends PopupContainerViewBaseProps<C>, S, C> extends React.Component<P, S> {
     static contextTypes: React.ValidationMap<any> = {
         focusManager: PropTypes.object
     };
@@ -39,14 +39,14 @@ export abstract class PopupContainerViewBase<P extends PopupContainerViewBasePro
 
     private _popupComponentStack: PopupComponent[] = [];
 
-    constructor(props: P, context: PopupContainerViewContext) {
+    constructor(props: P, context?: PopupContainerViewContext) {
         super(props, context);
     }
 
     getChildContext() {
         return {
             focusManager: this.context.focusManager,
-            popupContainer: this as PopupContainerViewBase<P, S>
+            popupContainer: this as PopupContainerViewBase<P, S, C>
         };
     }
 

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -350,16 +350,10 @@ export type ComponentBase = React.Component<any, any>;
  * Components
  */
 
-// Redefine RefObject here rather than using React.RefObject because
-// older versions of React don't support it.
-interface RefObject<T> {
-    readonly current: T | null;
-}
-
-export interface CommonProps {
+// Rely on RefAttributes type, which exists only in newer typescript definitions, but has support from React 16.3 (released Mar 29, 2018)
+export interface CommonProps<C = React.Component> extends React.RefAttributes<C> {
+    // ref and key are typed by react itself
     children?: ReactNode | ReactNode[];
-    ref?: string | ((obj: ComponentBase | null) => void) | RefObject<ComponentBase>;
-    key?: string | number;
     testId?: string;
 }
 
@@ -475,12 +469,12 @@ export interface FocusCandidate {
     accessibilityId?: string;
 }
 
-export interface CommonStyledProps<T> extends CommonProps {
+export interface CommonStyledProps<T, C> extends CommonProps<C> {
     style?: StyleRuleSetRecursive<T>;
 }
 
 // Button
-export interface ButtonProps extends CommonStyledProps<ButtonStyleRuleSet>, CommonAccessibilityProps {
+export interface ButtonProps extends CommonStyledProps<ButtonStyleRuleSet, RX.Button>, CommonAccessibilityProps {
     title?: string;
     disabled?: boolean;
     disabledOpacity?: number;
@@ -516,7 +510,7 @@ export interface PickerPropsItem {
     label: string;
     value: string;
 }
-export interface PickerProps extends CommonProps {
+export interface PickerProps extends CommonProps<RX.Picker> {
     items: PickerPropsItem[];
     selectedValue: string;
     onValueChange: (itemValue: string, itemPosition: number) => void;
@@ -534,7 +528,7 @@ export interface Headers {
 // Image
 export type ImageResizeMode = 'stretch' | 'contain' | 'cover' | 'auto' | 'repeat';
 
-export interface ImagePropsShared extends CommonProps {
+export interface ImagePropsShared<C> extends CommonProps<C> {
     source: string;
     headers?: Headers;
     accessibilityLabel?: string;
@@ -547,7 +541,7 @@ export interface ImagePropsShared extends CommonProps {
     onError?: (err?: Error) => void;
 }
 
-export interface ImageProps extends ImagePropsShared {
+export interface ImageProps extends ImagePropsShared<RX.Image> {
     style?: StyleRuleSetRecursive<ImageStyleRuleSet>;
 }
 
@@ -556,7 +550,7 @@ export interface ImageMetadata {
     height: number;
 }
 
-export interface AnimatedImageProps extends ImagePropsShared {
+export interface AnimatedImageProps extends ImagePropsShared<RX.AnimatedImage> {
     style?: StyleRuleSetRecursive<AnimatedImageStyleRuleSet | ImageStyleRuleSet>;
 }
 
@@ -569,7 +563,7 @@ export interface AnimatedImageProps extends ImagePropsShared {
 // | I am a very |
 // | important   |
 // | example     |
-export interface TextPropsShared extends CommonProps {
+export interface TextPropsShared<C> extends CommonProps<C> {
     selectable?: boolean;
     numberOfLines?: number;
 
@@ -599,11 +593,11 @@ export interface TextPropsShared extends CommonProps {
     onContextMenu?: (e: MouseEvent) => void;
 }
 
-export interface TextProps extends TextPropsShared {
+export interface TextProps extends TextPropsShared<RX.Text> {
     style?: StyleRuleSetRecursive<TextStyleRuleSet>;
 }
 
-export interface AnimatedTextProps extends TextPropsShared {
+export interface AnimatedTextProps extends TextPropsShared<RX.AnimatedText> {
     style?: StyleRuleSetRecursive<AnimatedTextStyleRuleSet | TextStyleRuleSet>;
 }
 
@@ -620,7 +614,7 @@ export enum LimitFocusType {
 }
 
 // View
-export interface ViewPropsShared extends CommonProps, CommonAccessibilityProps {
+export interface ViewPropsShared<C> extends CommonProps<C>, CommonAccessibilityProps {
     title?: string;
     ignorePointerEvents?: boolean;
     blockPointerEvents?: boolean; // Native-only prop for disabling touches on self and all child views
@@ -689,12 +683,12 @@ export interface ViewPropsShared extends CommonProps, CommonAccessibilityProps {
     onResponderTerminationRequest?: (e: SyntheticEvent) => boolean;
 }
 
-export interface ViewProps extends ViewPropsShared {
+export interface ViewProps extends ViewPropsShared<RX.View> {
     style?: StyleRuleSetRecursive<ViewStyleRuleSet>;
     useSafeInsets?: boolean;
 }
 
-export interface AnimatedViewProps extends ViewPropsShared {
+export interface AnimatedViewProps extends ViewPropsShared<RX.AnimatedView> {
     style?: StyleRuleSetRecursive<AnimatedViewStyleRuleSet | ViewStyleRuleSet>;
 }
 
@@ -770,7 +764,7 @@ export enum PreferredPanGesture {
     Vertical
 }
 
-export interface GestureViewProps extends CommonStyledProps<ViewStyleRuleSet>, CommonAccessibilityProps {
+export interface GestureViewProps extends CommonStyledProps<ViewStyleRuleSet, RX.GestureView>, CommonAccessibilityProps {
     // Gestures and attributes that apply only to touch inputs
     onPinchZoom?: (gestureState: MultiTouchGestureState) => void;
     onRotate?: (gestureState: MultiTouchGestureState) => void;
@@ -812,7 +806,7 @@ export interface ScrollIndicatorInsets {
 }
 
 // ScrollView
-export interface ScrollViewProps extends CommonStyledProps<ScrollViewStyleRuleSet>, CommonAccessibilityProps {
+export interface ScrollViewProps extends CommonStyledProps<ScrollViewStyleRuleSet, RX.ScrollView>, CommonAccessibilityProps {
     children?: ReactNode;
 
     vertical?: boolean; // By default true
@@ -881,7 +875,7 @@ export interface ScrollViewProps extends CommonStyledProps<ScrollViewStyleRuleSe
 }
 
 // Link
-export interface LinkProps extends CommonStyledProps<LinkStyleRuleSet> {
+export interface LinkProps extends CommonStyledProps<LinkStyleRuleSet, RX.Link> {
     title?: string;
     url: string;
     children?: ReactNode;
@@ -901,7 +895,7 @@ export interface LinkProps extends CommonStyledProps<LinkStyleRuleSet> {
 }
 
 // TextInput
-export interface TextInputPropsShared extends CommonProps, CommonAccessibilityProps {
+export interface TextInputPropsShared<C> extends CommonProps<C>, CommonAccessibilityProps {
     autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters';
     autoCorrect?: boolean;
     autoFocus?: boolean; // The component is a candidate for being autofocused.
@@ -952,16 +946,16 @@ export interface TextInputPropsShared extends CommonProps, CommonAccessibilityPr
     onScroll?: (newScrollLeft: number, newScrollTop: number) => void;
 }
 
-export interface TextInputProps extends TextInputPropsShared {
+export interface TextInputProps extends TextInputPropsShared<RX.TextInput> {
     style?: StyleRuleSetRecursive<TextInputStyleRuleSet>;
 }
 
-export interface AnimatedTextInputProps extends TextInputPropsShared {
+export interface AnimatedTextInputProps extends TextInputPropsShared<RX.AnimatedTextInput> {
     style?: StyleRuleSetRecursive<AnimatedTextInputStyleRuleSet | TextInputStyleRuleSet>;
 }
 
 // ActivityIndicator
-export interface ActivityIndicatorProps extends CommonStyledProps<ActivityIndicatorStyleRuleSet> {
+export interface ActivityIndicatorProps extends CommonStyledProps<ActivityIndicatorStyleRuleSet, RX.ActivityIndicator> {
     color: string;
     size?: 'large' | 'medium' | 'small' | 'tiny';
     deferTime?: number; // Number of ms to wait before displaying
@@ -1003,7 +997,7 @@ export interface WebViewSource {
     baseUrl?: string;
 }
 
-export interface WebViewProps extends CommonStyledProps<WebViewStyleRuleSet> {
+export interface WebViewProps extends CommonStyledProps<WebViewStyleRuleSet, RX.WebView> {
     url?: string;
     source?: WebViewSource;
     headers?: Headers;

--- a/src/common/utils/Timers.ts
+++ b/src/common/utils/Timers.ts
@@ -11,22 +11,25 @@
  * we can get compiler errors.
  */
 
+// global typing doesn't exist without node.d.ts, but we don't want it since this isn't a nodeJS app by default
+declare var global: {};
+
 const timerProvider = window || global;
 
 export default class Timers {
     static clearInterval(handle: number): void {
-        timerProvider.clearInterval(handle as any);
+        timerProvider.clearInterval(handle);
     }
 
     static clearTimeout(handle: number): void {
-        timerProvider.clearTimeout(handle as any);
+        timerProvider.clearTimeout(handle);
     }
 
     static setInterval(handler: () => void, timeout: number): number {
-        return timerProvider.setInterval(handler, timeout) as any;
+        return timerProvider.setInterval(handler, timeout);
     }
 
     static setTimeout(handler: () => void, timeout: number): number {
-        return timerProvider.setTimeout(handler, timeout) as any;
+        return timerProvider.setTimeout(handler, timeout);
     }
 }

--- a/src/native-common/Animated.tsx
+++ b/src/native-common/Animated.tsx
@@ -33,7 +33,7 @@ export const CommonAnimatedClasses: AnimatedClasses = {
 
 let animatedClasses: AnimatedClasses = CommonAnimatedClasses;
 
-class AnimatedWrapper<P, T> extends RX.AnimatedComponent<P, T> {
+class AnimatedWrapper<P, T, C> extends RX.AnimatedComponent<P, T, C> {
     protected _mountedComponent: RN.ReactNativeBaseComponent<any, any> | undefined;
 
     setNativeProps(props: P) {
@@ -68,7 +68,7 @@ class AnimatedWrapper<P, T> extends RX.AnimatedComponent<P, T> {
     }
 }
 
-class AnimatedImage extends AnimatedWrapper<RX.Types.AnimatedImageProps, RX.Types.Stateless> {
+class AnimatedImage extends AnimatedWrapper<RX.Types.AnimatedImageProps, RX.Types.Stateless, RX.AnimatedImage> {
     render() {
         const additionalProps = { ref: this._onMount, style: this.props.style };
         return (
@@ -82,7 +82,7 @@ class AnimatedImage extends AnimatedWrapper<RX.Types.AnimatedImageProps, RX.Type
     }
 }
 
-class AnimatedText extends AnimatedWrapper<RX.Types.AnimatedTextProps, RX.Types.Stateless>  {
+class AnimatedText extends AnimatedWrapper<RX.Types.AnimatedTextProps, RX.Types.Stateless, RX.AnimatedText>  {
     render() {
         const additionalProps = { ref: this._onMount, style: this.props.style };
         return (
@@ -96,7 +96,7 @@ class AnimatedText extends AnimatedWrapper<RX.Types.AnimatedTextProps, RX.Types.
     }
 }
 
-class AnimatedTextInput extends AnimatedWrapper<RX.Types.AnimatedTextInputProps, RX.Types.Stateless>   {
+class AnimatedTextInput extends AnimatedWrapper<RX.Types.AnimatedTextInputProps, RX.Types.Stateless, RX.AnimatedTextInput>   {
     render() {
         const additionalProps = {ref: this._onMount, style: this.props.style };
         return (
@@ -110,7 +110,7 @@ class AnimatedTextInput extends AnimatedWrapper<RX.Types.AnimatedTextInputProps,
     }
 }
 
-class AnimatedView extends AnimatedWrapper<RX.Types.AnimatedViewProps, RX.Types.Stateless> {
+class AnimatedView extends AnimatedWrapper<RX.Types.AnimatedViewProps, RX.Types.Stateless, RX.AnimatedView> {
     setFocusRestricted(restricted: boolean) {
         // Nothing to do.
     }

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -102,7 +102,7 @@ export class Button extends ButtonBase {
     private _opacityAnimatedValue: RN.Animated.Value | undefined;
     private _opacityAnimatedStyle: Types.AnimatedViewStyleRuleSet | undefined;
 
-    constructor(props: Types.ButtonProps, context: ButtonContext) {
+    constructor(props: Types.ButtonProps, context?: ButtonContext) {
         super(props, context);
         applyMixin(this, RN.Touchable.Mixin, [
             // Properties that Button and RN.Touchable.Mixin have in common. Button needs
@@ -113,7 +113,7 @@ export class Button extends ButtonBase {
         this.state = this.touchableGetInitialState();
         this._setOpacityStyles(props);
 
-        if (context.hasRxButtonAscendant) {
+        if (context && context.hasRxButtonAscendant) {
             if (AppConfig.isDevelopmentMode()) {
                 console.warn('Button components should not be embedded. Some APIs, e.g. Accessibility, will not work.');
             }

--- a/src/native-common/ModalContainer.tsx
+++ b/src/native-common/ModalContainer.tsx
@@ -33,7 +33,7 @@ const _styles = {
     }
 };
 
-export interface ModalContainerProps extends Types.CommonProps {
+export interface ModalContainerProps extends Types.CommonProps<ModalContainer> {
     hidden?: boolean;
 }
 

--- a/src/native-common/PopupContainerView.tsx
+++ b/src/native-common/PopupContainerView.tsx
@@ -28,7 +28,7 @@ const ALLEY_WIDTH = 2;
 // attempting a different position?
 const MIN_ANCHOR_OFFSET = 16;
 
-export interface PopupContainerViewProps extends PopupContainerViewBaseProps {
+export interface PopupContainerViewProps extends PopupContainerViewBaseProps<PopupContainerView> {
     popupOptions: Types.PopupOptions;
     anchorHandle?: number;
     onDismissPopup?: () => void;
@@ -57,12 +57,12 @@ export interface PopupContainerViewState {
     constrainedPopupHeight: number;
 }
 
-export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, PopupContainerViewState> {
+export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, PopupContainerViewState, PopupContainerView> {
     private _mountedComponent: RN.View | undefined;
     private _viewHandle: number | null = null;
     private _respositionPopupTimer: number | undefined;
 
-    constructor(props: PopupContainerViewProps, context: PopupContainerViewContext) {
+    constructor(props: PopupContainerViewProps, context?: PopupContainerViewContext) {
         super(props, context);
         this.state = this._getInitialState();
     }

--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -17,7 +17,8 @@ import ViewBase from './ViewBase';
 //   causes you to have to click twice instead of once on some pieces of UI in
 //   order for the UI to acknowledge your interaction.
 const overrideKeyboardShouldPersistTaps = RN.Platform.OS === 'macos' || RN.Platform.OS === 'windows';
-export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stateless, RN.ScrollView> implements RX.ScrollView {
+export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stateless, RN.ScrollView, RX.ScrollView>
+        implements RX.ScrollView {
     private _scrollTop = 0;
     private _scrollLeft = 0;
 

--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -48,7 +48,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
     private _selection: Selection = { start: 0, end: 0 };
     protected _mountedComponent: RN.TextInput | undefined;
 
-    constructor(props: Types.TextInputProps, context: TextInputContext) {
+    constructor(props: Types.TextInputProps, context?: TextInputContext) {
         super(props, context);
 
         this.state = {

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -18,7 +18,7 @@ import App from './App';
 import assert from '../common/assert';
 import { FocusArbitratorProvider } from '../common/utils/AutoFocusHelper';
 import EventHelpers from './utils/EventHelpers';
-import { Types } from '../common/Interfaces';
+import * as RX from '../common/Interfaces';
 import { clone, extend } from './utils/lodashMini';
 import Platform from './Platform';
 import Styles from './Styles';
@@ -128,7 +128,7 @@ export interface ViewContext {
     focusArbitrator?: FocusArbitratorProvider;
 }
 
-export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
+export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.View, RX.View> {
     static contextTypes: React.ValidationMap<any> = {
         focusArbitrator: PropTypes.object
     };
@@ -160,11 +160,11 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
     private _hideTimeout: number | undefined;
     private _defaultOpacityValue: number | undefined;
     private _opacityAnimatedValue: RN.Animated.Value | undefined;
-    private _opacityAnimatedStyle: Types.AnimatedViewStyleRuleSet | undefined;
+    private _opacityAnimatedStyle: RX.Types.AnimatedViewStyleRuleSet | undefined;
 
     private _focusArbitratorProvider: FocusArbitratorProvider | undefined;
 
-    constructor(props: Types.ViewProps, context: ViewContext) {
+    constructor(props: RX.Types.ViewProps, context?: ViewContext) {
         super(props, context);
         this._updateMixin(props, true);
         this._buildInternalProps(props);
@@ -174,7 +174,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         }
     }
 
-    componentWillReceiveProps(nextProps: Types.ViewProps) {
+    componentWillReceiveProps(nextProps: RX.Types.ViewProps) {
         this._updateMixin(nextProps, false);
         this._buildInternalProps(nextProps);
 
@@ -183,7 +183,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         }
     }
 
-    componentWillUpdate(nextProps: Types.ViewProps, nextState: {}) {
+    componentWillUpdate(nextProps: RX.Types.ViewProps, nextState: {}) {
         //
         // Exit fast if not an "animated children" case
         if (!(nextProps.animateChildEnter || nextProps.animateChildMove || nextProps.animateChildLeave)) {
@@ -260,7 +260,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         }
     }
 
-    private _updateMixin(props: Types.ViewProps, initial: boolean) {
+    private _updateMixin(props: RX.Types.ViewProps, initial: boolean) {
         const isButton = this._isButton(props);
         if (isButton && !this._mixinIsApplied) {
             // Create local handlers
@@ -323,7 +323,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
      * be careful with setting any non layout properties unconditionally in this method to any value
      * as on android that would lead to extra layers of Views.
      */
-    protected _buildInternalProps(props: Types.ViewProps) {
+    protected _buildInternalProps(props: RX.Types.ViewProps) {
         this._internalProps = clone(props) as any;
         this._internalProps.ref = this._setNativeComponent;
 
@@ -334,7 +334,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         }
 
         // Translate accessibilityProps from RX to RN, there are type diferrences for example:
-        // accessibilityLiveRegion prop is number (RX.Types.AccessibilityLiveRegion) in RX, but
+        // accessibilityLiveRegion prop is number (RX.RX.Types.AccessibilityLiveRegion) in RX, but
         // string is expected by RN.View.
         const accessibilityProps = {
             importantForAccessibility: AccessibilityUtil.importantForAccessibilityToString(props.importantForAccessibility),
@@ -423,7 +423,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         this._setOpacityTo(this._defaultOpacityValue!, duration);
     }
 
-    private _getDefaultOpacityValue(props: Types.ViewProps): number {
+    private _getDefaultOpacityValue(props: RX.Types.ViewProps): number {
         let flattenedStyles: { [key: string]: any } | undefined;
         if (props && props.style) {
             flattenedStyles = RN.StyleSheet.flatten(props.style as RN.StyleProp<RN.ViewStyle>);
@@ -467,11 +467,11 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         });
     }
 
-    protected _isButton(viewProps: Types.ViewProps): boolean {
+    protected _isButton(viewProps: RX.Types.ViewProps): boolean {
         return !!(viewProps.onPress || viewProps.onLongPress);
     }
 
-    private _updateFocusArbitratorProvider(props: Types.ViewProps) {
+    private _updateFocusArbitratorProvider(props: RX.Types.ViewProps) {
         if (props.arbitrateFocus) {
             if (this._focusArbitratorProvider) {
                 this._focusArbitratorProvider.setCallback(props.arbitrateFocus);
@@ -499,7 +499,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         );
     }
 
-    touchableHandlePress(e: Types.SyntheticEvent): void {
+    touchableHandlePress(e: RX.Types.SyntheticEvent): void {
         UserInterface.evaluateTouchLatency(e);
         if (EventHelpers.isRightMouseButton(e)) {
             if (this.props.onContextMenu) {
@@ -512,7 +512,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         }
     }
 
-    touchableHandleLongPress(e: Types.SyntheticEvent): void {
+    touchableHandleLongPress(e: RX.Types.SyntheticEvent): void {
         if (!EventHelpers.isRightMouseButton(e)) {
             if (this.props.onLongPress) {
                 this.props.onLongPress(EventHelpers.toMouseEvent(e));
@@ -520,7 +520,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         }
     }
 
-    touchableHandleActivePressIn(e: Types.SyntheticEvent): void {
+    touchableHandleActivePressIn(e: RX.Types.SyntheticEvent): void {
         if (this._isTouchFeedbackApplicable()) {
             if (this.props.underlayColor) {
                 if (this._hideTimeout) {
@@ -537,7 +537,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless, RN.View> {
         }
     }
 
-    touchableHandleActivePressOut(e: Types.SyntheticEvent): void {
+    touchableHandleActivePressOut(e: RX.Types.SyntheticEvent): void {
         if (this._isTouchFeedbackApplicable()) {
             if (this.props.underlayColor) {
                 if (this._hideTimeout) {

--- a/src/native-common/ViewBase.tsx
+++ b/src/native-common/ViewBase.tsx
@@ -12,7 +12,8 @@ import * as RN from 'react-native';
 import * as RX from '../common/Interfaces';
 import { isEqual } from './utils/lodashMini';
 
-export abstract class ViewBase<P extends RX.Types.ViewProps, S, T extends RN.View | RN.ScrollView> extends RX.ViewBase<P, S> {
+export abstract class ViewBase<P extends RX.Types.ViewPropsShared<C>, S, T extends RN.View | RN.ScrollView,
+        C extends RX.View | RX.ScrollView> extends RX.ViewBase<P, S> {
     private static _defaultViewStyle: RX.Types.ViewStyleRuleSet | undefined;
     private _layoutEventValues: RX.Types.ViewOnLayoutEvent | undefined;
 

--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -428,9 +428,9 @@ interface AnimatedAttribute {
 type AnimatedValueMap = { [transform: string]: AnimatedAttribute };
 
 // Function for creating wrapper AnimatedComponent around passed in component
-function createAnimatedComponent<PropsType extends RX.Types.CommonProps>(Component: any): any {
+function createAnimatedComponent<PropsType extends RX.Types.CommonProps<C>, C>(Component: any): any {
     class AnimatedComponentGenerated extends React.Component<PropsType, void>
-            implements RX.AnimatedComponent<PropsType, void>, ValueListener {
+            implements RX.AnimatedComponent<PropsType, void, C>, ValueListener {
 
         private _mountedComponent: any = null;
         private _propsWithoutStyle: any;
@@ -456,7 +456,7 @@ function createAnimatedComponent<PropsType extends RX.Types.CommonProps>(Compone
             }
         }
 
-        componentWillReceiveProps(props: RX.Types.CommonStyledProps<RX.Types.StyleRuleSet<Object>>) {
+        componentWillReceiveProps(props: RX.Types.CommonStyledProps<RX.Types.StyleRuleSet<Object>, C>) {
             this._updateStyles(props);
         }
 
@@ -718,10 +718,11 @@ function createAnimatedComponent<PropsType extends RX.Types.CommonProps>(Compone
             return transformList.join(' ');
         }
 
-        private _updateStyles(props: RX.Types.CommonStyledProps<RX.Types.StyleRuleSet<Object>>) {
+        // TODO: Find a better type here - previous type of 'object' didn't help us at all
+        private _updateStyles(props: RX.Types.CommonStyledProps<RX.Types.StyleRuleSet<any>, C>) {
             this._propsWithoutStyle = _.omit(props, 'style');
 
-            const rawStyles = Styles.combine(props.style || {}) as any;
+            const rawStyles = Styles.combine(props.style || {});
             this._processedStyle = {};
 
             const newAnimatedAttributes: { [transform: string]: Value } = {};
@@ -881,7 +882,7 @@ function createAnimatedComponent<PropsType extends RX.Types.CommonProps>(Compone
     return AnimatedComponentGenerated;
 }
 
-export let Image = createAnimatedComponent<RX.Types.ImageProps>(RXImage) as typeof RX.AnimatedImage;
+export let Image = createAnimatedComponent(RXImage) as typeof RX.AnimatedImage;
 export let Text = createAnimatedComponent(RXText) as typeof RX.AnimatedText;
 export let TextInput = createAnimatedComponent(RXTextInput) as typeof RX.AnimatedTextInput;
 export let View = createAnimatedComponent(RXView) as typeof RX.AnimatedView;

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -65,10 +65,10 @@ export class Button extends ButtonBase {
     private _isFocusedWithKeyboard = false;
     private _isHoverStarted = false;
 
-    constructor(props: Types.ButtonProps, context: ButtonContext) {
+    constructor(props: Types.ButtonProps, context?: ButtonContext) {
         super(props, context);
 
-        if (context.hasRxButtonAscendant) {
+        if (context && context.hasRxButtonAscendant) {
             if (AppConfig.isDevelopmentMode()) {
                 console.warn('Button components should not be embedded. Some APIs, e.g. Accessibility, will not work.');
             }

--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -19,6 +19,7 @@ import MouseResponder, { MouseResponderSubscription } from './utils/MouseRespond
 import Styles from './Styles';
 import Timers from '../common/utils/Timers';
 
+// Cast to any to allow merging of web and RX styles
 const _styles = {
     defaultView: {
         position: 'relative',
@@ -29,7 +30,7 @@ const _styles = {
         overflow: 'hidden',
         alignItems: 'stretch',
         justifyContent: 'center'
-    }
+    } as any
 };
 
 const _longPressDurationThreshold = 750;
@@ -203,7 +204,7 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
     }
 
     private _getStyles(): any {
-        const combinedStyles = Styles.combine([_styles.defaultView, this.props.style]) as any;
+        const combinedStyles = Styles.combine([_styles.defaultView, this.props.style]);
 
         let cursorName: string | undefined;
         switch (this.props.mouseOverCursor) {

--- a/src/web/ModalContainer.tsx
+++ b/src/web/ModalContainer.tsx
@@ -29,8 +29,8 @@ const _styles = {
     }
 };
 
-export class ModalContainer extends React.Component<Types.CommonProps, Types.Stateless> {
-    constructor(props: Types.CommonProps) {
+export class ModalContainer extends React.Component<Types.CommonProps<ModalContainer>, Types.Stateless> {
+    constructor(props: Types.CommonProps<ModalContainer>) {
         super(props);
     }
 

--- a/src/web/PopupContainerView.tsx
+++ b/src/web/PopupContainerView.tsx
@@ -13,14 +13,14 @@ import { Types } from '../common/Interfaces';
 import { clone } from './utils/lodashMini';
 import { PopupContainerViewBase, PopupContainerViewBaseProps, PopupContainerViewContext } from '../common/PopupContainerViewBase';
 
-export interface PopupContainerViewProps extends PopupContainerViewBaseProps {
+export interface PopupContainerViewProps extends PopupContainerViewBaseProps<PopupContainerView> {
     style: React.CSSProperties;
     onMouseEnter?: (e: React.MouseEvent<HTMLDivElement>) => void;
     onMouseLeave?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
-export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, Types.Stateless> {
-    constructor(props: PopupContainerViewProps, context: PopupContainerViewContext) {
+export class PopupContainerView extends PopupContainerViewBase<PopupContainerViewProps, Types.Stateless, PopupContainerView> {
+    constructor(props: PopupContainerViewProps, context?: PopupContainerViewContext) {
         super(props, context);
     }
 

--- a/src/web/RootView.tsx
+++ b/src/web/RootView.tsx
@@ -27,7 +27,7 @@ export class PopupDescriptor {
     constructor(public popupId: string, public popupOptions: Types.PopupOptions) {}
 }
 
-export interface RootViewProps extends Types.CommonProps {
+export interface RootViewProps extends Types.CommonProps<RootView> {
     mainView?: React.ReactNode;
     modal?: React.ReactElement<Types.ViewProps>;
     activePopup?: PopupDescriptor;
@@ -95,7 +95,7 @@ export interface MainViewContext {
 // This helper class wraps the main view and passes a boolean value
 // "isInRxMainView" to all children found within it. This is used to
 // prevent gesture handling within the main view when a modal is displayed.
-export class MainViewContainer extends React.Component<Types.CommonProps, Types.Stateless>
+export class MainViewContainer extends React.Component<Types.CommonProps<MainViewContainer>, Types.Stateless>
         implements React.ChildContextProvider<MainViewContext> {
     static childContextTypes: React.ValidationMap<any> = {
         isInRxMainView: PropTypes.bool

--- a/src/web/ScrollView.tsx
+++ b/src/web/ScrollView.tsx
@@ -76,7 +76,7 @@ const _customStyles = {
 // Default to once per frame.
 const _defaultScrollThrottleValue = 1000 / 60;
 
-export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stateless> implements RX.ScrollView {
+export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stateless, RX.ScrollView> implements RX.ScrollView {
     private _mountedComponent: HTMLElement | null = null;
 
     constructor(props: RX.Types.ScrollViewProps) {

--- a/src/web/Styles.ts
+++ b/src/web/Styles.ts
@@ -15,9 +15,8 @@ import StyleLeakDetector from '../common/StyleLeakDetector';
 type CssAliasMap = { [prop: string]: string };
 
 export class Styles extends RX.Styles {
-    // Combines a set of styles
-    combine<S>(ruleSet1: RX.Types.StyleRuleSetRecursive<S> | undefined, ruleSet2?: RX.Types.StyleRuleSetRecursive<S>)
-            : RX.Types.StyleRuleSetOrArray<S> | undefined {
+    // Combines a set of styles - for web we need to flatten to a single object
+    combine<S>(ruleSet1: RX.Types.StyleRuleSetRecursive<S> | undefined, ruleSet2?: RX.Types.StyleRuleSetRecursive<S>): S | undefined {
         if (!ruleSet1 && !ruleSet2) {
             return undefined;
         }
@@ -60,10 +59,10 @@ export class Styles extends RX.Styles {
                 }
             }
 
-            return combinedStyles as RX.Types.StyleRuleSet<S>;
+            return combinedStyles as S;
         }
 
-        return ruleSet;
+        return ruleSet as S;
     }
 
     // Creates opaque styles that can be used for View

--- a/src/web/Text.tsx
+++ b/src/web/Text.tsx
@@ -27,6 +27,7 @@ if (typeof document !== 'undefined') {
     document.head.appendChild(style);
 }
 
+// Cast to any to allow merging of web and RX styles
 const _styles = {
     defaultStyle: {
         position: 'relative',
@@ -37,7 +38,7 @@ const _styles = {
         whiteSpace: 'pre-wrap',
         overflowWrap: 'break-word',
         msHyphens: 'auto'
-    },
+    } as any,
     ellipsis: {
         position: 'relative',
         display: 'inline',
@@ -46,7 +47,7 @@ const _styles = {
         overflow: 'hidden',
         whiteSpace: 'pre',
         textOverflow: 'ellipsis'
-    }
+    } as any
 };
 
 export interface TextContext {
@@ -129,7 +130,7 @@ export class Text extends TextBase {
         // There's no way in HTML to properly handle numberOfLines > 1,
         // but we can correctly handle the common case where numberOfLines is 1.
         const combinedStyles = Styles.combine([this.props.numberOfLines === 1 ?
-            _styles.ellipsis : _styles.defaultStyle, this.props.style]) as any;
+            _styles.ellipsis : _styles.defaultStyle, this.props.style]);
 
         if (this.props.selectable) {
             combinedStyles.userSelect = 'text';

--- a/src/web/TextInput.tsx
+++ b/src/web/TextInput.tsx
@@ -23,6 +23,7 @@ export interface TextInputState {
 
 const _isMac = (typeof navigator !== 'undefined') && (typeof navigator.platform === 'string') && (navigator.platform.indexOf('Mac') >= 0);
 
+// Cast to any to allow merging of web and RX styles
 const _styles = {
     defaultStyle: {
         position: 'relative',
@@ -34,11 +35,11 @@ const _styles = {
         overflowX: 'hidden',
         overflowY: 'auto',
         alignItems: 'stretch'
-    },
+    } as any,
     formStyle: {
         display: 'flex',
         flex: 1
-    }
+    } as any
 };
 
 export interface TextInputContext {
@@ -140,7 +141,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
     private _isFocused = false;
     private _ariaLiveEnabled = false;
 
-    constructor(props: Types.TextInputProps, context: TextInputContext) {
+    constructor(props: Types.TextInputProps, context?: TextInputContext) {
         super(props, context);
 
         this.state = {
@@ -200,7 +201,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
     }
 
     render() {
-        const combinedStyles = Styles.combine([_styles.defaultStyle, this.props.style]) as any;
+        const combinedStyles = Styles.combine([_styles.defaultStyle, this.props.style]);
 
         // Always hide the outline.
         combinedStyles.outline = 'none';

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -17,13 +17,14 @@ import AppConfig from '../common/AppConfig';
 import { FocusArbitratorProvider } from '../common/utils/AutoFocusHelper';
 import { applyFocusableComponentMixin, FocusManager } from './utils/FocusManager';
 import { RestrictFocusType } from '../common/utils/FocusManager';
-import { Types } from '../common/Interfaces';
+import * as RX from '../common/Interfaces';
 import PopupContainerView from './PopupContainerView';
 import { PopupComponent } from '../common/PopupContainerViewBase';
 import restyleForInlineText from './utils/restyleForInlineText';
 import Styles from './Styles';
 import ViewBase from './ViewBase';
 
+// Cast to any to allow merging of web and RX styles
 const _styles = {
     defaultStyle: {
         position: 'relative',
@@ -33,7 +34,7 @@ const _styles = {
         flexShrink: 0,
         overflow: 'hidden',
         alignItems: 'stretch'
-    },
+    } as any,
 
     // See resize detector comments in renderResizeDetectorIfNeeded() method below.
     resizeDetectorContainerStyles: {
@@ -78,7 +79,7 @@ export interface ViewContext {
     focusArbitrator?: FocusArbitratorProvider;
 }
 
-export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
+export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RX.View> {
     static contextTypes: React.ValidationMap<any> = {
         isRxParentAText: PropTypes.bool,
         focusManager: PropTypes.object,
@@ -108,12 +109,12 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
     private _popupContainer: PopupContainerView | undefined;
     private _popupToken: PopupComponent | undefined;
 
-    constructor(props: Types.ViewProps, context: ViewContext) {
+    constructor(props: RX.Types.ViewProps, context?: ViewContext) {
         super(props, context);
 
         this._limitFocusWithin =
-            (props.limitFocusWithin === Types.LimitFocusType.Limited) ||
-            (props.limitFocusWithin === Types.LimitFocusType.Accessible);
+            (props.limitFocusWithin === RX.Types.LimitFocusType.Limited) ||
+            (props.limitFocusWithin === RX.Types.LimitFocusType.Accessible);
 
         if (this.props.restrictFocusWithin || this._limitFocusWithin) {
             this._focusManager = new FocusManager(context && context.focusManager);
@@ -123,7 +124,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
             }
         }
 
-        this._popupContainer = context.popupContainer;
+        this._popupContainer = context && context.popupContainer;
 
         if (props.arbitrateFocus) {
             this._updateFocusArbitratorProvider(props);
@@ -265,7 +266,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
         return !!this._popupContainer && this._popupContainer.isHidden();
     }
 
-    private _updateFocusArbitratorProvider(props: Types.ViewProps) {
+    private _updateFocusArbitratorProvider(props: RX.Types.ViewProps) {
         if (props.arbitrateFocus) {
             if (this._focusArbitratorProvider) {
                 this._focusArbitratorProvider.setCallback(props.arbitrateFocus);
@@ -316,7 +317,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
     }
 
     render() {
-        const combinedStyles = Styles.combine([_styles.defaultStyle, this.props.style]) as any;
+        const combinedStyles = Styles.combine([_styles.defaultStyle, this.props.style]);
         let ariaRole = AccessibilityUtil.accessibilityTraitToString(this.props.accessibilityTraits);
         const tabIndex = this.props.tabIndex;
         const ariaSelected = AccessibilityUtil.accessibilityTraitToAriaSelected(this.props.accessibilityTraits);
@@ -403,7 +404,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
             reactElement;
     }
 
-    componentWillReceiveProps(nextProps: Types.ViewProps) {
+    componentWillReceiveProps(nextProps: RX.Types.ViewProps) {
         super.componentWillReceiveProps(nextProps);
 
         if (AppConfig.isDevelopmentMode()) {
@@ -489,7 +490,7 @@ export class View extends ViewBase<Types.ViewProps, Types.Stateless> {
     }
 }
 
-applyFocusableComponentMixin(View, function(this: View, nextProps?: Types.ViewProps) {
+applyFocusableComponentMixin(View, function(this: View, nextProps?: RX.Types.ViewProps) {
     // VoiceOver with the VoiceOver key combinations (Ctrl+Option+Left/Right) focuses
     // <div>s when whatever tabIndex is set (even if tabIndex=-1). So, View is focusable
     // when tabIndex is not undefined.

--- a/src/web/ViewBase.tsx
+++ b/src/web/ViewBase.tsx
@@ -21,10 +21,10 @@ import Timers from '../common/utils/Timers';
 const _layoutTimerActiveDuration = 1000;
 const _layoutTimerInactiveDuration = 10000;
 
-export abstract class ViewBase<P extends RX.Types.ViewProps, S> extends RX.ViewBase<P, S> {
+export abstract class ViewBase<P extends RX.Types.ViewPropsShared<C>, S, C extends RX.View | RX.ScrollView> extends RX.ViewBase<P, S> {
     private static _viewCheckingTimer: number | undefined;
     private static _isResizeHandlerInstalled = false;
-    private static _viewCheckingList: ViewBase<RX.Types.ViewProps, RX.Types.Stateless>[] = [];
+    private static _viewCheckingList: ViewBase<RX.Types.ViewPropsShared<RX.View | RX.ScrollView>, any, RX.View | RX.ScrollView>[] = [];
     private static _appActivationState = RX.Types.AppActivationState.Active;
 
     abstract render(): JSX.Element;
@@ -57,7 +57,7 @@ export abstract class ViewBase<P extends RX.Types.ViewProps, S> extends RX.ViewB
         }
     }
 
-    componentWillReceiveProps(nextProps: RX.Types.ViewProps) {
+    componentWillReceiveProps(nextProps: RX.Types.ViewPropsShared<C>) {
         if (!!this.props.onLayout !== !!nextProps.onLayout) {
             if (this.props.onLayout) {
                 this._checkViewCheckerUnbuild();

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -88,7 +88,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
     private _popupContainer: PopupContainerView | undefined;
     private _popupToken: PopupComponent | undefined;
 
-    constructor(props: Types.ViewProps, context: ViewContext) {
+    constructor(props: Types.ViewProps, context?: ViewContext) {
         super(props, context);
 
         this._limitFocusWithin =
@@ -102,7 +102,7 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
                 this.setFocusLimited(true);
             }
         }
-        this._popupContainer = context.popupContainer;
+        this._popupContainer = context && context.popupContainer;
     }
 
     componentWillReceiveProps(nextProps: Types.ViewProps) {


### PR DESCRIPTION
Now when creating an RX.View, the ref callback will by typed as `string | (ref: RX.View | null) => void | RefObject<RX.View>` instead of `string | (ref: RX.Component<any, any> | null) => void | RefObject<RX.Component<any, any>>`