### PR TITLE
Fix TextInput defaultValue not working on native platforms

### DIFF
--- a/src/native-common/TextInput.tsx
+++ b/src/native-common/TextInput.tsx
@@ -53,7 +53,7 @@ export class TextInput extends React.Component<Types.TextInputProps, TextInputSt
         super(props, context);
 
         this.state = {
-            inputValue: props.value || '',
+            inputValue: props.value !== undefined ? props.value : (props.defaultValue || ''),
             isFocused: false
         };
     }


### PR DESCRIPTION
The TextInput defaultValue prop was never being used on native platforms.

This PR updates the constructor initial state setting code to match the web code that sets the initial inputValue state.