### PR TITLE
[FIX] Web touch: Prevent ButtonProps.onPressIn to trigger twice

### DIFF
--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -267,6 +267,10 @@ export class Button extends ButtonBase {
      * 4- Press in > leave button > release touch
      */
     private _onTouchEnd = (e: Types.SyntheticEvent | Types.TouchEvent) => {
+        if ('touches' in e) {
+            // Stop the to event sequence to prevent trigger button.onMouseDown
+            e.preventDefault();
+        }
         if (this._isMouseOver && this._ignoreTouchEnd) {
             /* 1 */
             e.stopPropagation();

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -263,8 +263,7 @@ export class Button extends ButtonBase {
      * 2- Long press > leave button > release touch
      * 3- Tap
      *
-     * Case where onPressOut is not triggered and the bubbling is NOT canceled:
-     * 4- Press in > leave button > release touch
+     * All other cases: onPressOut is not triggered and the bubbling is NOT canceled:
      */
     private _onTouchEnd = (e: Types.SyntheticEvent | Types.TouchEvent) => {
         if (this._isMouseOver && this._ignoreTouchEnd) {
@@ -276,23 +275,23 @@ export class Button extends ButtonBase {
             /* 3 */
             this._isMouseOver && !this._ignoreTouchEnd
         ) {
+            if ('touches' in e) {
+                // Stop the to event sequence to prevent trigger button.onMouseDown
+                e.preventDefault();
+                if (this.props.onPress) {
+                    this.props.onPress(e);
+                }
+            }
+
             if (this.props.onPressOut) {
                 this.props.onPressOut(e);
             }
-        } else {
-            /* 4 */
-            this._ignoreTouchEnd = false;
         }
+
+        this._ignoreTouchEnd = false;
 
         if (this._longPressTimer) {
             Timers.clearTimeout(this._longPressTimer);
-        }
-        if ('touches' in e) {
-            // Stop the to event sequence to prevent trigger button.onMouseDown
-            e.preventDefault();
-            if (this.props.onPress) {
-                this.props.onPress(e);
-            }
         }
     }
 

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -267,10 +267,6 @@ export class Button extends ButtonBase {
      * 4- Press in > leave button > release touch
      */
     private _onTouchEnd = (e: Types.SyntheticEvent | Types.TouchEvent) => {
-        if ('touches' in e) {
-            // Stop the to event sequence to prevent trigger button.onMouseDown
-            e.preventDefault();
-        }
         if (this._isMouseOver && this._ignoreTouchEnd) {
             /* 1 */
             e.stopPropagation();
@@ -290,6 +286,13 @@ export class Button extends ButtonBase {
 
         if (this._longPressTimer) {
             Timers.clearTimeout(this._longPressTimer);
+        }
+        if ('touches' in e) {
+            // Stop the to event sequence to prevent trigger button.onMouseDown
+            e.preventDefault();
+            if (this.props.onPress) {
+                this.props.onPress(e);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem: 
On web platform with a touch screen`onPressIn` is called twice.

## Repro:
- test at the **Button with press** on a mobile device
- the PressIn count increase by 2

## This PR does the following 
- prevent `onMouseDown` to trigger after `onTouchStart`

## QA
- test at the **Button with press** on a mobile device
- the PressIn count increase by 1
