### PR TITLE
Fix Navigation extension on web after commit 3849346b54357894e681c09c398613b1e979c806

### DIFF
--- a/extensions/navigation/src/web/Navigator.tsx
+++ b/extensions/navigation/src/web/Navigator.tsx
@@ -435,8 +435,9 @@ export class NavigatorImpl extends NavigatorBase<NavigatorState> {
             (enabledSceneNativeProps.style as any).opacity = 0;
         }
 
-        if (this.refs['scene_' + sceneIndex]) {
-            this._setNativeStyles(this.refs['scene_' + sceneIndex], enabledSceneNativeProps.style);
+        const sceneId = 'scene_' + sceneIndex;
+        if (this._sceneRefs[sceneId]) {
+            this._setNativeStyles(this._sceneRefs[sceneId], enabledSceneNativeProps.style);
         }
     }
 
@@ -555,7 +556,8 @@ export class NavigatorImpl extends NavigatorBase<NavigatorState> {
     }
 
     private _transitionSceneStyle(fromIndex: number, toIndex: number, progress: number, index: number) {
-        const viewAtIndex = this.refs['scene_' + index];
+        const sceneId = 'scene_' + index;
+        const viewAtIndex = this._sceneRefs[sceneId];
         if (viewAtIndex === undefined) {
             return;
         }


### PR DESCRIPTION
Commit 3849346b54357894e681c09c398613b1e979c806 changed some usage of `this.refs` to `this._sceneRefs` but not all, leading to reference tracking getting out of sync, which causes navigation between scenes to not always work correctly.

This PR changes a couple of remaining `this.refs`, which fixes #1057