### PR TITLE
[TS] Bind remaining web touch handlers

### DIFF
--- a/samples/RXPTest/src/Tests/ButtonTest.tsx
+++ b/samples/RXPTest/src/Tests/ButtonTest.tsx
@@ -66,6 +66,19 @@ const _styles = {
     labelText: RX.Styles.createTextStyle({
         fontSize: CommonStyles.generalFontSize,
         color: 'black'
+    }),
+    dropView: RX.Styles.createTextStyle({
+        flexDirection: 'row',
+        margin: 20,
+        backgroundColor: '#4575',
+        borderWidth: 1,
+        borderColor: '#457'
+    }),
+    wait: RX.Styles.createViewStyle({
+        backgroundColor: 'orange',
+    }),
+    ready: RX.Styles.createViewStyle({
+        backgroundColor: 'green',
     })
 };
 
@@ -78,6 +91,10 @@ interface ButtonViewState {
 
     button5PressCount: number;
     button5LongPressCount: number;
+
+    longPressed: boolean;
+    onResponderReleaseReceived: boolean;
+    onPressReceived: boolean;
 }
 
 class ButtonView extends RX.Component<RX.CommonProps, ButtonViewState> {
@@ -90,7 +107,10 @@ class ButtonView extends RX.Component<RX.CommonProps, ButtonViewState> {
             button4PressOutCount: 0,
             button4PressCount: 0,
             button5PressCount: 0,
-            button5LongPressCount: 0
+            button5LongPressCount: 0,
+            longPressed: false,
+            onResponderReleaseReceived: false,
+            onPressReceived: false
         };
     }
 
@@ -267,6 +287,44 @@ class ButtonView extends RX.Component<RX.CommonProps, ButtonViewState> {
                     </RX.Text>
                 </RX.Button>
 
+                <RX.View style={ _styles.explainTextContainer } key={ 'explanation9' }>
+                    <RX.Text style={ _styles.explainText }>
+                        Long press the button and leave it to release the touch in the blue View.
+                        The View should turn green when receiving the onResponderRelease (touch) or onPress (mouse) event
+                        only when the long press has been triggered.
+                    </RX.Text>
+                </RX.View>
+                <RX.View>
+                    <RX.View 
+                        style={ [
+                            _styles.dropView,
+                            this.state.onResponderReleaseReceived || this.state.onPressReceived ? _styles.ready : undefined
+                        ] }
+                        onPress={ () => {
+                            if (this.state.longPressed) {
+                                this.setState({onPressReceived: true });
+                            }
+                        }}
+                        onResponderRelease={ () => {
+                            if (this.state.longPressed) {
+                                this.setState({onResponderReleaseReceived: true})};
+                            }
+                        }
+                    >
+                        <RX.Button
+                            style={ [_styles.button2, this.state.longPressed ? _styles.ready : _styles.wait] }
+                            onPressIn={ () => this.setState({
+                                longPressed: false,
+                                onResponderReleaseReceived: false,
+                                onPressReceived: false
+                            })}
+                            onLongPress={ () => this.setState({longPressed: true})}
+                        >
+                            <RX.Text style={ _styles.button2Text }>Long press here</RX.Text>
+                        </RX.Button>
+                        <RX.Text style={ _styles.button2Text }>Release here, on the parent View</RX.Text>
+                    </RX.View>
+                </RX.View>
             </RX.View>
         );
     }

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -234,7 +234,7 @@ export class Button extends ButtonBase {
 
         // Touch has left the button, cancel the longpress handler.
         if (this._isMouseOver && this._longPressTimer) {
-            Timers.clearTimeout(this._longPressTimer);
+            clearTimeout(this._longPressTimer);
         }
     }
 
@@ -278,7 +278,7 @@ export class Button extends ButtonBase {
         }
 
         if (this._longPressTimer) {
-            Timers.clearTimeout(this._longPressTimer);
+            clearTimeout(this._longPressTimer);
         }
     }
 
@@ -296,7 +296,7 @@ export class Button extends ButtonBase {
 
         // Cancel longpress if mouse has left.
         if (this._longPressTimer) {
-            Timers.clearTimeout(this._longPressTimer);
+            clearTimeout(this._longPressTimer);
         }
     }
 

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -234,7 +234,7 @@ export class Button extends ButtonBase {
 
         // Touch has left the button, cancel the longpress handler.
         if (this._isMouseOver && this._longPressTimer) {
-            clearTimeout(this._longPressTimer);
+            Timers.clearTimeout(this._longPressTimer);
         }
     }
 
@@ -278,7 +278,7 @@ export class Button extends ButtonBase {
         }
 
         if (this._longPressTimer) {
-            clearTimeout(this._longPressTimer);
+            Timers.clearTimeout(this._longPressTimer);
         }
     }
 
@@ -296,7 +296,7 @@ export class Button extends ButtonBase {
 
         // Cancel longpress if mouse has left.
         if (this._longPressTimer) {
-            clearTimeout(this._longPressTimer);
+            Timers.clearTimeout(this._longPressTimer);
         }
     }
 

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -357,8 +357,11 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RX.Vi
             onMouseLeave: this.props.onMouseLeave,
             onMouseOver: this.props.onMouseOver,
             onMouseMove: this.props.onMouseMove,
-            // Weird things happens: ReactXP.Types.Touch is not assignable to React.Touch
+            // Weird things happen: ReactXP.Types.Touch is not assignable to React.Touch
+            onTouchStart: this.props.onResponderStart as React.HTMLAttributes<any>['onTouchStart'],
             onTouchMove: this.props.onResponderMove as React.HTMLAttributes<any>['onTouchMove'],
+            onTouchEnd: this.props.onResponderRelease,
+            onTouchCancel: this.props.onResponderTerminate,
             draggable: this.props.onDragStart ? true : undefined,
             onDragStart: this.props.onDragStart,
             onDrag: this.props.onDrag,


### PR DESCRIPTION
**Depends on #1083**

**Following PR #1079**

This PR does the following
- bind onTouchStart to ViewProps.onResponderStart
- bind onTouchEnd to ViewProps.onResponderRelease
- bind onTouchCancel to ViewProps.onResponderTerminate
- let the  onTouchEnd of a long press bubbles up
- add a test in ButtonTest.tsx