### PR TITLE
[FIX-1015] View responder events props are now triggered properly

### DIFF
--- a/samples/RXPTest/src/TestRegistry.ts
+++ b/samples/RXPTest/src/TestRegistry.ts
@@ -37,6 +37,7 @@ import UserInterfaceTest from './Tests/UserInterfaceTest';
 import UserPresenceTest from './Tests/UserPresenceTest';
 import ViewBasicTest from './Tests/ViewBasicTest';
 import ViewMouseTest from './Tests/ViewMouseTest';
+import ViewTouchTest from './Tests/ViewTouchTest';
 import WebViewBasicTest from './Tests/WebViewBasicTest';
 import WebViewDynamicTest from './Tests/WebViewDynamicTest';
 
@@ -80,6 +81,7 @@ class TestRegistry {
         this.registerTest(TextInputInteractiveTest);
         this.registerTest(ViewBasicTest);
         this.registerTest(ViewMouseTest);
+        this.registerTest(ViewTouchTest);
         this.registerTest(WebViewBasicTest);
         this.registerTest(WebViewDynamicTest);
 

--- a/samples/RXPTest/src/Tests/AnimationTest.tsx
+++ b/samples/RXPTest/src/Tests/AnimationTest.tsx
@@ -123,6 +123,8 @@ class AnimationView extends RX.Component<RX.CommonProps, AnimationViewState> {
     private _test3Animation = RX.Styles.createAnimatedTextStyle({
         transform: [{
             rotate: RX.Animated.interpolate(this._test3Angle, [0, 1], ['0deg', '360deg'])
+        }, {
+            rotateZ: RX.Animated.interpolate(this._test3Angle, [0, 1], ['0deg', '90deg'])
         }]
     });
 

--- a/samples/RXPTest/src/Tests/ViewTouchTest.tsx
+++ b/samples/RXPTest/src/Tests/ViewTouchTest.tsx
@@ -53,8 +53,26 @@ const _styles = {
 };
 
 interface TouchViewState {
-    view2hasAskedTobeResponder?: boolean;
-    view3hasAskedTobeResponder?: boolean;
+    touchResponderTest: {
+        view2TouchResponderEventHandlerState: {
+            start: boolean;
+            grant: boolean;
+            release: boolean;
+            terminationRequest: boolean;
+            terminate: boolean;
+        };
+        view3TouchResponderEventHandlerState: {
+            start: boolean;
+            grant: boolean;
+            release: boolean;
+            terminationRequest: boolean;
+            terminate: boolean;
+        };
+    };
+    nestedViewTouchTest: {
+        parentOnPress: boolean;
+        childOnPress: boolean;
+    };
     pressEvent?: RX.Types.TouchEvent;
 }
 
@@ -62,7 +80,28 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
 
     constructor(props: RX.CommonProps) {
         super(props);
-        this.state = { };
+        this.state = {
+            touchResponderTest: {
+                view2TouchResponderEventHandlerState: {
+                    start: false,
+                    grant: false,
+                    release: false,
+                    terminationRequest: false,
+                    terminate: false,
+                },
+                view3TouchResponderEventHandlerState: {
+                    start: false,
+                    grant: false,
+                    release: false,
+                    terminationRequest: false,
+                    terminate: false,
+                },
+            },
+            nestedViewTouchTest: {
+                parentOnPress: false,
+                childOnPress: false,
+            }
+        };
     }
 
     private static getTouchEventText(touchEvent?: RX.Types.TouchEvent): string {
@@ -80,6 +119,22 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                 ' touches = ' + touchEvent.touches;
         }
         return 'N/A';
+    }
+
+    private isView2TouchResponderEventHasBeenAllFired = () => {
+        return this.state.touchResponderTest.view2TouchResponderEventHandlerState.start &&
+            this.state.touchResponderTest.view2TouchResponderEventHandlerState.grant && 
+            this.state.touchResponderTest.view2TouchResponderEventHandlerState.release && 
+            this.state.touchResponderTest.view2TouchResponderEventHandlerState.terminationRequest && 
+            this.state.touchResponderTest.view2TouchResponderEventHandlerState.terminate;
+    }
+
+    private isView3TouchResponderEventHasBeenAllFired = () => {
+        return this.state.touchResponderTest.view3TouchResponderEventHandlerState.start &&
+            this.state.touchResponderTest.view3TouchResponderEventHandlerState.grant && 
+            this.state.touchResponderTest.view3TouchResponderEventHandlerState.release && 
+            this.state.touchResponderTest.view3TouchResponderEventHandlerState.terminationRequest && 
+            this.state.touchResponderTest.view3TouchResponderEventHandlerState.terminate;
     }
 
     render(): any {
@@ -105,18 +160,134 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                 </RX.View>
                 <RX.View style={_styles.wrapper}>
                     <RX.View
-                        style={[_styles.testContainer2, this.state.view2hasAskedTobeResponder ? _styles.success : undefined]}
+                        style={[_styles.testContainer2, this.isView2TouchResponderEventHasBeenAllFired() ? _styles.success : undefined]}
                         onStartShouldSetResponder={() => {
-                            this.setState({ view2hasAskedTobeResponder: true });
+                            console.log('onStartShouldSetResponder');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view2TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
+                                        start: true
+                                    }
+                                }
+                            });
                             return true;
+                        }}
+                        onResponderGrant={() => {
+                            console.log('onResponderGrant');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view2TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
+                                        grant: true
+                                    }
+                                }
+                            });
+                        }}
+                        onResponderRelease={() => {
+                            console.log('onResponderRelease');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view2TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
+                                        release: true
+                                    }
+                                }
+                            });
+                        }}
+                        onResponderTerminationRequest={() => {
+                            console.log('onResponderTerminationRequest');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view2TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
+                                        terminationRequest: true
+                                    }
+                                }
+                            });
+                            return true;
+                        }}
+                        onResponderTerminate={() => {
+                            console.log('onResponderTerminate');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view2TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
+                                        terminate: true
+                                    }
+                                }
+                            });
                         }}
                     />
                     <RX.View
-                        style={[_styles.testContainer3, this.state.view3hasAskedTobeResponder ? _styles.success : undefined]}
+                        style={[_styles.testContainer3, this.isView3TouchResponderEventHasBeenAllFired() ? _styles.success : undefined]}
                         onPress={() => null}
                         onStartShouldSetResponder={() => {
-                            this.setState({ view3hasAskedTobeResponder: true });
+                            console.log('onStartShouldSetResponder');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view3TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
+                                        start: true
+                                    }
+                                }
+                            });
                             return true;
+                        }}
+                        onResponderGrant={() => {
+                            console.log('onResponderGrant');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view3TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
+                                        grant: true
+                                    }
+                                }
+                            });
+                        }}
+                        onResponderRelease={() => {
+                            console.log('onResponderRelease');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view3TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
+                                        release: true
+                                    }
+                                }
+                            });
+                        }}
+                        onResponderTerminationRequest={() => {
+                            console.log('onResponderTerminationRequest');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view3TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
+                                        terminationRequest: true
+                                    }
+                                }
+                            });
+                            return true;
+                        }}
+                        onResponderTerminate={() => {
+                            console.log('onResponderTerminate');
+                            this.setState({
+                                touchResponderTest: {
+                                    ...this.state.touchResponderTest,
+                                    view3TouchResponderEventHandlerState: {
+                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
+                                        terminate: true
+                                    }
+                                }
+                            });
                         }}
                     />
                 </RX.View>

--- a/samples/RXPTest/src/Tests/ViewTouchTest.tsx
+++ b/samples/RXPTest/src/Tests/ViewTouchTest.tsx
@@ -53,26 +53,14 @@ const _styles = {
 };
 
 interface TouchViewState {
-    touchResponderTest: {
-        view2TouchResponderEventHandlerState: {
-            start: boolean;
-            grant: boolean;
-            release: boolean;
-            terminationRequest: boolean;
-            terminate: boolean;
-        };
-        view3TouchResponderEventHandlerState: {
-            start: boolean;
-            grant: boolean;
-            release: boolean;
-            terminationRequest: boolean;
-            terminate: boolean;
-        };
-    };
-    nestedViewTouchTest: {
-        parentOnPress: boolean;
-        childOnPress: boolean;
-    };
+    view2TouchResponderTestStart: boolean;
+    view2TouchResponderTestGrant: boolean;
+    view2TouchResponderTestRelease: boolean;
+    view3TouchResponderTestStart: boolean;
+    view3TouchResponderTestGrant: boolean;
+    view3TouchResponderTestRelease: boolean;
+    nestedViewTouchTestParent: boolean;
+    nestedViewTouchTestChild: boolean;
     pressEvent?: RX.Types.TouchEvent;
 }
 
@@ -81,26 +69,14 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
     constructor(props: RX.CommonProps) {
         super(props);
         this.state = {
-            touchResponderTest: {
-                view2TouchResponderEventHandlerState: {
-                    start: false,
-                    grant: false,
-                    release: false,
-                    terminationRequest: false,
-                    terminate: false,
-                },
-                view3TouchResponderEventHandlerState: {
-                    start: false,
-                    grant: false,
-                    release: false,
-                    terminationRequest: false,
-                    terminate: false,
-                },
-            },
-            nestedViewTouchTest: {
-                parentOnPress: false,
-                childOnPress: false,
-            }
+            view2TouchResponderTestStart: false,
+            view2TouchResponderTestGrant: false,
+            view2TouchResponderTestRelease: false,
+            view3TouchResponderTestStart: false,
+            view3TouchResponderTestGrant: false,
+            view3TouchResponderTestRelease: false,
+            nestedViewTouchTestParent: false,
+            nestedViewTouchTestChild: false,
         };
     }
 
@@ -122,19 +98,15 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
     }
 
     private isView2TouchResponderEventHasBeenAllFired = () => {
-        return this.state.touchResponderTest.view2TouchResponderEventHandlerState.start &&
-            this.state.touchResponderTest.view2TouchResponderEventHandlerState.grant && 
-            this.state.touchResponderTest.view2TouchResponderEventHandlerState.release && 
-            this.state.touchResponderTest.view2TouchResponderEventHandlerState.terminationRequest && 
-            this.state.touchResponderTest.view2TouchResponderEventHandlerState.terminate;
+        return this.state.view2TouchResponderTestStart &&
+            this.state.view2TouchResponderTestGrant && 
+            this.state.view2TouchResponderTestRelease;
     }
 
     private isView3TouchResponderEventHasBeenAllFired = () => {
-        return this.state.touchResponderTest.view3TouchResponderEventHandlerState.start &&
-            this.state.touchResponderTest.view3TouchResponderEventHandlerState.grant && 
-            this.state.touchResponderTest.view3TouchResponderEventHandlerState.release && 
-            this.state.touchResponderTest.view3TouchResponderEventHandlerState.terminationRequest && 
-            this.state.touchResponderTest.view3TouchResponderEventHandlerState.terminate;
+        return this.state.view3TouchResponderTestStart &&
+            this.state.view3TouchResponderTestGrant && 
+            this.state.view3TouchResponderTestRelease;
     }
 
     render(): any {
@@ -163,59 +135,18 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                         style={[_styles.testContainer2, this.isView2TouchResponderEventHasBeenAllFired() ? _styles.success : undefined]}
                         onStartShouldSetResponder={() => {
                             this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view2TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
-                                        start: true
-                                    }
-                                }
+                                view2TouchResponderTestStart: true
                             });
                             return true;
                         }}
                         onResponderGrant={() => {
                             this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view2TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
-                                        grant: true
-                                    }
-                                }
+                                view2TouchResponderTestGrant: true
                             });
                         }}
                         onResponderRelease={() => {
                             this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view2TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
-                                        release: true
-                                    }
-                                }
-                            });
-                        }}
-                        onResponderTerminationRequest={() => {
-                            this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view2TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
-                                        terminationRequest: true
-                                    }
-                                }
-                            });
-                            return true;
-                        }}
-                        onResponderTerminate={() => {
-                            this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view2TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view2TouchResponderEventHandlerState,
-                                        terminate: true
-                                    }
-                                }
+                                view2TouchResponderTestRelease: true
                             });
                         }}
                     />
@@ -224,59 +155,18 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                         onPress={() => null}
                         onStartShouldSetResponder={() => {
                             this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view3TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
-                                        start: true
-                                    }
-                                }
+                                view3TouchResponderTestStart: true
                             });
                             return true;
                         }}
                         onResponderGrant={() => {
                             this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view3TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
-                                        grant: true
-                                    }
-                                }
+                                view3TouchResponderTestGrant: true
                             });
                         }}
                         onResponderRelease={() => {
                             this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view3TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
-                                        release: true
-                                    }
-                                }
-                            });
-                        }}
-                        onResponderTerminationRequest={() => {
-                            this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view3TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
-                                        terminationRequest: true
-                                    }
-                                }
-                            });
-                            return true;
-                        }}
-                        onResponderTerminate={() => {
-                            this.setState({
-                                touchResponderTest: {
-                                    ...this.state.touchResponderTest,
-                                    view3TouchResponderEventHandlerState: {
-                                        ...this.state.touchResponderTest.view3TouchResponderEventHandlerState,
-                                        terminate: true
-                                    }
-                                }
+                                view3TouchResponderTestRelease: true
                             });
                         }}
                     />

--- a/samples/RXPTest/src/Tests/ViewTouchTest.tsx
+++ b/samples/RXPTest/src/Tests/ViewTouchTest.tsx
@@ -1,0 +1,146 @@
+/*
+* Tests mouse/touch/pointer functionality of a View component.
+*/
+
+import _ = require('lodash');
+import RX = require('reactxp');
+
+import * as CommonStyles from '../CommonStyles';
+import { Test, TestType } from '../Test';
+
+const _styles = {
+    explainTextContainer: RX.Styles.createViewStyle({
+        margin: 12,
+        alignItems: 'center'
+    }),
+    explainText: RX.Styles.createTextStyle({
+        fontSize: CommonStyles.generalFontSize,
+        color: CommonStyles.explainTextColor
+    }),
+    labelText: RX.Styles.createTextStyle({
+        margin: 8,
+        fontSize: CommonStyles.generalFontSize,
+    }),
+    testContainer1: RX.Styles.createTextStyle({
+        backgroundColor: '#eee',
+        borderColor: 'black',
+        borderWidth: 1,
+        margin: 20,
+    }),
+    wrapper: RX.Styles.createViewStyle({
+        flexDirection: 'row'
+    }),
+    testContainer2: RX.Styles.createViewStyle({
+        flex: 1,
+        height: 120,
+        margin: 20,        
+        borderWidth: 1,
+        backgroundColor: '#eee',
+        borderColor: 'black',
+    }),
+    testContainer3: RX.Styles.createViewStyle({
+        flex: 1,
+        height: 120,
+        margin: 20,        
+        borderWidth: 1,
+        backgroundColor: '#eee',
+        borderColor: 'black',
+    }),
+    success: RX.Styles.createViewStyle({
+        borderWidth: 2,
+        backgroundColor: 'green'
+    })
+};
+
+interface TouchViewState {
+    view2hasAskedTobeResponder?: boolean;
+    view3hasAskedTobeResponder?: boolean;
+    pressEvent?: RX.Types.TouchEvent;
+}
+
+class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
+
+    constructor(props: RX.CommonProps) {
+        super(props);
+        this.state = { };
+    }
+
+    private static getTouchEventText(touchEvent?: RX.Types.TouchEvent): string {
+        if (touchEvent) {
+            return 'altKey = ' + touchEvent.altKey +
+                ' changedTouches.length = ' + touchEvent.changedTouches.length +
+                ' ctrlKey = ' + touchEvent.ctrlKey +
+                ' metaKey = ' + touchEvent.metaKey +
+                ' shiftKey = ' + touchEvent.shiftKey +
+                ' targetTouches = ' + touchEvent.targetTouches +
+                ' locationX = ' + touchEvent.locationX +
+                ' locationY = ' + touchEvent.locationY +
+                ' pageX = ' + touchEvent.pageX +
+                ' pageY = ' + touchEvent.pageY +
+                ' touches = ' + touchEvent.touches;
+        }
+        return 'N/A';
+    }
+
+    render(): any {
+        return (
+            <RX.View>
+                <RX.View style={ _styles.explainTextContainer }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'The view below shows textual representation of the last mouse events it has received.' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View
+                    style={ _styles.testContainer1 }
+                    onPress={ e => this.setState({ pressEvent: _.clone(e.nativeEvent as RX.Types.TouchEvent)}) }
+                >
+                    <RX.Text style={ _styles.labelText }>
+                        { 'onPress: ' + ViewTouch.getTouchEventText(this.state.pressEvent) }
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={ _styles.explainTextContainer }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'The two views below should turn green if they received the `StartShouldSetResponder` event.' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={_styles.wrapper}>
+                    <RX.View
+                        style={[_styles.testContainer2, this.state.view2hasAskedTobeResponder ? _styles.success : undefined]}
+                        onStartShouldSetResponder={() => {
+                            this.setState({ view2hasAskedTobeResponder: true });
+                            return true;
+                        }}
+                    />
+                    <RX.View
+                        style={[_styles.testContainer3, this.state.view3hasAskedTobeResponder ? _styles.success : undefined]}
+                        onPress={() => null}
+                        onStartShouldSetResponder={() => {
+                            this.setState({ view3hasAskedTobeResponder: true });
+                            return true;
+                        }}
+                    />
+                </RX.View>
+            </RX.View>
+        );
+    }
+}
+
+class ViewTouchTest implements Test {
+    getPath(): string {
+        return 'Components/View/Touch';
+    }
+
+    getTestType(): TestType {
+        return TestType.Interactive;
+    }
+
+    render(onMount: (component: any) => void): RX.Types.ReactNode {
+        return (
+            <ViewTouch
+                ref={ onMount }
+            />
+        );
+    }
+}
+
+export default new ViewTouchTest();

--- a/samples/RXPTest/src/Tests/ViewTouchTest.tsx
+++ b/samples/RXPTest/src/Tests/ViewTouchTest.tsx
@@ -162,7 +162,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                     <RX.View
                         style={[_styles.testContainer2, this.isView2TouchResponderEventHasBeenAllFired() ? _styles.success : undefined]}
                         onStartShouldSetResponder={() => {
-                            console.log('onStartShouldSetResponder');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -175,7 +174,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             return true;
                         }}
                         onResponderGrant={() => {
-                            console.log('onResponderGrant');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -187,7 +185,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             });
                         }}
                         onResponderRelease={() => {
-                            console.log('onResponderRelease');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -199,7 +196,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             });
                         }}
                         onResponderTerminationRequest={() => {
-                            console.log('onResponderTerminationRequest');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -212,7 +208,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             return true;
                         }}
                         onResponderTerminate={() => {
-                            console.log('onResponderTerminate');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -228,7 +223,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                         style={[_styles.testContainer3, this.isView3TouchResponderEventHasBeenAllFired() ? _styles.success : undefined]}
                         onPress={() => null}
                         onStartShouldSetResponder={() => {
-                            console.log('onStartShouldSetResponder');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -241,7 +235,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             return true;
                         }}
                         onResponderGrant={() => {
-                            console.log('onResponderGrant');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -253,7 +246,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             });
                         }}
                         onResponderRelease={() => {
-                            console.log('onResponderRelease');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -265,7 +257,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             });
                         }}
                         onResponderTerminationRequest={() => {
-                            console.log('onResponderTerminationRequest');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,
@@ -278,7 +269,6 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             return true;
                         }}
                         onResponderTerminate={() => {
-                            console.log('onResponderTerminate');
                             this.setState({
                                 touchResponderTest: {
                                     ...this.state.touchResponderTest,

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -377,11 +377,11 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
         if (this._mixinIsApplied) {
             const responderProps = {
                 onStartShouldSetResponder: this.props.onStartShouldSetResponder || this.touchableHandleStartShouldSetResponder,
-                onResponderTerminationRequest: this.touchableHandleResponderTerminationRequest,
-                onResponderGrant: this.touchableHandleResponderGrant,
+                onResponderTerminationRequest: this.props.onResponderTerminationRequest || this.touchableHandleResponderTerminationRequest,
+                onResponderGrant: this.props.onResponderGrant || this.touchableHandleResponderGrant,
                 onResponderMove: this.touchableHandleResponderMove,
-                onResponderRelease: this.touchableHandleResponderRelease,
-                onResponderTerminate: this.touchableHandleResponderTerminate
+                onResponderRelease: this.props.onResponderRelease || this.touchableHandleResponderRelease,
+                onResponderTerminate: this.props.onResponderTerminate || this.touchableHandleResponderTerminate
             };
             this._internalProps = extend(this._internalProps, responderProps);
 

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -376,7 +376,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
         this._internalProps.style = baseStyle;
         if (this._mixinIsApplied) {
             const responderProps = {
-                onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,
+                onStartShouldSetResponder: this.props.onStartShouldSetResponder || this.touchableHandleStartShouldSetResponder,
                 onResponderTerminationRequest: this.touchableHandleResponderTerminationRequest,
                 onResponderGrant: this.touchableHandleResponderGrant,
                 onResponderMove: this.touchableHandleResponderMove,

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -379,7 +379,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
                 onStartShouldSetResponder: this.props.onStartShouldSetResponder || this.touchableHandleStartShouldSetResponder,
                 onResponderTerminationRequest: this.props.onResponderTerminationRequest || this.touchableHandleResponderTerminationRequest,
                 onResponderGrant: this.props.onResponderGrant || this.touchableHandleResponderGrant,
-                onResponderMove: this.touchableHandleResponderMove,
+                onResponderMove: this.props.onResponderMove || this.touchableHandleResponderMove,
                 onResponderRelease: this.props.onResponderRelease || this.touchableHandleResponderRelease,
                 onResponderTerminate: this.props.onResponderTerminate || this.touchableHandleResponderTerminate
             };


### PR DESCRIPTION
## Description

The responder event handlers props passed to a view are not triggered when onPress or onLongPress is also present.

## This PR does the following

- Assign the events handlers props if present or assign the default RN handler.
-  Add tests

More infos: #1015