### PR TITLE
[RN59] Make mixin application more robust View, Button

### DIFF
--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -54,7 +54,7 @@ function noop() { /* noop */ }
 
 function applyMixin(thisObj: any, mixin: {[propertyName: string]: any}, propertiesToSkip: string[]) {
     Object.getOwnPropertyNames(mixin).forEach(name => {
-        if (name !== 'constructor' && propertiesToSkip.indexOf(name) === -1) {
+        if (name !== 'constructor' && propertiesToSkip.indexOf(name) === -1 && typeof mixin[name].bind === 'function') {
             assert(
                 !(name in thisObj),
                 `An object cannot have a method with the same name as one of its mixins: "${name}"`

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -44,7 +44,7 @@ function noop() { /* noop */ }
 
 function applyMixin(thisObj: any, mixin: {[propertyName: string]: any}, propertiesToSkip: string[]) {
     Object.getOwnPropertyNames(mixin).forEach(name => {
-        if (name !== 'constructor' && propertiesToSkip.indexOf(name) === -1) {
+        if (name !== 'constructor' && propertiesToSkip.indexOf(name) === -1 && typeof mixin[name].bind === 'function') {
             assert(
                 !(name in thisObj),
                 `An object cannot have a method with the same name as one of its mixins: "${name}"`


### PR DESCRIPTION
In react-native 59, Facebook added a new arbitrary object into the Touchable mixin.
Reference: https://github.com/facebook/react-native/blame/master/Libraries/Components/Touchable/Touchable.js#L904

This causes the applyMixin methods to crash.

This commit makes the applicators skip the mixin’s attribute if it’s not bindable, restoring support for react-native 59. (This is as far as I've getting debugging, however!)