### PR TITLE
Replace external assert dependency with internal assert

### DIFF
--- a/extensions/imagesvg/package.json
+++ b/extensions/imagesvg/package.json
@@ -9,7 +9,6 @@
     "tslint": "tslint -p tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
   },
   "dependencies": {
-    "assert": "1.4.1",
     "react-native-svg": "9.3.3"
   },
   "peerDependencies": {

--- a/extensions/imagesvg/src/common/assert.ts
+++ b/extensions/imagesvg/src/common/assert.ts
@@ -1,0 +1,14 @@
+/**
+ * assert
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ *
+ */
+const assert = (cond: any, message?: string | undefined) => {
+    if (!cond) {
+        throw new Error(message || 'Assertion Failed');
+    }
+};
+
+export default assert;

--- a/extensions/imagesvg/src/native-common/ImageSvg.tsx
+++ b/extensions/imagesvg/src/native-common/ImageSvg.tsx
@@ -7,15 +7,15 @@
  * SVG (scalable vector graphics) images.
  */
 
-import * as assert from 'assert';
 import * as React from 'react';
 import * as RNSvg from 'react-native-svg';
 
+import assert from '../common/assert';
 import { ImageSvgProps } from '../common/Types';
 
 export class ImageSvg extends React.Component<ImageSvgProps, {}> {
     render() {
-        assert.ok(this.props.width && this.props.height, 'The width and height on imagesvg are mandatory.');
+        assert(this.props.width && this.props.height, 'The width and height on imagesvg are mandatory.');
 
         if (this.props.width > 0 && this.props.height > 0) {
             return (

--- a/extensions/imagesvg/src/web/ImageSvg.tsx
+++ b/extensions/imagesvg/src/web/ImageSvg.tsx
@@ -7,15 +7,15 @@
  * SVG (scalable vector graphics) images.
  */
 
-import * as assert from 'assert';
 import * as React from 'react';
 import { Styles as RXStyles } from 'reactxp';
 
+import assert from '../common/assert';
 import { ImageSvgProps } from '../common/Types';
 
 export class ImageSvg extends React.Component<ImageSvgProps, {}> {
     render() {
-        assert.ok(this.props.width && this.props.height, 'The width and height on imagesvg are mandatory.');
+        assert(this.props.width && this.props.height, 'The width and height on imagesvg are mandatory.');
 
         if (this.props.width > 0 && this.props.height > 0) {
             let combinedStyles = RXStyles.combine([{

--- a/extensions/navigation/package.json
+++ b/extensions/navigation/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@types/lodash": "4.14.123",
     "@types/node": "11.11.3",
-    "assert": "1.4.1",
     "lodash": "4.17.11",
     "rebound": "0.1.0",
     "reactxp-experimental-navigation": "1.0.14"

--- a/extensions/navigation/src/common/assert.ts
+++ b/extensions/navigation/src/common/assert.ts
@@ -1,0 +1,14 @@
+/**
+ * assert
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ *
+ */
+const assert = (cond: any, message?: string | undefined) => {
+    if (!cond) {
+        throw new Error(message || 'Assertion Failed');
+    }
+};
+
+export default assert;

--- a/extensions/navigation/src/native-common/NavigatorExperimentalDelegate.tsx
+++ b/extensions/navigation/src/native-common/NavigatorExperimentalDelegate.tsx
@@ -12,12 +12,12 @@
  * That's why we need to have the ability to pick different implementations for different platforms.
  */
 
-import * as assert from 'assert';
 import * as React from 'react';
 import * as RN from 'react-native';
 import * as RX from 'reactxp';
 import * as Navigation from 'reactxp-experimental-navigation';
 
+import assert from '../common/assert';
 import * as _ from '../common/lodashMini';
 import {
     CommandType,
@@ -333,10 +333,10 @@ export class NavigatorExperimentalDelegate extends NavigatorDelegate {
     }
 
     private _popN(state: NavigationState, n: number): NavigationState {
-        assert.ok(n > 0, 'n < 0 please pass positive value');
+        assert(n > 0, 'n < 0 please pass positive value');
         const initialRoutes = state.routes;
         const initialLength = initialRoutes.length;
-        assert.ok(initialLength >= n, 'navigation stack underflow');
+        assert(initialLength >= n, 'navigation stack underflow');
 
         let result: NavigationState = _.clone(state);
         result.routes = initialRoutes.slice(0, initialLength - n);

--- a/extensions/virtuallistview/package.json
+++ b/extensions/virtuallistview/package.json
@@ -9,7 +9,6 @@
     "tslint": "tslint --project tsconfig.json -r tslint.json --fix || true"
   },
   "dependencies": {
-    "assert": "^1.4.1",
     "lodash": "^4.17.10"
   },
   "peerDependencies": {

--- a/extensions/virtuallistview/package.json
+++ b/extensions/virtuallistview/package.json
@@ -15,7 +15,6 @@
     "reactxp": "^1.6.1"
   },
   "devDependencies": {
-    "@types/assert": "^1.4.0",
     "reactxp": "^1.6.1",
     "tslint": "5.11.0",
     "tslint-microsoft-contrib": "6.0.0",

--- a/extensions/virtuallistview/src/VirtualListCell.tsx
+++ b/extensions/virtuallistview/src/VirtualListCell.tsx
@@ -7,9 +7,10 @@
  * container for a single list item.
  */
 
-import * as assert from 'assert';
 import { createRef } from 'react';
 import * as RX from 'reactxp';
+
+import assert from './assert';
 
 export interface VirtualListCellInfo {
     key: string;
@@ -172,20 +173,20 @@ export class VirtualListCell<ItemInfo extends VirtualListCellInfo> extends RX.Co
 
     componentWillReceiveProps(nextProps: VirtualListCellProps<ItemInfo>) {
         // If it's inactive, it had better be invisible.
-        assert.ok(nextProps.isActive || !nextProps.isVisible);
+        assert(nextProps.isActive || !nextProps.isVisible);
 
-        assert.ok(nextProps.useNativeDriver === this.props.useNativeDriver);
+        assert(nextProps.useNativeDriver === this.props.useNativeDriver);
 
         // All callbacks should be prebound to optimize performance.
-        assert.ok(this.props.onLayout === nextProps.onLayout, 'onLayout callback changed');
-        assert.ok(this.props.onItemSelected === nextProps.onItemSelected, 'onItemSelected callback changed');
-        assert.ok(this.props.onItemFocused === nextProps.onItemFocused, 'onItemFocused callback changed');
-        assert.ok(this.props.onAnimateStartStop === nextProps.onAnimateStartStop, 'onAnimateStartStop callback changed');
-        assert.ok(this.props.renderItem === nextProps.renderItem, 'renderItem callback changed');
+        assert(this.props.onLayout === nextProps.onLayout, 'onLayout callback changed');
+        assert(this.props.onItemSelected === nextProps.onItemSelected, 'onItemSelected callback changed');
+        assert(this.props.onItemFocused === nextProps.onItemFocused, 'onItemFocused callback changed');
+        assert(this.props.onAnimateStartStop === nextProps.onAnimateStartStop, 'onAnimateStartStop callback changed');
+        assert(this.props.renderItem === nextProps.renderItem, 'renderItem callback changed');
 
         // We assume this prop doesn't change for perf reasons. Callers should modify
         // the key to force an unmount/remount if these need to change.
-        assert.ok(this.props.isScreenReaderModeEnabled === nextProps.isScreenReaderModeEnabled);
+        assert(this.props.isScreenReaderModeEnabled === nextProps.isScreenReaderModeEnabled);
 
         this.setItemKey(nextProps.itemKey);
 

--- a/extensions/virtuallistview/src/VirtualListView.tsx
+++ b/extensions/virtuallistview/src/VirtualListView.tsx
@@ -35,11 +35,11 @@
  *    position all in the same frame if possible.
  */
 
-import * as assert from 'assert';
 import * as _ from 'lodash';
 import { createRef, RefObject } from 'react';
 import * as RX from 'reactxp';
 
+import assert from './assert';
 import { VirtualListCell, VirtualListCellInfo, VirtualListCellRenderDetails } from './VirtualListCell';
 
 // Specifies information about each item to be displayed in the list.
@@ -372,7 +372,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
             itemIndex++;
             // Make sure there are no duplicate keys.
             if (newItemMap.has(item.key)) {
-                assert.ok(false, 'Found a duplicate key: ' + item.key);
+                assert(false, 'Found a duplicate key: ' + item.key);
                 if (props.logInfo) {
                     props.logInfo('Item with key ' + item.key + ' is duplicated at positions ' + itemIndex +
                         ' and ' + newItemMap.get(item.key)!);
@@ -628,10 +628,10 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
         if (this._isMounted) {
             const hasAnimation = this._pendingAnimations.has(itemKey);
             if (animateStart) {
-                assert.ok(!hasAnimation, 'unexpected animation start');
+                assert(!hasAnimation, 'unexpected animation start');
                 this._pendingAnimations.add(itemKey);
             } else {
-                assert.ok(hasAnimation, 'unexpected animation complete');
+                assert(hasAnimation, 'unexpected animation complete');
                 this._pendingAnimations.delete(itemKey);
 
                 // We defer this because there are cases where we can cancel animations
@@ -830,7 +830,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
             const item = props.itemList[itemIndex];
             const isHeightKnown = this._isItemHeightKnown(item);
             const itemHeight = this._getHeightOfItem(item);
-            assert.ok(itemHeight > 0, 'list items should always have non-zero height');
+            assert(itemHeight > 0, 'list items should always have non-zero height');
 
             this._itemsInRenderBlock++;
             this._heightOfRenderBlock += itemHeight;
@@ -1012,8 +1012,8 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
             newCell.top = top;
             newCell.shouldUpdate = true;
 
-            assert.ok(newCell.isHeightConstant === isHeightConstant, 'isHeightConstant assumed to not change');
-            assert.ok(newCell.itemTemplate === itemTemplate, 'itemTemplate assumed to not change');
+            assert(newCell.isHeightConstant === isHeightConstant, 'isHeightConstant assumed to not change');
+            assert(newCell.itemTemplate === itemTemplate, 'itemTemplate assumed to not change');
 
             const mountedCell = newCell.cellRef.current;
             if (mountedCell) {
@@ -1074,7 +1074,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
 
         const cellInfo = this._activeCells.get(itemKey);
         if (!cellInfo) {
-            assert.ok(false, 'Missing cell');
+            assert(false, 'Missing cell');
             return;
         }
 
@@ -1126,7 +1126,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
             const item = this.props.itemList[itemIndex];
 
             const virtualCellInfo = this._activeCells.get(item.key)!;
-            assert.ok(virtualCellInfo, 'Active Cell not found for key ' + item.key + ', index=' + i);
+            assert(virtualCellInfo, 'Active Cell not found for key ' + item.key + ', index=' + i);
 
             cellList.push({
                 cellInfo: virtualCellInfo,
@@ -1140,7 +1140,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
         }
 
         for (const virtualCellInfo of this._recycledCells) {
-            assert.ok(virtualCellInfo, 'Recycled Cells array contains a null/undefined object');
+            assert(virtualCellInfo, 'Recycled Cells array contains a null/undefined object');
             cellList.push({
                 cellInfo: virtualCellInfo,
                 item: undefined,
@@ -1362,7 +1362,7 @@ export class VirtualListView<ItemInfo extends VirtualListViewItemInfo>
             index = this._itemMap.get(this.state.lastFocusedItemKey);
 
             if (index === undefined) {
-                assert.ok(false, 'Something went wrong in finding last focused item');
+                assert(false, 'Something went wrong in finding last focused item');
                 return false;
             }
 

--- a/extensions/virtuallistview/src/assert.ts
+++ b/extensions/virtuallistview/src/assert.ts
@@ -1,0 +1,14 @@
+/**
+ * assert
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ *
+ */
+const assert = (cond: any, message?: string | undefined) => {
+    if (!cond) {
+        throw new Error(message || 'Assertion Failed');
+    }
+};
+
+export default assert;


### PR DESCRIPTION
This is a follow-up to PR #982.

That PR replaced the external assert dependency with an internal assert function in the main ReactXP code. This PR does the same with the extensions.