### PR TITLE
[FIX] Fix longPress support on web

### DIFF
--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -102,6 +102,8 @@ export class Button extends ButtonBase {
                 aria-selected={ ariaSelected }
                 aria-checked={ ariaChecked }
                 onClick={ this.onClick }
+                onTouchStart={ this._onMouseDown }
+                onTouchEnd={ this._onMouseUp }
                 onContextMenu={ this._onContextMenu }
                 onMouseDown={ this._onMouseDown }
                 onMouseUp={ this._onMouseUp }


### PR DESCRIPTION
**Issue:**
Actually the long press does not work on mobile web.

**Repro :**

```
          <RXButton style={Styles.createButtonStyle({
            width: 100,
            height: 50,
            backgroundColor: 'blue',
            alignItems: 'center'
          })}
            onPress={() => console.log('press')} //<-- trigger on both mobile and desktop
            onLongPress={() => console.log('long press')} //<-- trigger on desktop only
          >
              <Text style={{color: 'white'}}>PRESS ME</Text>
        </RXButton>
```

Also the LongPress test does work on mobile.

**Problem spoted:**
This is due to the missing binding of onTouchStart/onTouchEnd on the Button web implementation.

**Depends on** #1078 (for testing)

This commit fixes the following:

- add the missing binding onTouchStart/onTouchEnd