### PR TITLE
If containerHeight hasn't been updated via onLayout yet, estimate it …

### DIFF
--- a/extensions/virtuallistview/src/VirtualListView.tsx
+++ b/extensions/virtuallistview/src/VirtualListView.tsx
@@ -478,6 +478,13 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
             this._itemsAboveRenderBlock + this._itemsInRenderBlock - 1);
         this._heightBelowRenderBlock = this._calcHeightOfItems(props,
             this._itemsAboveRenderBlock + this._itemsInRenderBlock, props.itemList.length - 1);
+
+        // Pre-populate the container height with known values early - if there are dynamically sized items in the list, this will be
+        // corrected during the onLayout phase
+        if (this._containerHeight === 0) {
+            this._containerHeight = this._heightAboveRenderBlock + this._heightOfRenderBlock + this._heightBelowRenderBlock;
+            this._containerHeightValue.setValue(this._containerHeight);
+        }
     }
 
     private _calcOverdrawAmount() {


### PR DESCRIPTION
…from render block info

For fixed height items, this should always be accurate. For variable height items, it will be corrected shortly after.
This allows the VLV to start displaying content if the container onLayout is delayed. This removes a timing hole for scrolling to items when there's only fixed height items