### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,19 @@
   "requires": true,
   "dependencies": {
     "@types/lodash": {
-      "version": "4.14.121",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.121.tgz",
-      "integrity": "sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ=="
+      "version": "4.14.122",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.122.tgz",
+      "integrity": "sha512-9IdED8wU93ty8gP06ninox+42SBSJHp2IAamsSYMUY76mshRTeUsid/gtbl8ovnOwy8im41ib4cxTiIYMXGKew=="
     },
     "@types/prop-types": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.9.tgz",
-      "integrity": "sha512-Nha5b+jmBI271jdTMwrHiNXM+DvThjHOfyZtMX9kj/c/LUj2xiLHsG/1L3tJ8DjAoQN48cHwUwtqBotjyXaSdQ=="
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.0.tgz",
+      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg=="
     },
     "@types/react": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.3.tgz",
-      "integrity": "sha512-PjPocAxL9SNLjYMP4dfOShW/rj9FDBJGu3JFRt0zEYf77xfihB6fq8zfDpMrV6s82KnAi7F1OEe5OsQX25Ybdw==",
+      "version": "16.8.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.7.tgz",
+      "integrity": "sha512-0xbkIyrDNKUn4IJVf8JaCn+ucao/cq6ZB8O6kSzhrJub1cVSqgTArtG0qCfdERWKMEIvUbrwLXeQMqWEsyr9dA==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -32,9 +32,9 @@
       }
     },
     "@types/react-native": {
-      "version": "0.57.36",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.36.tgz",
-      "integrity": "sha512-6u2WWupQ+mVRsICZqiy3BCGi9vivluhut/+Z1dbjXKn9ms9MrCVvnyQ0jyooqhtmtRzquH6mYYNYArGYdEajjg==",
+      "version": "0.57.38",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.38.tgz",
+      "integrity": "sha512-bmY2ad/vQgP0HMT7Q7EQzirDBt5ibp+kBHclTnY7/i5MrdqE1oY+3b9NkDg3ohXlumr7p5stAG6I55nhfeUV6Q==",
       "requires": {
         "@types/prop-types": "*",
         "@types/react": "*"
@@ -174,9 +174,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
-      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
+      "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg=="
     },
     "diff": {
       "version": "3.5.0",
@@ -259,9 +259,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -288,6 +288,21 @@
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
       }
     },
     "object-assign": {
@@ -327,9 +342,9 @@
       }
     },
     "react-is": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
-      "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q=="
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
+      "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA=="
     },
     "rebound": {
       "version": "0.1.0",
@@ -389,9 +404,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
-      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
+      "integrity": "sha512-fplQqb2miLbcPhyHoMV4FU9PtNRbgmm/zI5d3SZwwmJQM6V0eodju+hplpyfhLWpmwrDNfNYU57uYRb8s0zZoQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -402,6 +417,7 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.7.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
@@ -420,9 +436,9 @@
       }
     },
     "tslint-microsoft-contrib": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz",
-      "integrity": "sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.1.0.tgz",
+      "integrity": "sha512-8DgmiPTgNQSYTjrKKv/h1aHnDd7EkGAjTxatrjfSDp5jUXENGI7Qj7qi7T8xBdTZN9Z3nb80u0NhdBBOMcQFHg==",
       "dev": true,
       "requires": {
         "tsutils": "^2.27.2 <2.29.0"
@@ -469,9 +485,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
-      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "tslint-release": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib"
   },
   "dependencies": {
-    "@types/react": "16.8.3",
-    "@types/lodash": "4.14.121",
-    "@types/react-dom": "16.8.2",
-    "@types/react-native": "0.57.36",
+    "@types/lodash": "^4.14.122",
+    "@types/react": "^16.8.7",
+    "@types/react-dom": "^16.8.2",
+    "@types/react-native": "^0.57.38",
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "rebound": "^0.1.0",
@@ -23,17 +23,17 @@
     "synctasks": "^0.3.3"
   },
   "peerDependencies": {
-    "react": "^16.5.0",
-    "react-dom": "^16.5.0",
-    "react-native": "^0.55.0",
-    "react-native-windows": "^0.55.0-rc.0"
+    "react": "16.6.3",
+    "react-dom": "16.6.3",
+    "react-native": "0.58.6",
+    "react-native-windows": "^0.57.0-rc.5"
   },
   "devDependencies": {
-    "tslint": "5.12.1",
-    "tslint-microsoft-contrib": "6.0.0",
-    "tslint-react": "3.6.0",
-    "tsutils": "3.8.0",
-    "typescript": "3.3.3"
+    "tslint": "^5.13.1",
+    "tslint-microsoft-contrib": "^6.1.0",
+    "tslint-react": "^3.6.0",
+    "tsutils": "^3.8.0",
+    "typescript": "^3.3.3333"
   },
   "homepage": "https://microsoft.github.io/reactxp/",
   "repository": {

--- a/samples/RXPTest/android/app/src/main/AndroidManifest.xml
+++ b/samples/RXPTest/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme"
+      android:usesCleartextTraffic="true"
       tools:ignore="AllowBackup,GoogleAppIndexingWarning">
       <activity
         android:name=".MainActivity"

--- a/samples/RXPTest/android/build.gradle
+++ b/samples/RXPTest/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 28
         targetSdkVersion = 28
         supportLibVersion = "28.0.0"
-        reactNativeVersion = "0.57.8"
+        reactNativeVersion = "0.58.6"
     }
     repositories {
         google()

--- a/samples/RXPTest/package.json
+++ b/samples/RXPTest/package.json
@@ -26,10 +26,10 @@
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
-    "react": "^16.8.2",
-    "react-dom": "^16.8.2",
-    "react-native": "^0.58.4",
-    "react-native-windows": "^0.57.0-rc.4",
+    "react": "16.6.3",
+    "react-dom": "16.6.3",
+    "react-native": "0.58.6",
+    "react-native-windows": "^0.57.0-rc.5",
     "reactxp": "^1.6.0-rc.2"
   }
 }


### PR DESCRIPTION
Update all the dependencies of the main package and the RXPTest sample.

I have pinned `react` to exactly version `16.6.3` and `react-native` to exactly version `0.58.6` for better reassurance of compatibility. `react-native` always seems to specify an exact version of `react` as a dependency, which I assume is so they can have an easier time providing capability between the two libraries. As of writing this, the latest version of `react-native` is `0.58.6`, which has a dependency of exactly `16.6.3` for `react` so that is what I've included. It seems to me like following how `react-native` does dependencies is a good way to go about things but if the core ReactXP maintainers have other thoughts, I'm keen to hear.

I also needed to add `android:usesCleartextTraffic="true"` to the RXPTest AndroidManifest to make Metro Bundler work on Android 9.0+ because Android 9.0+ doesn't allow HTTP by default, only HTTPS, but Metro Bundler uses HTTP.