### PR TITLE
RXPTest - Adjust UserInterfaceTest number comparison

### DIFF
--- a/samples/RXPTest/src/Tests/ImageApiTest.tsx
+++ b/samples/RXPTest/src/Tests/ImageApiTest.tsx
@@ -7,6 +7,7 @@ import RX = require('reactxp');
 
 import * as CommonStyles from '../CommonStyles';
 import { AutoExecutableTest, TestResult, TestType } from '../Test';
+import { approxEquals } from '../Utilities';
 
 const _styles = {
     container: RX.Styles.createViewStyle({
@@ -123,16 +124,18 @@ class ImageView extends RX.Component<RX.CommonProps, ImageViewState> {
         if (this._testResult) {
             if (!dimensions) {
                 this._testResult.errors.push('Received undefined dimensions from onLoad');
-            } else if (dimensions.width !== image1ExpectedWidth || dimensions.height !== image1ExpectedHeight) {
-                this._testResult.errors.push('Received unexpected dimensions from onLoad');
+            } else if (!approxEquals(dimensions.width, image1ExpectedWidth) || !approxEquals(dimensions.height, image1ExpectedHeight)) {
+                this._testResult.errors.push(`Expected dimensions from onLoad to be ${image1ExpectedWidth}x${image1ExpectedHeight}. Got ${dimensions.width}x${dimensions.height}`);
             }
 
             // Now call the component back to see if we get the same dimensions.
-            if (this._image1Ref!.getNativeWidth() !== image1ExpectedWidth) {
-                this._testResult.errors.push('Received unexpected width from getNativeWidth');
+            const width = this._image1Ref!.getNativeWidth();
+            const height = this._image1Ref!.getNativeHeight();
+            if (width == null || !approxEquals(width, image1ExpectedWidth)) {
+                this._testResult.errors.push(`Expected width from getNativeWidth to be ${image1ExpectedWidth}. Got ${width}`);
             }
-            if (this._image1Ref!.getNativeHeight() !== image1ExpectedHeight) {
-                this._testResult.errors.push('Received unexpected height from getNativeHeight');
+            if (height == null || !approxEquals(height, image1ExpectedHeight)) {
+                this._testResult.errors.push(`Expected height from getNativeHeight to be ${image1ExpectedHeight}. Got ${height}`);
             }
         }
 

--- a/samples/RXPTest/src/Tests/UserInterfaceTest.tsx
+++ b/samples/RXPTest/src/Tests/UserInterfaceTest.tsx
@@ -151,20 +151,22 @@ class UserInterfaceView extends RX.Component<RX.CommonProps, UserInterfaceState>
         }).then(layoutInfo => {
             childRelative = layoutInfo;
 
-            if (parentAbsolute.height !== 100 || parentAbsolute.width !== 100) {
-                result.errors.push('Expected parent view to be 100x100.');
+            if (!this._approxEquals(parentAbsolute.height, 100) || !this._approxEquals(parentAbsolute.width, 100)) {
+                result.errors.push(`Expected parent view to be 100x100. Got ${parentAbsolute.height}x${parentAbsolute.width}`);
             }
 
-            if (childAbsolute.height !== 24 || childAbsolute.width !== 24) {
-                result.errors.push('Expected child view to be 24x24.');
+            if (!this._approxEquals(childAbsolute.height, 24) || !this._approxEquals(childAbsolute.width, 24)) {
+                result.errors.push(`Expected child view to be 24x24. Got ${childAbsolute.height}x${childAbsolute.width}`);
             }
 
-            if (childAbsolute.x - parentAbsolute.x !== 20 || childAbsolute.y - parentAbsolute.y !== 20) {
-                result.errors.push('Expected absolute position of child view to be 20x20 from parent.');
+            const xValue = childAbsolute.x - parentAbsolute.x;
+            const yValue = childAbsolute.y - parentAbsolute.y;
+            if (!this._approxEquals(xValue, 20) || !this._approxEquals(yValue, 20)) {
+                result.errors.push(`Expected absolute position of child view to be 20x20 from parent. Got ${xValue}x${yValue}`);
             }
 
-            if (childRelative.x !== 20 || childRelative.y !== 20) {
-                result.errors.push('Expected relative position of child view to be 20x20 from parent.');
+            if (!this._approxEquals(childRelative.x, 20) || !this._approxEquals(childRelative.y, 20)) {
+                result.errors.push(`Expected relative position of child view to be 20x20 from parent. Got ${childRelative.x}x${childRelative.y}`);
             }
         }).catch(err => {
             result.errors.push('Error occurred when measuring views.');
@@ -182,6 +184,13 @@ class UserInterfaceView extends RX.Component<RX.CommonProps, UserInterfaceState>
             // Mark the test as complete.
             complete(result);
         });
+    }
+
+    private _approxEquals(value1: number, value2: number, epsilon?: number): boolean {
+        if (epsilon == null) {
+            epsilon = 0.0001;
+        }
+        return Math.abs(value1 - value2) < epsilon;
     }
 }
 

--- a/samples/RXPTest/src/Tests/UserInterfaceTest.tsx
+++ b/samples/RXPTest/src/Tests/UserInterfaceTest.tsx
@@ -8,6 +8,7 @@ import SyncTasks = require('synctasks');
 
 import * as CommonStyles from '../CommonStyles';
 import { AutoExecutableTest, TestResult, TestType } from '../Test';
+import { approxEquals } from '../Utilities';
 
 const _styles = {
     container: RX.Styles.createViewStyle({
@@ -151,21 +152,21 @@ class UserInterfaceView extends RX.Component<RX.CommonProps, UserInterfaceState>
         }).then(layoutInfo => {
             childRelative = layoutInfo;
 
-            if (!this._approxEquals(parentAbsolute.height, 100) || !this._approxEquals(parentAbsolute.width, 100)) {
-                result.errors.push(`Expected parent view to be 100x100. Got ${parentAbsolute.height}x${parentAbsolute.width}`);
+            if (!approxEquals(parentAbsolute.width, 100) || !approxEquals(parentAbsolute.height, 100)) {
+                result.errors.push(`Expected parent view to be 100x100. Got ${parentAbsolute.width}x${parentAbsolute.height}`);
             }
 
-            if (!this._approxEquals(childAbsolute.height, 24) || !this._approxEquals(childAbsolute.width, 24)) {
-                result.errors.push(`Expected child view to be 24x24. Got ${childAbsolute.height}x${childAbsolute.width}`);
+            if (!approxEquals(childAbsolute.width, 24) || !approxEquals(childAbsolute.height, 24)) {
+                result.errors.push(`Expected child view to be 24x24. Got ${childAbsolute.width}x${childAbsolute.height}`);
             }
 
             const xValue = childAbsolute.x - parentAbsolute.x;
             const yValue = childAbsolute.y - parentAbsolute.y;
-            if (!this._approxEquals(xValue, 20) || !this._approxEquals(yValue, 20)) {
+            if (!approxEquals(xValue, 20) || !approxEquals(yValue, 20)) {
                 result.errors.push(`Expected absolute position of child view to be 20x20 from parent. Got ${xValue}x${yValue}`);
             }
 
-            if (!this._approxEquals(childRelative.x, 20) || !this._approxEquals(childRelative.y, 20)) {
+            if (!approxEquals(childRelative.x, 20) || !approxEquals(childRelative.y, 20)) {
                 result.errors.push(`Expected relative position of child view to be 20x20 from parent. Got ${childRelative.x}x${childRelative.y}`);
             }
         }).catch(err => {
@@ -184,13 +185,6 @@ class UserInterfaceView extends RX.Component<RX.CommonProps, UserInterfaceState>
             // Mark the test as complete.
             complete(result);
         });
-    }
-
-    private _approxEquals(value1: number, value2: number, epsilon?: number): boolean {
-        if (epsilon == null) {
-            epsilon = 0.0001;
-        }
-        return Math.abs(value1 - value2) < epsilon;
     }
 }
 

--- a/samples/RXPTest/src/Utilities.ts
+++ b/samples/RXPTest/src/Utilities.ts
@@ -1,0 +1,6 @@
+export function approxEquals(value1: number, value2: number, epsilon?: number): boolean {
+    if (epsilon == null) {
+        epsilon = 0.0001;
+    }
+    return Math.abs(value1 - value2) < epsilon;
+}


### PR DESCRIPTION
Running the RXPTest results in an error within the APIs - UserInterface test when run with the following set up:
- macOS 10.14.3
- Xcode 10.1
- Building for iPhone X simulator
- Building using command `cd ./samples/RXPTest/ && npm i && npm run ios`

When running the test I got these errors:
![Screenshot1](https://user-images.githubusercontent.com/1635228/54068221-824f1e80-429e-11e9-87bd-9a11e42eeea3.png)

The first error is expected on some older versions of React Native but the second error isn't. So I expanded the error to see what the actual values where and got this:
![Screenshot2](https://user-images.githubusercontent.com/1635228/54068223-87ac6900-429e-11e9-9d78-b87d76e15bc7.png)

So to me that just looks like a float rounding comparison issue that shouldn't actually fail the test. So this PR adds a `_approxEquals` function that compares the difference against an epsilon value to account for rounding errors. This PR also keeps my expanded error logs as I think they could help for future bug hunting. Using these code changes, I now get this:
![Screenshot3](https://user-images.githubusercontent.com/1635228/54068244-e671e280-429e-11e9-91ab-44fed5402e05.png)