### PR TITLE
Fix #1112

### DIFF
--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -570,7 +570,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
     }
 
     blur() {
-        if (this._nativeComponent && this._nativeComponent.blur) {
+        if (ViewBase._supportsNativeFocusBlur && this._nativeComponent && this._nativeComponent.blur) {
             this._nativeComponent.blur();
         }
     }
@@ -587,7 +587,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
         if (this._isMounted) {
             AccessibilityUtil.setAccessibilityFocus(this);
         }
-        if (this._nativeComponent) {
+        if (ViewBase._supportsNativeFocusBlur && this._nativeComponent) {
             if (this._nativeComponent.focus) {
                 this._nativeComponent.focus();
             } else if ((this._nativeComponent as any)._component) {

--- a/src/native-common/ViewBase.tsx
+++ b/src/native-common/ViewBase.tsx
@@ -15,6 +15,7 @@ import { isEqual } from './utils/lodashMini';
 
 export abstract class ViewBase<P extends RX.Types.ViewPropsShared<C>, S, T extends RN.View | RN.ScrollView,
         C extends RX.View | RX.ScrollView> extends RX.ViewBase<P, S> {
+    protected static readonly _supportsNativeFocusBlur = RN.Platform.OS !== 'android';
     private static _defaultViewStyle: RX.Types.ViewStyleRuleSet | undefined;
     private _layoutEventValues: RX.Types.ViewOnLayoutEvent | undefined;
 


### PR DESCRIPTION
Android manages to dispatch focus calls to TextInput handling, which results in a crash. Prevent these calls from occuring