### PR TITLE
[FIX] Web: prevent triggering longPress when pointer is outside the button

### DIFF
--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -104,6 +104,7 @@ export class Button extends ButtonBase {
                 aria-checked={ ariaChecked }
                 onClick={ this.onClick }
                 onTouchStart={ this._onMouseDown }
+                onTouchMove={ this._onTouchMove }
                 onTouchEnd={ this._onMouseUp }
                 onContextMenu={ this._onContextMenu }
                 onMouseDown={ this._onMouseDown }
@@ -215,6 +216,20 @@ export class Button extends ButtonBase {
                     this._ignoreClick = true;
                 }
             }, this.props.delayLongPress || _longPressTime);
+        }
+    }
+
+    private _onTouchMove = (e: React.SyntheticEvent<HTMLButtonElement, TouchEvent>) => {
+        const buttonRect = (e.target as HTMLButtonElement).getBoundingClientRect();
+        const isTouchOutside =
+            e.nativeEvent.touches[0].clientX < buttonRect.left ||
+            e.nativeEvent.touches[0].clientX > buttonRect.right ||
+            e.nativeEvent.touches[0].clientY < buttonRect.top ||
+            e.nativeEvent.touches[0].clientY > buttonRect.bottom;
+
+        // Touch has left the button, cancel the longpress handler.
+        if (isTouchOutside && this._longPressTimer) {
+            clearTimeout(this._longPressTimer);
         }
     }
 

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -221,14 +221,14 @@ export class Button extends ButtonBase {
 
     private _onTouchMove = (e: React.SyntheticEvent<HTMLButtonElement, TouchEvent>) => {
         const buttonRect = (e.target as HTMLButtonElement).getBoundingClientRect();
-        const isTouchOutside =
-            e.nativeEvent.touches[0].clientX < buttonRect.left ||
-            e.nativeEvent.touches[0].clientX > buttonRect.right ||
-            e.nativeEvent.touches[0].clientY < buttonRect.top ||
-            e.nativeEvent.touches[0].clientY > buttonRect.bottom;
+        this._isMouseOver =
+            e.nativeEvent.touches[0].clientX > buttonRect.left &&
+            e.nativeEvent.touches[0].clientX < buttonRect.right &&
+            e.nativeEvent.touches[0].clientY > buttonRect.top &&
+            e.nativeEvent.touches[0].clientY < buttonRect.bottom;
 
         // Touch has left the button, cancel the longpress handler.
-        if (isTouchOutside && this._longPressTimer) {
+        if (this._isMouseOver && this._longPressTimer) {
             clearTimeout(this._longPressTimer);
         }
     }
@@ -251,13 +251,15 @@ export class Button extends ButtonBase {
     }
 
     private _onMouseEnter = (e: Types.SyntheticEvent) => {
-        this._isMouseOver = true;
         this._onHoverStart(e);
     }
 
     private _onMouseLeave = (e: Types.SyntheticEvent) => {
         this._isMouseOver = false;
         this._onHoverEnd(e);
+
+        // The mouse is still down. A long press may be just happened. Re-enable the next click.
+        this._ignoreClick = false;
 
         // Cancel longpress if mouse has left.
         if (this._longPressTimer) {

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -258,6 +258,11 @@ export class Button extends ButtonBase {
     private _onMouseLeave = (e: Types.SyntheticEvent) => {
         this._isMouseOver = false;
         this._onHoverEnd(e);
+
+        // Cancel longpress if mouse has left.
+        if (this._longPressTimer) {
+            clearTimeout(this._longPressTimer);
+        }
     }
 
     // When we get focus on an element, show the hover effect on the element.

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -60,7 +60,7 @@ export class Button extends ButtonBase {
 
     private _mountedButton: HTMLButtonElement | null = null;
     private _lastMouseDownEvent: Types.SyntheticEvent | undefined;
-    private _ignoreMouseUp = false;
+    private _ignoreTouchEnd = false;
     private _ignoreClick = false;
     private _longPressTimer: number | undefined;
     private _isMouseOver = false;
@@ -105,7 +105,7 @@ export class Button extends ButtonBase {
                 onClick={ this.onClick }
                 onTouchStart={ this._onMouseDown }
                 onTouchMove={ this._onTouchMove }
-                onTouchEnd={ this._onMouseUp }
+                onTouchEnd={ this._onTouchEnd }
                 onContextMenu={ this._onContextMenu }
                 onMouseDown={ this._onMouseDown }
                 onMouseUp={ this._onMouseUp }
@@ -195,6 +195,7 @@ export class Button extends ButtonBase {
     }
 
     private _onMouseDown = (e: React.SyntheticEvent<any>) => {
+        this._isMouseOver = true;
         if (this.props.onPressIn) {
             this.props.onPressIn(e);
         }
@@ -212,8 +213,12 @@ export class Button extends ButtonBase {
                 if (this.props.onLongPress) {
                     // lastMouseDownEvent can never be undefined at this point
                     this.props.onLongPress(this._lastMouseDownEvent!);
-                    this._ignoreMouseUp = true;
-                    this._ignoreClick = true;
+
+                    if ('touches' in e) {
+                        this._ignoreTouchEnd = true;
+                    } else {
+                        this._ignoreClick = true;
+                    }
                 }
             }, this.props.delayLongPress || _longPressTime);
         }
@@ -234,15 +239,42 @@ export class Button extends ButtonBase {
     }
 
     private _onMouseUp = (e: Types.SyntheticEvent | Types.TouchEvent) => {
-        if (this._ignoreMouseUp) {
-            e.stopPropagation();
-            // Touch event won't trigger onClick when a long press is released. So we reset the ignore flag here.
-            if ('touches' in e) {
-                this._ignoreClick = false;
-            }
-        }
         if (this.props.onPressOut) {
             this.props.onPressOut(e);
+        }
+
+        if (this._longPressTimer) {
+            clearTimeout(this._longPressTimer);
+        }
+    }
+
+    /**
+     * Case where onPressOut is not triggered and the bubbling is canceled:
+     * 1- Long press > release
+     *
+     * Cases where onPressOut is triggered:
+     * 2- Long press > leave button > release touch
+     * 3- Tap
+     *
+     * Case where onPressOut is not triggered and the bubbling is NOT canceled:
+     * 4- Press in > leave button > release touch
+     */
+    private _onTouchEnd = (e: Types.SyntheticEvent | Types.TouchEvent) => {
+        if (this._isMouseOver && this._ignoreTouchEnd) {
+            /* 1 */
+            e.stopPropagation();
+        } else if (
+            /* 2 */
+            !this._isMouseOver && this._ignoreTouchEnd ||
+            /* 3 */
+            this._isMouseOver && !this._ignoreTouchEnd
+        ) {
+            if (this.props.onPressOut) {
+                this.props.onPressOut(e);
+            }
+        } else {
+            /* 4 */
+            this._ignoreTouchEnd = false;
         }
 
         if (this._longPressTimer) {

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -251,6 +251,7 @@ export class Button extends ButtonBase {
     }
 
     private _onMouseEnter = (e: Types.SyntheticEvent) => {
+        this._isMouseOver = true;
         this._onHoverStart(e);
     }
 


### PR DESCRIPTION
This PR fixes a bug which allows the long press handler to be triggered while the pointer has left the button.

**Current behavior**
1- The user presses a button and leaves it during the long press delay.
2- The counter still increases.

![bug-longpress](https://user-images.githubusercontent.com/3670794/56279002-95f46d00-6107-11e9-968d-56bb73ebf865.gif)

**Expected behavior**
1- The user presses a button and leaves it during the long press delay.
2- The counter does not increase.

This PR does the following:
- web desktop: clear the long press timer when the mouse leaves the button
- web mobile: clear the long press timer when the touch leaves the button
