### PR TITLE
RXPTest - Fix iOS build linker error

### DIFF
--- a/samples/RXPTest/ios/RXPTest.xcodeproj/project.pbxproj
+++ b/samples/RXPTest/ios/RXPTest.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		D2278308222FDC55009150CC /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2278307222FDC55009150CC /* JavaScriptCore.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -292,6 +293,7 @@
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		D2278307222FDC55009150CC /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -299,6 +301,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2278308222FDC55009150CC /* JavaScriptCore.framework in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
@@ -466,6 +469,7 @@
 				13B07FAE1A68108700A75B9A /* RXPTest */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
+				D22782DB222FDC54009150CC /* Frameworks */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -477,6 +481,14 @@
 				13B07F961A680F5B00A75B9A /* RXPTest.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		D22782DB222FDC54009150CC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D2278307222FDC55009150CC /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */


### PR DESCRIPTION
Building the RXPTest sample for iOS results in an Xcode linker error with the following set up:
- macOS 10.14.3
- Xcode 10.1
- Building for iPhone X simulator
- Building using command `cd ./samples/RXPTest/ && npm i && npm run ios`

From what I can tell, the build fails because the Xcode project is missing a reference to JavaScriptCore.framework. So, this PR adds that.

<details><summary>Expand here to see linker errors</summary>

```
Undefined symbols for architecture x86_64:
  "_JSClassCreate", referenced from:

      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::$_0::operator()() const in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::$_1::operator()() const in libReact.a(JSCRuntime.o)

  "_JSContextGetGlobalObject", referenced from:

      facebook::jsc::JSCRuntime::global() in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSEvaluateScript", referenced from:

      facebook::jsc::JSCRuntime::evaluateJavaScript(std::__1::unique_ptr<facebook::jsi::Buffer const, std::__1::default_delete<facebook::jsi::Buffer const> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in libReact.a(JSCRuntime.o)

  "_JSGlobalContextCreateInGroup", referenced from:

      facebook::jsc::JSCRuntime::JSCRuntime() in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::JSCRuntime() in libReact.a(JSCRuntime.o)

  "_JSGlobalContextRelease", referenced from:

      facebook::jsc::JSCRuntime::JSCRuntime() in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::~JSCRuntime() in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::JSCRuntime() in libReact.a(JSCRuntime.o)

  "_JSGlobalContextRetain", referenced from:

      facebook::jsc::JSCRuntime::JSCRuntime(OpaqueJSContext*) in libReact.a(JSCRuntime.o)

  "_JSObjectCallAsConstructor", referenced from:

      facebook::jsc::JSCRuntime::callAsConstructor(facebook::jsi::Function const&, facebook::jsi::Value const*, unsigned long) in libReact.a(JSCRuntime.o)

  "_JSObjectCallAsFunction", referenced from:

      facebook::jsc::JSCRuntime::call(facebook::jsi::Function const&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) in libReact.a(JSCRuntime.o)

  "_JSObjectCopyPropertyNames", referenced from:

      facebook::jsc::JSCRuntime::getPropertyNames(facebook::jsi::Object const&) in libReact.a(JSCRuntime.o)

  "_JSObjectGetPrivate", referenced from:

      facebook::jsc::JSCRuntime::getHostObject(facebook::jsi::Object const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::getHostFunction(facebook::jsi::Function const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::HostObjectProxy::finalize(OpaqueJSValue*) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::HostObjectProxy::getProperty(OpaqueJSContext const*, OpaqueJSValue*, OpaqueJSString*, OpaqueJSValue const**) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::HostObjectProxy::setProperty(OpaqueJSContext const*, OpaqueJSValue*, OpaqueJSString*, OpaqueJSValue const*, OpaqueJSValue const**) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::HostObjectProxy::getPropertyNames(OpaqueJSContext const*, OpaqueJSValue*, OpaqueJSPropertyNameAccumulator*) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

      ...

  "_JSObjectGetProperty", referenced from:

      facebook::jsc::JSCRuntime::getProperty(facebook::jsi::Object const&, facebook::jsi::String const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::getProperty(facebook::jsi::Object const&, facebook::jsi::PropNameID const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSObjectGetPropertyAtIndex", referenced from:

      facebook::jsc::JSCRuntime::getValueAtIndex(facebook::jsi::Array const&, unsigned long) in libReact.a(JSCRuntime.o)

  "_JSObjectGetPrototype", referenced from:

      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSObjectHasProperty", referenced from:

      facebook::jsc::JSCRuntime::hasProperty(facebook::jsi::Object const&, facebook::jsi::String const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::hasProperty(facebook::jsi::Object const&, facebook::jsi::PropNameID const&) in libReact.a(JSCRuntime.o)

  "_JSObjectIsFunction", referenced from:

      facebook::jsc::JSCRuntime::isFunction(facebook::jsi::Object const&) const in libReact.a(JSCRuntime.o)

  "_JSObjectMake", referenced from:

      facebook::jsc::JSCRuntime::makeObjectValue(OpaqueJSValue*) const in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>) in libReact.a(JSCRuntime.o)

  "_JSObjectMakeArray", referenced from:

      facebook::jsc::JSCRuntime::createArray(unsigned long) in libReact.a(JSCRuntime.o)

  "_JSObjectSetPrivate", referenced from:

      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::HostObjectProxy::finalize(OpaqueJSValue*) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::finalize(OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSObjectSetProperty", referenced from:

      facebook::jsc::JSCRuntime::setPropertyValue(facebook::jsi::Object&, facebook::jsi::PropNameID const&, facebook::jsi::Value const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::setPropertyValue(facebook::jsi::Object&, facebook::jsi::String const&, facebook::jsi::Value const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createArray(unsigned long) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSObjectSetPropertyAtIndex", referenced from:

      facebook::jsc::JSCRuntime::setValueAtIndexImpl(facebook::jsi::Array&, unsigned long, facebook::jsi::Value const&) in libReact.a(JSCRuntime.o)

  "_JSObjectSetPrototype", referenced from:

      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSPropertyNameAccumulatorAddName", referenced from:

      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::HostObjectProxy::getPropertyNames(OpaqueJSContext const*, OpaqueJSValue*, OpaqueJSPropertyNameAccumulator*) in libReact.a(JSCRuntime.o)

  "_JSPropertyNameArrayGetCount", referenced from:

      facebook::jsc::JSCRuntime::getPropertyNames(facebook::jsi::Object const&) in libReact.a(JSCRuntime.o)

  "_JSPropertyNameArrayGetNameAtIndex", referenced from:

      facebook::jsc::JSCRuntime::getPropertyNames(facebook::jsi::Object const&) in libReact.a(JSCRuntime.o)

  "_JSPropertyNameArrayRelease", referenced from:

      facebook::jsc::JSCRuntime::getPropertyNames(facebook::jsi::Object const&) in libReact.a(JSCRuntime.o)

  "_JSStringCreateWithUTF8CString", referenced from:

      facebook::jsc::JSCRuntime::evaluateJavaScript(std::__1::unique_ptr<facebook::jsi::Buffer const, std::__1::default_delete<facebook::jsi::Buffer const> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createPropNameIDFromAscii(char const*, unsigned long) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createPropNameIDFromUtf8(unsigned char const*, unsigned long) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createStringFromUtf8(unsigned char const*, unsigned long) in libReact.a(JSCRuntime.o)
      facebook::jsc::(anonymous namespace)::getLengthString() in libReact.a(JSCRuntime.o)
      facebook::jsc::(anonymous namespace)::getEmptyString() in libReact.a(JSCRuntime.o)
      facebook::jsc::(anonymous namespace)::getNameString() in libReact.a(JSCRuntime.o)
      ...

  "_JSStringGetMaximumUTF8CStringSize", referenced from:

      facebook::jsc::(anonymous namespace)::JSStringToSTLString(OpaqueJSString*) in libReact.a(JSCRuntime.o)

  "_JSStringGetUTF8CString", referenced from:

      facebook::jsc::(anonymous namespace)::JSStringToSTLString(OpaqueJSString*) in libReact.a(JSCRuntime.o)

  "_JSStringIsEqual", referenced from:

      facebook::jsc::JSCRuntime::compare(facebook::jsi::PropNameID const&, facebook::jsi::PropNameID const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::strictEquals(facebook::jsi::String const&, facebook::jsi::String const&) const in libReact.a(JSCRuntime.o)

  "_JSStringRelease", referenced from:

      facebook::jsc::JSCRuntime::evaluateJavaScript(std::__1::unique_ptr<facebook::jsi::Buffer const, std::__1::default_delete<facebook::jsi::Buffer const> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::JSCStringValue::invalidate() in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createPropNameIDFromAscii(char const*, unsigned long) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createPropNameIDFromUtf8(unsigned char const*, unsigned long) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSStringRetain", referenced from:

      facebook::jsc::JSCRuntime::JSCStringValue::JSCStringValue(OpaqueJSString*, std::__1::atomic<long>&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::HostFunctionMetadata(facebook::jsc::JSCRuntime*, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>, unsigned int, OpaqueJSString*) in libReact.a(JSCRuntime.o)

  "_JSValueIsArray", referenced from:

      facebook::jsc::JSCRuntime::isArray(facebook::jsi::Object const&) const in libReact.a(JSCRuntime.o)

  "_JSValueIsBoolean", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueIsInstanceOfConstructor", referenced from:

      facebook::jsc::JSCRuntime::instanceOf(facebook::jsi::Object const&, facebook::jsi::Function const&) in libReact.a(JSCRuntime.o)

  "_JSValueIsNull", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueIsNumber", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueIsObject", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueIsObjectOfClass", referenced from:

      facebook::jsc::JSCRuntime::isHostObject(facebook::jsi::Object const&) const in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::isHostFunction(facebook::jsi::Function const&) const in libReact.a(JSCRuntime.o)

  "_JSValueIsString", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueIsUndefined", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueMakeBoolean", referenced from:

      facebook::jsc::JSCRuntime::valueRef(facebook::jsi::Value const&) in libReact.a(JSCRuntime.o)

  "_JSValueMakeNull", referenced from:

      facebook::jsc::JSCRuntime::valueRef(facebook::jsi::Value const&) in libReact.a(JSCRuntime.o)

  "_JSValueMakeNumber", referenced from:

      facebook::jsc::JSCRuntime::valueRef(facebook::jsi::Value const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createArray(unsigned long) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSValueMakeString", referenced from:

      facebook::jsc::JSCRuntime::valueRef(facebook::jsi::Value const&) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSValueMakeUndefined", referenced from:

      facebook::jsc::JSCRuntime::valueRef(facebook::jsi::Value const&) in libReact.a(JSCRuntime.o)

      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::HostObjectProxy::getProperty(OpaqueJSContext const*, OpaqueJSValue*, OpaqueJSString*, OpaqueJSValue const**) in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::call(OpaqueJSContext const*, OpaqueJSValue*, OpaqueJSValue*, unsigned long, OpaqueJSValue const* const*, OpaqueJSValue const**) in libReact.a(JSCRuntime.o)

  "_JSValueProtect", referenced from:

      facebook::jsc::JSCRuntime::JSCObjectValue::JSCObjectValue(OpaqueJSContext*, std::__1::atomic<bool> const&, OpaqueJSValue*, std::__1::atomic<long>&) in libReact.a(JSCRuntime.o)

  "_JSValueToBoolean", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueToNumber", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueToObject", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::HostFunctionMetadata::initialize(OpaqueJSContext const*, OpaqueJSValue*) in libReact.a(JSCRuntime.o)

  "_JSValueToStringCopy", referenced from:

      facebook::jsc::JSCRuntime::createValue(OpaqueJSValue const*) const in libReact.a(JSCRuntime.o)

  "_JSValueUnprotect", referenced from:

      facebook::jsc::JSCRuntime::JSCObjectValue::invalidate() in libReact.a(JSCRuntime.o)

  "_kJSClassDefinitionEmpty", referenced from:

      facebook::jsc::JSCRuntime::createObject(std::__1::shared_ptr<facebook::jsi::HostObject>)::$_0::operator()() const in libReact.a(JSCRuntime.o)
      facebook::jsc::JSCRuntime::createFunctionFromHostFunction(facebook::jsi::PropNameID const&, unsigned int, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>)::$_1::operator()() const in libReact.a(JSCRuntime.o)

ld: symbol(s) not found for architecture x86_64

clang: error: linker command failed with exit code 1 (use -v to see invocation)



** BUILD FAILED **
```
</details>