### PR TITLE
Add more mouse cursor type into GestureMouseCursor

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -756,7 +756,14 @@ export enum GestureMouseCursor {
     Default,
     Pointer,
     Grab,
-    Move
+    Move,
+    EWResize,
+    NSResize,
+    NESWResize,
+    NWSEResize,
+    NotAllowed,
+    ZoomIn,
+    ZoomOut
 }
 
 export enum PreferredPanGesture {

--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -219,6 +219,34 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
             case Types.GestureMouseCursor.Pointer:
                 cursorName = 'pointer';
                 break;
+
+            case Types.GestureMouseCursor.NSResize:
+                cursorName = 'ns-resize';
+                break;
+
+            case Types.GestureMouseCursor.EWResize:
+                cursorName = 'ew-resize';
+                break;
+
+            case Types.GestureMouseCursor.NESWResize:
+                cursorName = 'nesw-resize';
+                break;
+
+            case Types.GestureMouseCursor.NWSEResize:
+                cursorName = 'nwse-resize';
+                break;
+
+            case Types.GestureMouseCursor.NotAllowed:
+                cursorName = 'not-allowed';
+                break;
+
+            case Types.GestureMouseCursor.ZoomIn:
+                cursorName = 'zoom-in';
+                break;
+
+            case Types.GestureMouseCursor.ZoomOut:
+                cursorName = 'zoom-out';
+                break;
         }
 
         if (cursorName) {


### PR DESCRIPTION
Hi, I would like to add more mouse Cursor type support into ReactXP.

All new cursor is coming from and tested on both electron and chrome.
https://developer.mozilla.org/en-US/docs/Web/CSS/cursor

Thanks,
/Wei