### PR TITLE
Fixes #1102 Interpolated Values are not updated properly when tied to…

### DIFF
--- a/src/web/Animated.tsx
+++ b/src/web/Animated.tsx
@@ -193,7 +193,7 @@ export class Value extends RX.Types.AnimatedValue {
     // After an animation is stopped or completed, updates
     // the final value.
     _updateFinalValue(value: number | string) {
-        this._value = value;
+        this.setValue(value);
     }
 }
 


### PR DESCRIPTION
… timed transformations

InterpolatedValue relies on setValue of the base AnimatedValue to determine it's iner state. Directly setting the value in _updateFinalValue prevents the InterpolatedValue from getting the correct value, so animating in the reverse direction fails