### PR TITLE
[FIX] Web: Prevent onLongPress and onPress on disabled button

### DIFF
--- a/samples/RXPTest/src/Tests/ButtonTest.tsx
+++ b/samples/RXPTest/src/Tests/ButtonTest.tsx
@@ -147,9 +147,8 @@ class ButtonView extends RX.Component<RX.CommonProps, ButtonViewState> {
                 <RX.Button
                     style={ _styles.button2 }
                     disabled={ true }
-                    onPress={ () => {
-                        // no-op
-                    } }
+                    onLongPress={() => alert('Long press')}
+                    onPress={() => alert('press')}
                 >
                     <RX.Text style={ _styles.button2Text }>
                         { 'Disabled Button' }

--- a/src/web/Button.tsx
+++ b/src/web/Button.tsx
@@ -195,6 +195,10 @@ export class Button extends ButtonBase {
     }
 
     private _onMouseDown = (e: React.SyntheticEvent<any>) => {
+        if (this.props.disabled) {
+            return;
+        }
+
         this._isMouseOver = true;
         if (this.props.onPressIn) {
             this.props.onPressIn(e);
@@ -246,7 +250,7 @@ export class Button extends ButtonBase {
     }
 
     private _onMouseUp = (e: Types.SyntheticEvent | Types.TouchEvent) => {
-        if (this.props.onPressOut) {
+        if (!this.props.disabled && this.props.onPressOut) {
             this.props.onPressOut(e);
         }
 


### PR DESCRIPTION
## Problem: 
`disabled` has no effect on :
- touch web: onLongPress and onPress
- mouse web: onTouchStart, onTouchEnd,  onLongPress and onPress

## Repro:
- add those two handler to the RX.Button disabled test
```
onLongPress={() => alert('Long press')}
onPress={() => alert('press')}
```
### Actual behavior
- on desktop web: the onLongPress is fired
- on mobile web: both onLongPress and onPress are fired

### Expected behavior
- nothing should be fired

## QA
- Do the RX.Button disabled test on mobile web
- [x] press the button: no alert should pop
- [x] long press the button: no alert should pop
Do the RX.Button disabled test on desktop Chrome
- [x] long press the button: no alert should pop

## This PR does the following 
- Prevent onLongPress, onMouseDown/Up when `disabled` is set on
- add test