### PR TITLE
Build Caveats - for unpublished dependencies

### DIFF
--- a/samples/RXPTest/README.md
+++ b/samples/RXPTest/README.md
@@ -2,6 +2,9 @@
 
 This app provides tests for all of the functionality exposed by ReactXP.
 
+### Caveat: Development Dependencies on ReactXP
+*If/when RXPTest has development dependencies on (as yet) unpublished changes to ReactXP, a successfully build may require following the [Testing your Change](https://github.com/Microsoft/reactxp/blob/master/CONTRIBUTING.md#testing-your-change) instructions to copy the appropriate `dist` folder structure to RXPTest. It may also require appropriate types being specified in "devDependencies" in RXPTest's package.json  eg `"@types/react": "16.7.20"`*  
+
 ### Building
 
 - From the RXPTest directory, run `npm install`. This fetches the dependencies.


### PR DESCRIPTION
Given RXPTest by design exercises ReactXP it can have transient dependencies on as yet unpublished changes. The proposed changes to the README.md gives a pointer on how to address these.