### PR TITLE
Fix textDecorationStyle and textDecorationColor on web

### DIFF
--- a/src/web/Styles.ts
+++ b/src/web/Styles.ts
@@ -431,6 +431,26 @@ export class Styles extends RX.Styles {
             delete def.textDecorationLine;
         }
 
+        // CSS doesn't support 'textDecorationStyle'
+        if (def.textDecorationStyle !== undefined) {
+            if (def.textDecoration !== undefined) {
+                def.textDecoration += ' ' + def.textDecorationStyle;
+            } else {
+                def.textDecoration = def.textDecorationStyle;
+            }
+            delete def.textDecorationStyle;
+        }
+
+        // CSS doesn't support 'textDecorationColor'
+        if (def.textDecorationColor !== undefined) {
+            if (def.textDecoration !== undefined) {
+                def.textDecoration += ' ' + def.textDecorationColor;
+            } else {
+                def.textDecoration = def.textDecorationColor;
+            }
+            delete def.textDecorationColor;
+        }
+
         // Add common aliases if necessary.
         const jsAliases = this._getCssPropertyAliasesJsStyle();
         for (const prop in jsAliases) {


### PR DESCRIPTION
Tested the web version of RXPTest - Components - Text on:
- macOS 10.14.3
- Chrome 72.0.3626.121

Before change:
![screen shot 2019-03-05 at 9 48 37 pm](https://user-images.githubusercontent.com/1635228/53800488-f5038580-3f90-11e9-91c1-e393842847d6.png)

After change:
![screen shot 2019-03-05 at 9 48 54 pm](https://user-images.githubusercontent.com/1635228/53800498-fa60d000-3f90-11e9-9463-15317a33ab6b.png)