### PR TITLE
See #1044: "TodoList: Fails to show ViewTodoPanel on native platforms"

### DIFF
--- a/samples/TodoList/src/ts/views/TodoListItem.tsx
+++ b/samples/TodoList/src/ts/views/TodoListItem.tsx
@@ -18,6 +18,7 @@ interface TodoListItemProps extends RX.CommonProps {
     todo: Todo;
     isSelected: boolean;
     searchString?: string;
+    onPress: (todoId: string) => void;
 }
 
 interface TodoListItemState {
@@ -73,8 +74,17 @@ export default class TodoListItem extends ComponentBase<TodoListItemProps, TodoL
 
     render(): JSX.Element | null {
         return (
-            <HoverButton onRenderChild={ this._onRenderItem } />
+            <HoverButton
+              onRenderChild={ this._onRenderItem }
+              onPress={ this._onPress }/>
         );
+    }
+
+    private _onPress = (e: RX.Types.SyntheticEvent) => {
+        // Prevent VirtualListView.onItemSelected from
+        // being triggering in the web app.
+        e.stopPropagation();
+        this.props.onPress(this.props.todo.id);
     }
 
     private _onRenderItem = (isHovering: boolean) => {

--- a/samples/TodoList/src/ts/views/TodoListPanel.tsx
+++ b/samples/TodoList/src/ts/views/TodoListPanel.tsx
@@ -130,7 +130,6 @@ export default class TodoListPanel extends ComponentBase<TodoListPanelProps, Tod
                     itemList={ this.state.filteredTodoList }
                     renderItem={ this._renderItem }
                     style={ _styles.listScroll }
-                    onItemSelected={ this._onPressTodo }
                 />
             </RX.View>
         );
@@ -171,13 +170,13 @@ export default class TodoListPanel extends ComponentBase<TodoListPanelProps, Tod
                 height={ _listItemHeight }
                 isSelected={ item.todo.id === this.props.selectedTodoId }
                 searchString={ this.state.searchString }
+                onPress={ this._onPressTodo }
             />
         );
     };
 
-    private _onPressTodo = (itemInfo: TodoListItemInfo) => {
-        const todo = itemInfo.todo;
-        this.props.onSelect(todo.id);
+    private _onPressTodo = (todoId: string) => {
+        this.props.onSelect(todoId);
         this.setState({
             searchString: '',
             filteredTodoList: this.state.todos


### PR DESCRIPTION
Fixed by passing a callback function as a property to TodoListItem, which will open the ViewTodoPanel on the selected item. A second callback function is passed to the onPress property of the HoverButton, which will call the first callback function. Note that this fix totally bypassed `VirtualListView.onItemSelected()`.