### PR TITLE
[FIX] Web: ScrollViewProps.scrollEnabled does not work

### DIFF
--- a/samples/RXPTest/src/Tests/ScrollViewBasicTest.tsx
+++ b/samples/RXPTest/src/Tests/ScrollViewBasicTest.tsx
@@ -180,6 +180,22 @@ class ScrollViewView extends RX.Component<RX.CommonProps, ScrollViewState> {
                         </RX.View>
                     </RX.ScrollView>
                 </RX.View>
+
+                <RX.View style={ _styles.explainTextContainer } key={ 'explanation3' }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'Scroll is disabled' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={ _styles.scrollViewContainer }>
+                    <RX.ScrollView
+                        style={ _styles.scrollView1 }
+                        scrollEnabled={ false }
+                    >
+                        <RX.View style={ _styles.listContainer }>
+                            { numberItems }
+                        </RX.View>
+                    </RX.ScrollView>
+                </RX.View>
             </RX.View>
         );
     }

--- a/src/web/ScrollView.tsx
+++ b/src/web/ScrollView.tsx
@@ -250,16 +250,17 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
     }
 
     private _getContainerStyle(): RX.Types.ScrollViewStyleRuleSet {
+        const { scrollEnabled = true } = this.props;
         const styles: any = [{ display: 'block' }];
         const sourceStyles = this._customScrollbarEnabled ? _customStyles : _styles;
 
         styles.push(sourceStyles.defaultStyle);
 
-        if (this.props.horizontal && this.props.vertical) {
+        if (scrollEnabled && this.props.horizontal && this.props.vertical) {
             styles.push(sourceStyles.bothStyle);
-        } else if (this.props.horizontal) {
+        } else if (scrollEnabled && this.props.horizontal) {
             styles.push(sourceStyles.horizontalStyle);
-        } else {
+        } else if (scrollEnabled) {
             styles.push(sourceStyles.verticalStyle);
         }
 


### PR DESCRIPTION
## Problem: 
`scrollEnabled` has no effect on web (did not test Native)

## Repro:
- add this in ScrollViewBasicTest
```
                <RX.View style={ _styles.scrollViewContainer }>
                    <RX.ScrollView
                        style={ _styles.scrollView1 }
                        scrollEnabled={ false }
                    >
                        <RX.View style={ _styles.listContainer }>
                            { numberItems }
                        </RX.View>
                    </RX.ScrollView>
                </RX.View>
```
- the scroll is still active

## QA
- The test above is included in this PR. Run the app test and go to the last test in  ScrollViewBasic
- the scrolling is disabled

## This PR does the following 
- `scrollEnabled` is now applied properly
- add test in ScrollViewBasicTest