### PR TITLE
[FIX] Web mobile: can't press after a long press

### DIFF
--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -217,6 +217,10 @@ export class Button extends ButtonBase {
     }
 
     private _onMouseUp = (e: Types.SyntheticEvent) => {
+        if (this._ignoreClick) {
+            e.stopPropagation();
+            this._ignoreClick = false;
+        }
         if (this.props.onPressOut) {
             this.props.onPressOut(e);
         }

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -60,6 +60,7 @@ export class Button extends ButtonBase {
 
     private _mountedButton: HTMLButtonElement | null = null;
     private _lastMouseDownEvent: Types.SyntheticEvent | undefined;
+    private _ignoreMouseUp = false;
     private _ignoreClick = false;
     private _longPressTimer: number | undefined;
     private _isMouseOver = false;
@@ -210,16 +211,20 @@ export class Button extends ButtonBase {
                 if (this.props.onLongPress) {
                     // lastMouseDownEvent can never be undefined at this point
                     this.props.onLongPress(this._lastMouseDownEvent!);
+                    this._ignoreMouseUp = true;
                     this._ignoreClick = true;
                 }
             }, this.props.delayLongPress || _longPressTime);
         }
     }
 
-    private _onMouseUp = (e: Types.SyntheticEvent) => {
-        if (this._ignoreClick) {
+    private _onMouseUp = (e: Types.SyntheticEvent | Types.TouchEvent) => {
+        if (this._ignoreMouseUp) {
             e.stopPropagation();
-            this._ignoreClick = false;
+            // Touch event won't trigger onClick when a long press is released. So we reset the ignore flag here.
+            if ('touches' in e) {
+                this._ignoreClick = false;
+            }
         }
         if (this.props.onPressOut) {
             this.props.onPressOut(e);


### PR DESCRIPTION
## Issue
**Current behavior**
User cannot press button again just after a long press. The user mush do a double tap as a workaround.
This can be reproducted on the current test app on the long press button test on web mobile:
1- do a long press, the "Long press count" increases
2- do a press, the "Press count" does not change
3- do a press again, the "Press count" increases.

**Expected behavior**
1- do a long press, the "Long press count" should increase
2- do a press, the "Press count" should increase

## Fix
This PR does the following.
- reflect the behavior of desktop: the onMouseUp event after a longPress is canceled and the _ignoreClick flag is reset.

## QA
1- do a long press, the "Long press count" should increase
2- do a press, the "Press count" should increase