### PR TITLE
Declare ACCESS_NETWORK_STATE permission

### DIFF
--- a/samples/RXPTest/android/app/src/main/AndroidManifest.xml
+++ b/samples/RXPTest/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
The API - Network test requires that the ACCESS_NETWORK_STATE permission is declared -( without it the test errors.)