### PR TITLE
Fix transform rotate styles not working on web

### DIFF
--- a/src/web/Styles.ts
+++ b/src/web/Styles.ts
@@ -305,9 +305,7 @@ export class Styles extends RX.Styles {
                         animatedTransforms[key] = t[key];
                     } else {
                         let value: string = t[key].toString();
-                        if (key.indexOf('rotate') === 0) {
-                            value += 'deg';
-                        } else if (key.indexOf('translate') === 0) {
+                        if (key.indexOf('translate') === 0) {
                             value += 'px';
                         }
 


### PR DESCRIPTION
React Native platforms expect transform rotate styles to be expressed with a string in either degrees (deg) or radians (rad), e.g. `transform: [{ rotateZ: '45deg' }]`. If you just try to pass a number, e.g. `'45'`, you will get an error like:
`Invariant Violation: Rotate transform must be expressed in degrees (deg) or radians (rad): {"rotateZ":"45"}`

However, the web styles code would always add 'deg' to the end of the string so you would end up with CSS like `transform: rotateZ(45degdeg)` which obviously won't work.

This PR removes the code that adds that extra 'deg'.