### PR TITLE
Fix Ref<T> type

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -355,7 +355,7 @@ export type ComponentBase = React.Component<any, any>;
 interface RefObject<T> {
     readonly current: T | null;
 }
-type Ref<T> = (instance: T | null) => void | RefObject<T> | null;
+type Ref<T> = { bivarianceHack(instance: T | null): void }['bivarianceHack'] | RefObject<T> | null;
 interface RefAttributes<T> {
     ref?: Ref<T>;
     key?: string | number;


### PR DESCRIPTION
The previous typing was intended to be:
```typescript
 (instance: T | null) => void |
 RefObject<T> |
 null;
```

But because of a lack of parenthesis, the actual type was:
```typescript
 (instance: T | null) => (void | RefObject<T> | null);
```
which breaks the type if you're using RefObject. 

This could be fixed by adding parenthesis like so:
```typescript
 ((instance: T | null) => void) | RefObject<T> | null;
```
But instead I copied the existing type from @types/react which also includes a hack to enable bivariance on callback refs.