### PR TITLE
Fix video extension to support react-native local assets.

### DIFF
--- a/docs/docs/extensions/video.md
+++ b/docs/docs/extensions/video.md
@@ -85,8 +85,8 @@ resizeMode: 'contain'|'cover'|'stretch' = 'contain';
 // Displays controls for play, pause, etc.
 showControls: boolean = false;
 
-// Source of video (URL)
-source: string;
+// Source of video (URL) or resource `id` as resolved by `require()` for `react-native` targets.
+source: string | number;
 
 // See below for supported styles
 style: ViewStyleRuleSet | ViewStyleRuleSet[] = [];

--- a/extensions/video/src/common/Types.ts
+++ b/extensions/video/src/common/Types.ts
@@ -28,7 +28,7 @@ export interface VideoInfo {
 }
 
 export interface VideoProps extends RXTypes.CommonStyledProps<RXTypes.ViewStyleRuleSet, Video> {
-    source: string;
+    source: string | number;
     accessibilityLabel?: string;
     showControls?: boolean;
     preload?: 'auto'|'metadata'|'none';

--- a/extensions/video/src/native-common/Video.tsx
+++ b/extensions/video/src/native-common/Video.tsx
@@ -32,6 +32,9 @@ class Video extends RX.Component<Types.VideoProps, VideoState> {
     }
 
     render() {
+        const source = typeof this.props.source === 'number'
+            ? this.props.source
+            : { uri: this.props.source };
         return (
             <RNVideo
                 ref={ this._onMount }
@@ -39,7 +42,7 @@ class Video extends RX.Component<Types.VideoProps, VideoState> {
                 paused={ !this.state.isPlaying }
                 muted={ this.state.isMuted }
                 repeat={ this.props.loop }
-                source={ { uri: this.props.source } }
+                source={ source }
                 style={ this.props.style }
                 onEnd={ this._onEnd }
                 onBuffer={ this._onBuffer }


### PR DESCRIPTION
In react-native local assets resolved by `require()` resolve to number. They should be passed to `react-native-video` as is.

Attempt to fix #1065.

As for now, tested on iOS target.