### PR TITLE
Disable drag/drop interference with GestureView panning on web

### DIFF
--- a/src/web/GestureView.tsx
+++ b/src/web/GestureView.tsx
@@ -258,6 +258,12 @@ export class GestureView extends React.Component<Types.GestureViewProps, Types.S
     }
 
     private _onMouseDown = (e: React.MouseEvent<any>) => {
+        if (this.props.onPan || this.props.onPanHorizontal || this.props.onPanVertical) {
+            // Disable mousedown default action that initiates a drag/drop operation and breaks panning with a not-allowed cursor.
+            // https://w3c.github.io/uievents/#mousedown
+            e.preventDefault();
+        }
+
         if (this.props.onLongPress) {
             this._startLongPressTimer(e);
         }


### PR DESCRIPTION
The mousedown event has a "[default action](https://w3c.github.io/uievents/#mousedown)" that sometimes starts a drag/drop operation, even for elements not marked as draggable. When this occurs while attempting a pan gesture, it changes the mouse cursor to a "not-allowed" icon and prevents further panning.

This change disables the default action when panning listeners are attached to GestureView so that it doesn't enter this state.