### PR TITLE
Fix RX.Button crash due to failed mixing

### DIFF
--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -54,7 +54,7 @@ function noop() { /* noop */ }
 
 function applyMixin(thisObj: any, mixin: {[propertyName: string]: any}, propertiesToSkip: string[]) {
     Object.getOwnPropertyNames(mixin).forEach(name => {
-        if (name !== 'constructor' && propertiesToSkip.indexOf(name) === -1 && typeof mixin[name].bind === 'function') {
+        if (name !== 'constructor' && propertiesToSkip.indexOf(name) === -1 && typeof mixin[name].bind === 'function' && mixin[name].bind) {
             assert(
                 !(name in thisObj),
                 `An object cannot have a method with the same name as one of its mixins: "${name}"`


### PR DESCRIPTION
After migrating to RN 0.59.2, I am seeing the issue described [here ](https://github.com/Microsoft/reactxp/issues/1074) crash the app on launch (reactxp@1.3.0-rc.6).

I am seeing that the applyMixin fn is failing to bind when
`name=== "withoutDefaultFocusAndBlur"`
and
`mixin[name] = { "withoutDefaultFocusAndBlur": {} }.`

Checking if the bind fn exists on the mixin[name] prototype before trying to bind fixes the issue