### PR TITLE
Update dependencies

### DIFF
--- a/extensions/imagesvg/package.json
+++ b/extensions/imagesvg/package.json
@@ -6,25 +6,28 @@
   "license": "MIT",
   "scripts": {
     "build": "npm run tslint && tsc",
-    "tslint": "tslint -p tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
+    "tslint": "tslint -p tsconfig.json -r tslint.json --fix || true"
   },
   "dependencies": {
     "assert": "1.4.1",
-    "react-native-svg": "9.3.3"
+    "react-native-svg": "^9.5.1"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^16.4.0",
-    "react-native": "^0.55.0",
-    "react-native-windows": "^0.54.0"
+    "react": "^16.0",
+    "reactxp": "^1.6.1",
+    "react-dom": "^16.0",
+    "react-native": ">=0.57 <0.60",
+    "react-native-windows": "^0.57.1"
   },
   "devDependencies": {
-    "@types/react-native": "0.57.40",
-    "@types/node": "11.11.3",
-    "reactxp": "1.6.0",
-    "tslint": "5.14.0",
-    "tslint-microsoft-contrib": "6.1.0",
-    "typescript": "3.3.3333"
+    "@types/react-native": "^0.57.62",
+    "@types/node": "^11.13.14",
+    "reactxp": "^1.6.1",
+    "tslint": "^5.17.0",
+    "tslint-microsoft-contrib": "^6.2.0",
+    "tslint-react": "^4.0.0",
+    "tsutils": "^3.14.0",
+    "typescript": "^3.5.1"
   },
   "types": "dist/web/PluginBase.d.ts"
 }

--- a/extensions/imagesvg/tslint.json
+++ b/extensions/imagesvg/tslint.json
@@ -1,4 +1,8 @@
 {
+  "rulesDirectory": [
+      "./node_modules/tslint-microsoft-contrib",
+      "./node_modules/tslint-react/rules"
+  ],
   "rules": {
     "align": [true, "statements"],
     "class-name": true,

--- a/extensions/navigation/package.json
+++ b/extensions/navigation/package.json
@@ -16,25 +16,28 @@
     "react"
   ],
   "dependencies": {
-    "@types/lodash": "4.14.123",
-    "@types/node": "11.11.3",
     "assert": "1.4.1",
-    "lodash": "4.17.11",
-    "rebound": "0.1.0",
+    "lodash": "^4.17.11",
+    "rebound": "^0.1.0",
     "reactxp-experimental-navigation": "1.0.14"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "reactxp": "^1.6.0",
-    "react-dom": "^16.4.0",
-    "react-native": "^0.55.0",
-    "react-native-windows": "^0.54.0"
+    "react": "^16.0",
+    "reactxp": "^1.6.1",
+    "react-dom": "^16.0",
+    "react-native": ">=0.57 <0.60",
+    "react-native-windows": "^0.57.1"
   },
   "devDependencies": {
-    "@types/react-native": "0.57.40",
-    "reactxp": "^1.6.0",
-    "tslint": "5.14.0",
-    "typescript": "3.3.3333"
+    "@types/lodash": "^4.14.134",
+    "@types/node": "^11.13.14",
+    "@types/react-native": "^0.57.62",
+    "reactxp": "^1.6.1",
+    "tslint": "^5.17.0",
+    "tslint-microsoft-contrib": "^6.2.0",
+    "tslint-react": "^4.0.0",
+    "tsutils": "^3.14.0",
+    "typescript": "^3.5.1"
   },
   "author": "ReactXP Team <reactxp@microsoft.com>",
   "license": "MIT",

--- a/extensions/navigation/tslint.json
+++ b/extensions/navigation/tslint.json
@@ -1,4 +1,8 @@
 {
+  "rulesDirectory": [
+      "./node_modules/tslint-microsoft-contrib",
+      "./node_modules/tslint-react/rules"
+  ],
   "rules": {
     "align": [true, "statements"],
     "class-name": true,

--- a/extensions/video/package.json
+++ b/extensions/video/package.json
@@ -6,25 +6,28 @@
   "license": "MIT",
   "scripts": {
     "build": "npm run tslint && tsc",
-    "tslint": "tslint -p tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
+    "tslint": "tslint -p tsconfig.json -r tslint.json --fix || true"
   },
   "dependencies": {
-    "@types/lodash": "4.14.123",
-    "@types/react-native": "0.57.40",
-    "lodash": "4.17.11",
+    "lodash": "^4.17.11",
     "react-native-video": "2.3.1"
   },
   "peerDependencies": {
-    "reactxp": "^1.6.0",
-    "react-dom": "^16.4.0",
-    "react-native": "^0.55.0",
-    "react-native-windows": "^0.54.0"
+    "react": "^16.0",
+    "reactxp": "^1.6.1",
+    "react-dom": "^16.0",
+    "react-native": ">=0.57 <0.60",
+    "react-native-windows": "^0.57.1"
   },
   "devDependencies": {
-    "reactxp": "^1.6.0",
-    "typescript": "3.3.3333",
-    "tslint": "5.14.0",
-    "tslint-microsoft-contrib": "6.1.0"
+    "@types/lodash": "^4.14.134",
+    "@types/react-native": "^0.57.62",
+    "reactxp": "^1.6.1",
+    "tslint": "^5.17.0",
+    "tslint-microsoft-contrib": "^6.2.0",
+    "tslint-react": "^4.0.0",
+    "tsutils": "^3.14.0",
+    "typescript": "^3.5.1"
   },
   "types": "dist/web/PluginBase.d.ts"
 }

--- a/extensions/video/tslint.json
+++ b/extensions/video/tslint.json
@@ -1,4 +1,8 @@
 {
+  "rulesDirectory": [
+      "./node_modules/tslint-microsoft-contrib",
+      "./node_modules/tslint-react/rules"
+  ],
   "rules": {
     "align": [true, "statements"],
     "class-name": true,

--- a/extensions/virtuallistview/package.json
+++ b/extensions/virtuallistview/package.json
@@ -10,18 +10,24 @@
   },
   "dependencies": {
     "assert": "^1.4.1",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.11"
   },
   "peerDependencies": {
-    "reactxp": "^1.6.1"
+    "react": "^16.0",
+    "reactxp": "^1.6.1",
+    "react-dom": "^16.0",
+    "react-native": ">=0.57 <0.60",
+    "react-native-windows": "^0.57.1"
   },
   "devDependencies": {
     "@types/assert": "^1.4.0",
+    "@types/lodash": "^4.14.134",
     "reactxp": "^1.6.1",
-    "tslint": "5.11.0",
-    "tslint-microsoft-contrib": "6.0.0",
-    "tslint-react": "3.6.0",
-    "typescript": "3.2.1"
+    "tslint": "^5.17.0",
+    "tslint-microsoft-contrib": "^6.2.0",
+    "tslint-react": "^4.0.0",
+    "tsutils": "^3.14.0",
+    "typescript": "^3.5.1"
   },
   "homepage": "https://microsoft.github.io/reactxp/docs/extensions/virtuallistview.html",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,19 +25,22 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.123",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
+      "version": "4.14.134",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
+      "integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==",
+      "dev": true
     },
     "@types/react": {
-      "version": "16.8.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.14.tgz",
-      "integrity": "sha512-26tFVJ1omGmzIdFTFmnC5zhz1GTaqCjxgUxV4KzWvsybF42P7/j4RBn6UeO3KbHPXqKWZszMXMoI65xIWm954A==",
+      "version": "16.8.19",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.19.tgz",
+      "integrity": "sha512-QzEzjrd1zFzY9cDlbIiFvdr+YUmefuuRYrPxmkwG0UQv5XF35gFIi7a95m1bNVcFU0VimxSZ5QVGSiBmlggQXQ==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -47,14 +50,16 @@
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.4.tgz",
       "integrity": "sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
     },
     "@types/react-native": {
-      "version": "0.57.51",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.51.tgz",
-      "integrity": "sha512-0LkXPeV1Hn+5zZ0BE6RBrBJTpM2P4S+306H9lKdi220PHFwMtHt1k8SiQpqUA2yjpi+c6pFIq6H2zZGusPHT9w==",
+      "version": "0.57.62",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.62.tgz",
+      "integrity": "sha512-KdbGlJNPdUDS952y3nzMmeZ+hcbFsRW4FDs9AL+CK7FjiKEVTPeAMmrhk8eMzGnPQBtjyNcZs2uieGpwkh8GXQ==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/react": "*"
@@ -139,9 +144,10 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
-      "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
+      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==",
+      "dev": true
     },
     "diff": {
       "version": "3.5.0",
@@ -174,9 +180,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -312,9 +318,9 @@
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "react-native-webview": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-5.7.2.tgz",
-      "integrity": "sha512-sBErRnlNGHRrSTbcrmamly6DVmth3kgoInQujlvypSo0YsaVe/NRQs3wVDt5EZWg0GUwHQr+qACzOf0qeUMFVg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-5.11.0.tgz",
+      "integrity": "sha512-8hqq7Gr5tP6seWUJ5G1qmSmSo53hljhXIkZT09SX07pfAw1pbEoIMg7uYvZGk7BVkYiwIO4nkyg+M501E8CL8g==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5",
@@ -327,9 +333,9 @@
       "integrity": "sha1-BjjGGpNma7UVpYoD4c+zQCHoi3I="
     },
     "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -367,15 +373,15 @@
       "integrity": "sha512-8Gr8WHInZt5oU1q2N7ANqLSZ/TJn6bYlkqkwJJoGowFc5l81DRORgtHH9eJUpJGJsGJgYyWeVfKGVtUdTu4TEQ=="
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
     "tslint": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
-      "integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.17.0.tgz",
+      "integrity": "sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -384,7 +390,7 @@
         "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
@@ -405,9 +411,9 @@
       }
     },
     "tslint-microsoft-contrib": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.1.1.tgz",
-      "integrity": "sha512-u6tK+tgt8Z1YRJxe4kpWWEx/6FTFxdga50+osnANifsfC7BMzh8c/t/XbNntTRiwMfpHkQ9xtUjizCDLxN1Yeg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.2.0.tgz",
+      "integrity": "sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==",
       "dev": true,
       "requires": {
         "tsutils": "^2.27.2 <2.29.0"
@@ -434,18 +440,18 @@
       }
     },
     "tsutils": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.10.0.tgz",
-      "integrity": "sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
+      "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
       }
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -8,14 +8,10 @@
     "build": "npm run tslint && tsc",
     "build-release": "npm run tslint-release && tsc",
     "watch": "npm run tslint && tsc --watch",
-    "tslint": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true",
-    "tslint-release": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib"
+    "tslint": "tslint --project tsconfig.json -r tslint.json --fix || true",
+    "tslint-release": "tslint --project tsconfig.json -r tslint.json"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.123",
-    "@types/react": "^16.8.14",
-    "@types/react-dom": "^16.8.4",
-    "@types/react-native": "^0.57.51",
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "rebound": "^0.1.0",
@@ -30,12 +26,16 @@
     "react-native-windows": "^0.57.1"
   },
   "devDependencies": {
-    "react-native-webview": "^5.7.2",
-    "tslint": "^5.16.0",
-    "tslint-microsoft-contrib": "^6.1.1",
+    "@types/lodash": "^4.14.134",
+    "@types/react": "^16.8.19",
+    "@types/react-dom": "^16.8.4",
+    "@types/react-native": "^0.57.62",
+    "react-native-webview": "^5.11.0",
+    "tslint": "^5.17.0",
+    "tslint-microsoft-contrib": "^6.2.0",
     "tslint-react": "^4.0.0",
-    "tsutils": "^3.10.0",
-    "typescript": "^3.4.5"
+    "tsutils": "^3.14.0",
+    "typescript": "^3.5.1"
   },
   "homepage": "https://microsoft.github.io/reactxp/",
   "repository": {


### PR DESCRIPTION
This PR:

1. Updates all dependencies in the main library and all extensions to the latest versions
2. Moves some `@types/*` dependencies from `dependencies` to `devDependencies` as downstream users of ReactXP packages don't necessarily  need those dependencies
3. Moves some tslint rules out of the npm commands and into `tslint.json`