### PR TITLE
[TS] Add onTouchMoveCapture and onTouchStartCapture for web touch

### DIFF
--- a/docs/docs/components/view.md
+++ b/docs/docs/components/view.md
@@ -142,6 +142,8 @@ onBlur: (e: FocusEvent) => void = undefined;
 onKeyPress: (e: KeyboardEvent) => void = undefined;
 
 // Touch-specific Events
+onTouchStartCapture: (e: React.SyntheticEvent) => void = undefined;
+onTouchMoveCapture: (e: React.SyntheticEvent) => void = undefined;
 onLongPress: (e: SyntheticEvent) => void = undefined;
 onMoveShouldSetResponder: (e: React.SyntheticEvent) => boolean =
     undefined;

--- a/samples/RXPTest/src/Tests/ViewTouchTest.tsx
+++ b/samples/RXPTest/src/Tests/ViewTouchTest.tsx
@@ -54,6 +54,17 @@ const _styles = {
         backgroundColor: '#eee',
         borderColor: 'black',
     }),
+    testContainer5: RX.Styles.createViewStyle({
+        flex: 1,
+        margin: 20,        
+        padding: 20,        
+        borderWidth: 1,
+        backgroundColor: '#eee',
+        borderColor: 'black',
+    }),
+    successText: RX.Styles.createTextStyle({
+       color: 'green'
+    }),
     success: RX.Styles.createViewStyle({
         borderWidth: 2,
         backgroundColor: 'green'
@@ -74,6 +85,8 @@ interface TouchViewState {
     nestedViewTouchTestParent: boolean;
     nestedViewTouchTestChild: boolean;
     pressEvent?: RX.Types.TouchEvent;
+    didCapturedTouchIn?: boolean;
+    didCapturedTouchMove?: boolean;
 }
 
 class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
@@ -206,6 +219,25 @@ class ViewTouch extends RX.Component<RX.CommonProps, TouchViewState> {
                 >
                     <RX.Text style={ _styles.labelText }>
                         { `Touch position on page: x: ${this.state.touchPositionOnPage.x} y: ${this.state.touchPositionOnPage.y}`}
+                    </RX.Text>
+                </RX.View>
+                <RX.View style={ _styles.explainTextContainer }>
+                    <RX.Text style={ _styles.explainText }>
+                        { 'The view below shows textual representation of the capture phase of a touch in' }
+                        { '  - The text `View captured touch in` should turn green' }
+                        { '  - The text `View captured touch move` should turn green' }
+                    </RX.Text>
+                </RX.View>
+                <RX.View
+                    style={ _styles.testContainer5 }
+                    onTouchStartCapture={ () => this.setState({ didCapturedTouchIn: true }) }
+                    onTouchMoveCapture={ () => this.setState({ didCapturedTouchMove: true }) }
+                >
+                    <RX.Text style={ [_styles.labelText, this.state.didCapturedTouchIn ? _styles.successText : {}] }>
+                        View captured touch in
+                    </RX.Text>
+                    <RX.Text style={ [_styles.labelText, this.state.didCapturedTouchMove ? _styles.successText : {}] }>
+                        View captured touch move
                     </RX.Text>
                 </RX.View>
             </RX.View>

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -688,6 +688,7 @@ export interface ViewPropsShared<C = React.Component> extends CommonProps<C>, Co
     onResponderRelease?: (e: SyntheticEvent) => void;
     onResponderStart?: (e: TouchEvent) => void;
     onResponderMove?: (e: TouchEvent) => void;
+    onTouchMoveCapture?: (e: TouchEvent) => void;
     onResponderEnd?: (e: TouchEvent) => void;
     onResponderTerminate?: (e: SyntheticEvent) => void;
     onResponderTerminationRequest?: (e: SyntheticEvent) => boolean;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -688,6 +688,7 @@ export interface ViewPropsShared<C = React.Component> extends CommonProps<C>, Co
     onResponderRelease?: (e: SyntheticEvent) => void;
     onResponderStart?: (e: TouchEvent) => void;
     onResponderMove?: (e: TouchEvent) => void;
+    onTouchStartCapture?: (e: TouchEvent) => void;
     onTouchMoveCapture?: (e: TouchEvent) => void;
     onResponderEnd?: (e: TouchEvent) => void;
     onResponderTerminate?: (e: SyntheticEvent) => void;

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -359,7 +359,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RX.Vi
             onMouseMove: this.props.onMouseMove,
             // Weird things happen: ReactXP.Types.Touch is not assignable to React.Touch
             onTouchStart: this.props.onResponderStart as React.HTMLAttributes<any>['onTouchStart'],
-            onTouchStartCapture: this.props.onResponderStart as React.HTMLAttributes<any>['onTouchStartCapture'],
+            onTouchStartCapture: this.props.onTouchStartCapture as React.HTMLAttributes<any>['onTouchStartCapture'],
             onTouchMove: this.props.onResponderMove as React.HTMLAttributes<any>['onTouchMove'],
             onTouchMoveCapture: this.props.onTouchMoveCapture as React.HTMLAttributes<any>['onTouchMoveCapture'],
             onTouchEnd: this.props.onResponderRelease,

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -359,7 +359,9 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RX.Vi
             onMouseMove: this.props.onMouseMove,
             // Weird things happen: ReactXP.Types.Touch is not assignable to React.Touch
             onTouchStart: this.props.onResponderStart as React.HTMLAttributes<any>['onTouchStart'],
+            onTouchStartCapture: this.props.onResponderStart as React.HTMLAttributes<any>['onTouchStartCapture'],
             onTouchMove: this.props.onResponderMove as React.HTMLAttributes<any>['onTouchMove'],
+            onTouchMoveCapture: this.props.onTouchMoveCapture as React.HTMLAttributes<any>['onTouchMoveCapture'],
             onTouchEnd: this.props.onResponderRelease,
             onTouchCancel: this.props.onResponderTerminate,
             draggable: this.props.onDragStart ? true : undefined,


### PR DESCRIPTION
## Context
Following PR  #1082 and #1079 effort for bringing iso functionality on web touch and native touch platforms.

## This PR does the following:
This PR focus on the the touch event capture phase which is not exposed for the web platform.
To keep the API surface lean, as the previous PR, the compatible RN props will be used.
This PR does not expose all the capture phase handlers. The rest may be part of a later PR.

- add support for onTouchStartCapture for mobile web and RN
- add support for onTouchMoveCapture for mobile web and RN
- add test on `WiewTouchTest`

## QA
Do the last `WiewTouchTest` test on browser desktop in mobile device simulation or in real device browser (with `npm run web -- --host xxx.xxx.xxx.xxx`) .
- [x] The text `View captured touch in` should turn green
- [x] The text `View captured touch move` should turn green

Do the last `WiewTouchTest` test in React Native test app
- [ ] The text `View captured touch in` should turn green
- [ ] The text `View captured touch move` should turn green