### PR TITLE
[TS] Add onHoverEnd support for web touch devices

### DIFF
--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -226,16 +226,23 @@ export class Button extends ButtonBase {
 
     private _onTouchMove = (e: React.SyntheticEvent<HTMLButtonElement, TouchEvent>) => {
         const buttonRect = (e.target as HTMLButtonElement).getBoundingClientRect();
-        this._isMouseOver =
+        const wasMouseOver = this._isMouseOver;
+        const isMouseOver =
             e.nativeEvent.touches[0].clientX > buttonRect.left &&
             e.nativeEvent.touches[0].clientX < buttonRect.right &&
             e.nativeEvent.touches[0].clientY > buttonRect.top &&
             e.nativeEvent.touches[0].clientY < buttonRect.bottom;
 
         // Touch has left the button, cancel the longpress handler.
-        if (this._isMouseOver && this._longPressTimer) {
-            Timers.clearTimeout(this._longPressTimer);
+        if (wasMouseOver && !isMouseOver) {
+            if (this._longPressTimer) {
+                clearTimeout(this._longPressTimer);
+            }
+            if (this.props.onHoverEnd) {
+                this.props.onHoverEnd(e);
+            }
         }
+        this._isMouseOver = isMouseOver;
     }
 
     private _onMouseUp = (e: Types.SyntheticEvent | Types.TouchEvent) => {


### PR DESCRIPTION
### Issue

The actuel implementation of web touch prevent to trigger onTouch in this case:
1- press a button
2- leave the button (before the long press delay)
3- release

The problem is that  sometimes you need to know when the user leave the button without releasing the touch.
My use case was the Ripple implementation of Material Design.
Exemple [here](https://dagatsoin.github.io/sproutch/?selectedKind=Sproutch&selectedStory=Button&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)

I need to have the same behavior with touch and mouse:

When a user leave the button I want to be able to fade out the Ripple to let the user know that the action won't be triggered and it can safely release the touch.

This commit does the following
- trigger onHoverEnd when the touch leaves the button