### PR TITLE
[TS] Improve dev experience on mobile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,9 @@ To test your change:
 3. Update dependencies: `npm i`
 4. Copy the locally-built reactxp library: `cp -r ../../dist/* ./node_modules/reactxp/dist`
 5. Rebuild the test app: `npm run web-watch` or `npm run rn-watch`
-6. If testing the web version, open the test in the browser: `open ./index.html` and run the test
+6. If testing the web version: 
+  - for desktop: open the test in the browser: `open ./index.html` and run the test
+  - for mobile: run `npm run web -- -host YOUR_LOCAL_IP` then on your mobile enter `http://YOUR_LOCAL_IP:8080`
 7. If testing one or more RN versions, open the corresponding native project and build and run the test
 
 ## Contributor License Agreement ("CLA")

--- a/samples/RXPTest/index.html
+++ b/samples/RXPTest/index.html
@@ -15,6 +15,11 @@
     *:focus {
         outline: 0;
     }
+    button,
+    button > *  {
+      -moz-user-select: none;
+      -webkit-user-select: none;
+    }
   </style>
 </head>
 <body>

--- a/samples/RXPTest/index.html
+++ b/samples/RXPTest/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset='utf-8'>
   <style>
     html, body, .app-container {

--- a/samples/RXPTest/package.json
+++ b/samples/RXPTest/package.json
@@ -10,6 +10,7 @@
     "android": "node node_modules/react-native/local-cli/cli.js run-android",
     "ios": "node node_modules/react-native/local-cli/cli.js run-ios",
     "windows": "node node_modules/react-native/local-cli/cli.js run-windows",
+    "web": "webpack-dev-server",
     "tslint": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
   },
   "devDependencies": {
@@ -24,7 +25,8 @@
     "tslint-microsoft-contrib": "^6.1.0",
     "typescript": "^3.3.3333",
     "webpack": "^4.29.6",
-    "webpack-cli": "^3.3.0"
+    "webpack-cli": "^3.3.0",
+    "webpack-dev-server": "^3.3.1"
   },
   "dependencies": {
     "react": "16.8.4",


### PR DESCRIPTION
While fixing #1077 I encountered various issues during my development experience:
- can't run index.html on mobile!
- Test app is zoomed out
- Long press triggers magnifying glass on iOS

This PR does the following:
- add `webpack-dev-server` to serves the index.html
- add instruction to run test on mobile
- add meta tag to zoom issue on mobile
- makes app test buttons unselectable