### PR TITLE
[FIX] onTouchMove on mobile web does not trigger

### DIFF
--- a/samples/RXPTest/src/Tests/ViewTouchTest.tsx
+++ b/samples/RXPTest/src/Tests/ViewTouchTest.tsx
@@ -46,6 +46,14 @@ const _styles = {
         backgroundColor: '#eee',
         borderColor: 'black',
     }),
+    testContainer4: RX.Styles.createViewStyle({
+        flex: 1,
+        height: 150,
+        margin: 20,        
+        borderWidth: 1,
+        backgroundColor: '#eee',
+        borderColor: 'black',
+    }),
     success: RX.Styles.createViewStyle({
         borderWidth: 2,
         backgroundColor: 'green'
@@ -59,6 +67,10 @@ interface TouchViewState {
     view3TouchResponderTestStart: boolean;
     view3TouchResponderTestGrant: boolean;
     view3TouchResponderTestRelease: boolean;
+    touchPositionOnPage: {
+        x: number | null
+        y: number | null
+    };
     nestedViewTouchTestParent: boolean;
     nestedViewTouchTestChild: boolean;
     pressEvent?: RX.Types.TouchEvent;
@@ -75,6 +87,10 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
             view3TouchResponderTestStart: false,
             view3TouchResponderTestGrant: false,
             view3TouchResponderTestRelease: false,
+            touchPositionOnPage: {
+                x: null,
+                y: null
+            },
             nestedViewTouchTestParent: false,
             nestedViewTouchTestChild: false,
         };
@@ -83,7 +99,7 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
     private static getTouchEventText(touchEvent?: RX.Types.TouchEvent): string {
         if (touchEvent) {
             return 'altKey = ' + touchEvent.altKey +
-                ' changedTouches.length = ' + touchEvent.changedTouches.length +
+                ' changedTouches.length = ' + (touchEvent.changedTouches && touchEvent.changedTouches.length) +
                 ' ctrlKey = ' + touchEvent.ctrlKey +
                 ' metaKey = ' + touchEvent.metaKey +
                 ' shiftKey = ' + touchEvent.shiftKey +
@@ -170,6 +186,27 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                             });
                         }}
                     />
+                </RX.View>
+                <RX.View style={ _styles.explainTextContainer }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'When touching this view, it will display the page coordinates of the touch position.' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View
+                    style={ _styles.testContainer4 }
+                    onTouchMove={ e => {
+                        const touch = e.touches[0];
+                        if (touch) {
+                            this.setState({ touchPositionOnPage: {
+                                x: Math.round(touch.pageX),
+                                y: Math.round(touch.pageY)
+                            }});
+                        }
+                    }}
+                >
+                    <RX.Text style={ _styles.labelText }>
+                        { `Touch position on page: x: ${this.state.touchPositionOnPage.x} y: ${this.state.touchPositionOnPage.y}`}
+                    </RX.Text>
                 </RX.View>
             </RX.View>
         );

--- a/samples/RXPTest/src/Tests/ViewTouchTest.tsx
+++ b/samples/RXPTest/src/Tests/ViewTouchTest.tsx
@@ -194,7 +194,7 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                 </RX.View>
                 <RX.View
                     style={ _styles.testContainer4 }
-                    onTouchMove={ e => {
+                    onResponderMove={ e => {
                         const touch = e.touches[0];
                         if (touch) {
                             this.setState({ touchPositionOnPage: {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -666,7 +666,6 @@ export interface ViewPropsShared<C = React.Component> extends CommonProps<C>, Co
     onDrop?: (e: DragEvent) => void;
     onMouseOver?: (e: MouseEvent) => void;
     onMouseMove?: (e: MouseEvent) => void;
-    onTouchMove?: (e: TouchEvent) => void;
 
     onPress?: (e: SyntheticEvent) => void;
     onLongPress?: (e: SyntheticEvent) => void;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -666,6 +666,7 @@ export interface ViewPropsShared<C = React.Component> extends CommonProps<C>, Co
     onDrop?: (e: DragEvent) => void;
     onMouseOver?: (e: MouseEvent) => void;
     onMouseMove?: (e: MouseEvent) => void;
+    onTouchMove?: (e: TouchEvent) => void;
 
     onPress?: (e: SyntheticEvent) => void;
     onLongPress?: (e: SyntheticEvent) => void;

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -358,7 +358,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RX.Vi
             onMouseOver: this.props.onMouseOver,
             onMouseMove: this.props.onMouseMove,
             // Weird things happens: ReactXP.Types.Touch is not assignable to React.Touch
-            onTouchMove: this.props.onTouchMove as React.HTMLAttributes<any>['onTouchMove'],
+            onTouchMove: this.props.onResponderMove as React.HTMLAttributes<any>['onTouchMove'],
             draggable: this.props.onDragStart ? true : undefined,
             onDragStart: this.props.onDragStart,
             onDrag: this.props.onDrag,

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -357,6 +357,8 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RX.Vi
             onMouseLeave: this.props.onMouseLeave,
             onMouseOver: this.props.onMouseOver,
             onMouseMove: this.props.onMouseMove,
+            // Weird things happens: ReactXP.Types.Touch is not assignable to React.Touch
+            onTouchMove: this.props.onTouchMove as React.HTMLAttributes<any>['onTouchMove'],
             draggable: this.props.onDragStart ? true : undefined,
             onDragStart: this.props.onDragStart,
             onDrag: this.props.onDrag,


### PR DESCRIPTION
**Depends on #1078** for testing on mobile.

**Issue:**
View.onTouchMove handler is not available on mobile web.

This commit does the following:
- bind props to div.onTouchMove handler
- add test to ViewTouch


**Note**
Weird lint error forces me to force cast the [TouchEvent handler](https://github.com/Microsoft/reactxp/pull/1079/files#diff-cb2be5fd7674a7551341c483786ef131R361)

Full error: 
```
Type '((e: TouchEvent) => void) | undefined' is not assignable to type '((event: TouchEvent<any>) => void) | undefined'.
  Type '(e: TouchEvent) => void' is not assignable to type '(event: TouchEvent<any>) => void'.
    Types of parameters 'e' and 'event' are incompatible.
      Type 'TouchEvent<any>' is not assignable to type 'TouchEvent'.
        Types of property 'changedTouches' are incompatible.
          Type 'React.TouchList' is not assignable to type 'import("/Users/***/dev/reactxp/src/common/Types").TouchList'.
            Types of property 'item' are incompatible.
              Type '(index: number) => React.Touch' is not assignable to type '(index: number) => import("/Users/***/dev/reactxp/src/common/Types").Touch'.
                Type 'Touch' is missing the following properties from type 'Touch': locationX, locationY
```