### PR TITLE
Breaking Change: Remove SyncTasks from reactxp core and prefer ES6 promises

### DIFF
--- a/extensions/netinfo/package.json
+++ b/extensions/netinfo/package.json
@@ -9,8 +9,7 @@
     "tslint": "tslint -p tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
   },
   "dependencies": {
-    "@react-native-community/netinfo": "^3.2.0",
-    "synctasks": "^0.3.3"
+    "@react-native-community/netinfo": "^3.2.0"
   },
   "peerDependencies": {
     "reactxp": "^2.0.0-rc.1",

--- a/extensions/netinfo/src/common/Interfaces.ts
+++ b/extensions/netinfo/src/common/Interfaces.ts
@@ -8,14 +8,13 @@
  * info. This was extracted from the reactxp core
  */
 
-import * as SyncTasks from 'synctasks';
 import SubscribableEvent from 'subscribableevent';
 
 import * as Types from './Types';
 
 export abstract class NetInfo {
-    abstract isConnected(): SyncTasks.Promise<boolean>;
-    abstract getType(): SyncTasks.Promise<Types.DeviceNetworkType>;
+    abstract isConnected(): Promise<boolean>;
+    abstract getType(): Promise<Types.DeviceNetworkType>;
     connectivityChangedEvent = new SubscribableEvent<(isConnected: boolean) => void>();
 }
 

--- a/extensions/netinfo/src/native-common/NetInfo.tsx
+++ b/extensions/netinfo/src/native-common/NetInfo.tsx
@@ -8,7 +8,6 @@
  */
 
 import * as RNNetInfo from '@react-native-community/netinfo';
-import * as SyncTasks from 'synctasks';
 
 import * as Types from '../common/Types';
 import * as Interfaces from '../common/Interfaces';
@@ -24,20 +23,16 @@ export class NetInfo extends Interfaces.NetInfo {
         RNNetInfo.addEventListener(onEventOccurredHandler);
     }
 
-    isConnected(): SyncTasks.Promise<boolean> {
-        const deferred = SyncTasks.Defer<boolean>();
-
-        RNNetInfo.fetch().then((state: RNNetInfo.NetInfoState) => {
-            deferred.resolve(state.isConnected);
+    isConnected(): Promise<boolean> {
+        return RNNetInfo.fetch().then((state: RNNetInfo.NetInfoState) => {
+            return state.isConnected;
         }).catch(() => {
-            deferred.reject('NetInfo.isConnected.fetch() failed');
+            return Promise.reject('NetInfo.isConnected.fetch() failed');
         });
-
-        return deferred.promise();
     }
 
-    getType(): SyncTasks.Promise<Types.DeviceNetworkType> {
-        return SyncTasks.fromThenable(RNNetInfo.fetch()).then((state: RNNetInfo.NetInfoState) => {
+    getType(): Promise<Types.DeviceNetworkType> {
+        return RNNetInfo.fetch().then((state: RNNetInfo.NetInfoState) => {
             return NetInfo._getNetworkTypeFromConnectionInfo(state);
         });
     }

--- a/extensions/netinfo/src/web/NetInfo.tsx
+++ b/extensions/netinfo/src/web/NetInfo.tsx
@@ -7,8 +7,6 @@
  * Web-specific implementation of the cross-platform Video abstraction.
  */
 
-import * as SyncTasks from 'synctasks';
-
 import * as Types from '../common/Types';
 import * as Interfaces from '../common/Interfaces';
 
@@ -27,12 +25,12 @@ export class NetInfo extends Interfaces.NetInfo {
         }
     }
 
-    isConnected(): SyncTasks.Promise<boolean> {
-        return SyncTasks.Resolved(navigator.onLine);
+    isConnected(): Promise<boolean> {
+        return Promise.resolve(navigator.onLine);
     }
 
-    getType(): SyncTasks.Promise<Types.DeviceNetworkType> {
-        return SyncTasks.Resolved(Types.DeviceNetworkType.Unknown);
+    getType(): Promise<Types.DeviceNetworkType> {
+        return Promise.resolve(Types.DeviceNetworkType.Unknown);
     }
 }
 

--- a/extensions/netinfo/tsconfig.json
+++ b/extensions/netinfo/tsconfig.json
@@ -11,6 +11,7 @@
         "strict": true,
         "outDir": "dist/",
         "lib": [
+            "es2015.promise",
             "es5",
             "dom"
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -367,11 +367,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "synctasks": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/synctasks/-/synctasks-0.3.3.tgz",
-      "integrity": "sha512-8Gr8WHInZt5oU1q2N7ANqLSZ/TJn6bYlkqkwJJoGowFc5l81DRORgtHH9eJUpJGJsGJgYyWeVfKGVtUdTu4TEQ=="
-    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "rebound": "^0.1.0",
-    "subscribableevent": "^1.0.1",
-    "synctasks": "^0.3.3"
+    "subscribableevent": "^1.0.1"
   },
   "peerDependencies": {
     "react": "^16.0",

--- a/samples/ImageList/src/stores/ImageStore.ts
+++ b/samples/ImageList/src/stores/ImageStore.ts
@@ -20,7 +20,7 @@ export class ImageStore extends StoreBase {
     private _searchQuery = '';
     private _images: Image[] = [];
 
-    private _request: SyncTasks.STPromise<void> | null = null;
+    private _request: SyncTasks.Promise<void> | null = null;
 
     @autoSubscribe
     getImages() {
@@ -68,7 +68,7 @@ export class ImageStore extends StoreBase {
         this._request = this._searchImages(searchQuery);
     }
 
-    private _searchImages(query: string): SyncTasks.STPromise<void> {
+    private _searchImages(query: string): SyncTasks.Promise<void> {
         return GiphyClient.searchImages(query)
             .then(images => {
                 this._images = images;

--- a/samples/RXPTest/src/Tests/LocationTest.tsx
+++ b/samples/RXPTest/src/Tests/LocationTest.tsx
@@ -158,7 +158,7 @@ class LocationView extends RX.Component<RX.CommonProps, LocationState> {
                     polledPositionHistory: this.state.polledPositionHistory +
                         '(' + this._formatError(err.code as RX.Types.LocationErrorType) + ')\n'
                 });
-            }).always(() => {
+            }).finally(() => {
                 sampleCount++;
                 if (sampleCount < totalSamplesInTest) {
                     _.delay(() => {

--- a/samples/RXPTest/src/Tests/NetworkTest.tsx
+++ b/samples/RXPTest/src/Tests/NetworkTest.tsx
@@ -4,10 +4,10 @@
 
 import _ = require('lodash');
 import RX = require('reactxp');
-import RXNetInfo, { Types as RXNetInfoTypes } from 'reactxp-netinfo'
+import RXNetInfo, { Types as RXNetInfoTypes } from 'reactxp-netinfo';
 
 import * as CommonStyles from '../CommonStyles';
-import { Test, TestResult, TestType } from '../Test';
+import { Test, TestType } from '../Test';
 
 const _styles = {
     container: RX.Styles.createViewStyle({

--- a/samples/RXPTest/src/Tests/StorageTest.tsx
+++ b/samples/RXPTest/src/Tests/StorageTest.tsx
@@ -85,7 +85,7 @@ class StorageBasicTest implements AutoExecutableTest {
             });
         }).catch(error => {
             results.errors.push('Received unexpected error from RX.Storage');
-        }).always(() => {
+        }).finally(() => {
             complete(results);
         });
     }

--- a/samples/RXPTest/src/Tests/UserInterfaceTest.tsx
+++ b/samples/RXPTest/src/Tests/UserInterfaceTest.tsx
@@ -4,7 +4,6 @@
 
 import _ = require('lodash');
 import RX = require('reactxp');
-import SyncTasks = require('synctasks');
 
 import * as CommonStyles from '../CommonStyles';
 import { AutoExecutableTest, TestResult, TestType } from '../Test';
@@ -182,7 +181,7 @@ class UserInterfaceView extends RX.Component<RX.CommonProps, UserInterfaceState>
         });
 
         // Wait for all async tasks to complete.
-        SyncTasks.all([measureTask, multiplierTask]).then(() => {
+        Promise.all([measureTask, multiplierTask]).then(() => {
             // Mark the test as complete.
             complete(result);
         });

--- a/samples/RXPTest/tsconfig.json
+++ b/samples/RXPTest/tsconfig.json
@@ -15,7 +15,13 @@
     "noImplicitReturns": true,
     "outDir": "./dist/",
     "types" : ["lodash", "react", "react-dom"],
-    "strict": true
+    "strict": true,
+    "lib": [
+        "es2015.promise",
+        "es2018.promise",
+        "es5",
+        "dom"
+    ]
   },
   "include": [
     "./src/**/*"

--- a/samples/TodoList/src/ts/app/AppBootstrapperNative.tsx
+++ b/samples/TodoList/src/ts/app/AppBootstrapperNative.tsx
@@ -17,7 +17,6 @@ import { DbProvider } from 'nosqlprovider';
 import { CordovaNativeSqliteProvider } from 'nosqlprovider/dist/CordovaNativeSqliteProvider';
 import { InMemoryProvider } from 'nosqlprovider/dist/InMemoryProvider';
 import * as RX from 'reactxp';
-import * as SyncTasks from 'synctasks';
 
 import AppBootstrapper from './AppBootstrapper';
 
@@ -32,7 +31,7 @@ class AppBootstrapperNative extends AppBootstrapper {
         ];
     }
 
-    protected _getInitialUrl(): SyncTasks.Promise<string | undefined> {
+    protected _getInitialUrl(): Promise<string | undefined> {
         return RX.Linking.getInitialUrl();
     }
 }

--- a/samples/TodoList/src/ts/app/AppBootstrapperWeb.tsx
+++ b/samples/TodoList/src/ts/app/AppBootstrapperWeb.tsx
@@ -22,7 +22,6 @@ import { DbProvider } from 'nosqlprovider';
 import { IndexedDbProvider } from 'nosqlprovider/dist/IndexedDbProvider';
 import { InMemoryProvider } from 'nosqlprovider/dist/InMemoryProvider';
 import { WebSqlProvider } from 'nosqlprovider/dist/WebSqlProvider';
-import * as SyncTasks from 'synctasks';
 
 import AppBootstrapper from './AppBootstrapper';
 
@@ -36,8 +35,8 @@ class AppBootstrapperWeb extends AppBootstrapper {
         ];
     }
 
-    protected _getInitialUrl(): SyncTasks.Promise<string | undefined> {
-        return SyncTasks.Resolved(window.location.href);
+    protected _getInitialUrl(): Promise<string | undefined> {
+        return Promise.resolve(window.location.href);
     }
 }
 

--- a/samples/TodoList/src/ts/controls/Modal.tsx
+++ b/samples/TodoList/src/ts/controls/Modal.tsx
@@ -8,7 +8,6 @@
 import * as assert from 'assert';
 import * as RX from 'reactxp';
 import { ComponentBase } from 'resub';
-import * as SyncTasks from 'synctasks';
 
 import KeyCodes from '../utilities/KeyCodes';
 import { Colors } from '../app/Styles';
@@ -198,18 +197,16 @@ export default class Modal extends ComponentBase<ModalProps, ModalState> {
         });
     }
 
-    static dismissAnimated(modalId: string): SyncTasks.Promise<void> {
+    static dismissAnimated(modalId: string): Promise<void> {
         let modal = Modal._visibleModalMap[modalId];
         if (!modal) {
-            return SyncTasks.Rejected('Modal ID not found');
+            return Promise.reject('Modal ID not found');
         }
 
-        let deferred = SyncTasks.Defer<void>();
-        modal._animateClose(() => {
-            RX.Modal.dismiss(modalId);
-            deferred.resolve(void 0);
-        });
-
-        return deferred.promise();
+        return new Promise<void>(resolve => {
+            modal._animateClose(() => {
+                RX.Modal.dismiss(modalId);
+                resolve(void 0);
+            });
     }
 }

--- a/samples/TodoList/src/ts/controls/SimpleDialog.tsx
+++ b/samples/TodoList/src/ts/controls/SimpleDialog.tsx
@@ -9,7 +9,6 @@
 import * as _ from 'lodash';
 import * as RX from 'reactxp';
 import { ComponentBase } from 'resub';
-import * as SyncTasks from 'synctasks';
 
 import KeyCodes from '../utilities/KeyCodes';
 import Modal from './Modal';
@@ -225,7 +224,7 @@ export default class SimpleDialog extends ComponentBase<SimpleDialogProps, RX.St
         return false;
     }
 
-    static dismissAnimated(dialogId: string): SyncTasks.Promise<void> {
+    static dismissAnimated(dialogId: string): Promise<void> {
         return Modal.dismissAnimated(dialogId);
     }
 }

--- a/samples/TodoList/src/ts/utilities/ShimHelpers.ts
+++ b/samples/TodoList/src/ts/utilities/ShimHelpers.ts
@@ -5,9 +5,6 @@
 * Helpers to shim various aspects of the app for React Native.
 */
 
-import * as assert from 'assert';
-import * as SyncTasks from 'synctasks';
-
 import { Options as ReSubOptions } from 'resub';
 
 import ExceptionReporter from './ExceptionReporter';
@@ -18,23 +15,6 @@ export function shimEnvironment(isDev: boolean, isNative: boolean) {
     // Set resub development options early, before autosubscriptions set themselves up.
     ReSubOptions.development = isDev;
     ReSubOptions.preventTryCatchInRender = true;
-
-    // Set SyncTasks exception rules early. We don't want to swallow any exceptions.
-    SyncTasks.config.catchExceptions = false;
-    SyncTasks.config.exceptionHandler = (err: Error) => {
-        if (!err) {
-            return;
-        }
-
-        assert.fail('Unhandled exception: ' + JSON.stringify(err));
-
-        // tslint:disable-next-line
-        throw err;
-    };
-
-    SyncTasks.config.unhandledErrorHandler = (err: any) => {
-        assert.fail('Unhandled rejected SyncTask. Error: ' + JSON.stringify(err));
-    };
 
     // Install our exception-reporting alert on local builds.
     let exceptionReporter = new ExceptionReporter();

--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -10,7 +10,6 @@
 
 import * as React from 'react';
 import SubscribableEvent from 'subscribableevent';
-import * as SyncTasks from 'synctasks';
 
 import AppConfig from './AppConfig';
 import * as Types from './Types';
@@ -74,13 +73,13 @@ export abstract class UserInterface {
 
     // Measurements
     abstract measureLayoutRelativeToWindow(component: React.Component<any>):
-        SyncTasks.Promise<Types.LayoutInfo>;
+        Promise<Types.LayoutInfo>;
     abstract measureLayoutRelativeToAncestor(component: React.Component<any>,
-        ancestor: React.Component<any>): SyncTasks.Promise<Types.LayoutInfo>;
+        ancestor: React.Component<any>): Promise<Types.LayoutInfo>;
     abstract measureWindow(rootViewId?: string): Types.Dimensions;
 
     // Content Size Multiplier
-    abstract getContentSizeMultiplier(): SyncTasks.Promise<number>;
+    abstract getContentSizeMultiplier(): Promise<number>;
     contentSizeMultiplierChangedEvent = new SubscribableEvent<(multiplier: number) => void>();
     abstract setMaxContentSizeMultiplier(maxContentSizeMultiplier: number): void;
 
@@ -113,13 +112,13 @@ export abstract class Popup {
 
 export abstract class Linking {
     // Incoming deep links
-    abstract getInitialUrl(): SyncTasks.Promise<string | undefined>;
+    abstract getInitialUrl(): Promise<string | undefined>;
     deepLinkRequestEvent = new SubscribableEvent<(url: string) => void>();
 
     // Outgoing deep links
-    abstract openUrl(url: string): SyncTasks.Promise<void>;
-    abstract launchSms(smsData: Types.SmsInfo): SyncTasks.Promise<void>;
-    abstract launchEmail(emailData: Types.EmailInfo): SyncTasks.Promise<void>;
+    abstract openUrl(url: string): Promise<void>;
+    abstract launchSms(smsData: Types.SmsInfo): Promise<void>;
+    abstract launchEmail(emailData: Types.EmailInfo): Promise<void>;
 
     protected abstract _createEmailUrl(emailInfo: Types.EmailInfo): string;
 }
@@ -151,8 +150,8 @@ export class Component<P, T> extends React.Component<P, T> {}
 export interface ImageConstructor {
     new (props: Types.ImageProps): Image;
 
-    prefetch(url: string): SyncTasks.Promise<boolean>;
-    getMetadata(url: string): SyncTasks.Promise<Types.ImageMetadata>;
+    prefetch(url: string): Promise<boolean>;
+    getMetadata(url: string): Promise<Types.ImageMetadata>;
 }
 
 export abstract class Image extends React.Component<Types.ImageProps> {
@@ -162,7 +161,7 @@ export abstract class Image extends React.Component<Types.ImageProps> {
 
 export abstract class Clipboard {
     abstract setText(text: string): void;
-    abstract getText(): SyncTasks.Promise<string>;
+    abstract getText(): Promise<string>;
 }
 
 export abstract class Link extends React.Component<Types.LinkProps> implements FocusableComponent {
@@ -172,18 +171,18 @@ export abstract class Link extends React.Component<Types.LinkProps> implements F
 }
 
 export abstract class Storage {
-    abstract getItem(key: string): SyncTasks.Promise<string | undefined>;
-    abstract setItem(key: string, value: string): SyncTasks.Promise<void>;
-    abstract removeItem(key: string): SyncTasks.Promise<void>;
-    abstract clear(): SyncTasks.Promise<void>;
+    abstract getItem(key: string): Promise<string | undefined>;
+    abstract setItem(key: string, value: string): Promise<void>;
+    abstract removeItem(key: string): Promise<void>;
+    abstract clear(): Promise<void>;
 }
 
 export abstract class Location {
     abstract isAvailable(): boolean;
     abstract setConfiguration(config: LocationConfiguration): void;
-    abstract getCurrentPosition(options?: PositionOptions): SyncTasks.Promise<Position>;
+    abstract getCurrentPosition(options?: PositionOptions): Promise<Position>;
     abstract watchPosition(successCallback: Types.LocationSuccessCallback, errorCallback?: Types.LocationFailureCallback,
-        options?: PositionOptions): SyncTasks.Promise<Types.LocationWatchId>;
+        options?: PositionOptions): Promise<Types.LocationWatchId>;
     abstract clearWatch(watchID: Types.LocationWatchId): void;
 }
 

--- a/src/common/Linking.ts
+++ b/src/common/Linking.ts
@@ -7,8 +7,6 @@
  * Common implementation for deep linking.
  */
 
-import * as SyncTasks from 'synctasks';
-
 import * as RX from './Interfaces';
 import { filter } from './lodashMini';
 
@@ -23,17 +21,17 @@ const emailHostRegex = /^[a-z0-9.-]+$/i;
 const emailHostConstraintViolationRegex = /\.\.|^[.-]|[.-]$|\.-|-\./i;
 
 export abstract class Linking extends RX.Linking {
-    protected abstract _openUrl(url: string): SyncTasks.Promise<void>;
+    protected abstract _openUrl(url: string): Promise<void>;
 
     // Launches SMS app
-    launchSms(phoneInfo: RX.Types.SmsInfo): SyncTasks.Promise<void> {
+    launchSms(phoneInfo: RX.Types.SmsInfo): Promise<void> {
         // Format phone info
         const phoneUrl = this._createSmsUrl(phoneInfo);
         return this._openUrl(phoneUrl);
     }
 
     // Opens url
-    openUrl(url: string): SyncTasks.Promise<void> {
+    openUrl(url: string): Promise<void> {
         return this._openUrl(url);
     }
 

--- a/src/common/utils/PromiseDefer.ts
+++ b/src/common/utils/PromiseDefer.ts
@@ -1,0 +1,49 @@
+
+/**
+ * PromiseDefer.ts
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ *
+ * Creates a deferral object that wraps promises with easier to use type-safety
+ */
+
+import Timers from './Timers';
+
+export class Defer<T> {
+    private _promise: Promise<T>;
+    private _resolver: ((value: T) => void) | undefined;
+    private _rejector: ((value: any) => void) | undefined;
+    constructor() {
+        this._promise = new Promise<T>((res, rej) => {
+            this._resolver = res;
+            this._rejector = rej;
+        });
+    }
+
+    resolve(value: T) {
+        // Resolver shouldn't be undefined, but it's technically possible
+        if (!this._resolver) {
+            Timers.setTimeout(() => {
+                this.resolve(value);
+            }, 10);
+            return;
+        }
+        this._resolver(value);
+    }
+
+    reject(value: any) {
+        // Rejector shouldn't be undefined, but it's technically possible
+        if (!this._rejector) {
+            Timers.setTimeout(() => {
+                this.reject(value);
+            }, 10);
+            return;
+        }
+        this._rejector(value);
+    }
+
+    promise(): Promise<T> {
+        return this._promise;
+    }
+}

--- a/src/native-common/Clipboard.ts
+++ b/src/native-common/Clipboard.ts
@@ -8,7 +8,6 @@
  */
 
 import * as RN from 'react-native';
-import * as SyncTasks from 'synctasks';
 
 import * as RX from '../common/Interfaces';
 
@@ -17,8 +16,8 @@ export class Clipboard extends RX.Clipboard  {
         RN.Clipboard.setString(text);
     }
 
-    getText(): SyncTasks.Promise<string> {
-        return SyncTasks.fromThenable(RN.Clipboard.getString());
+    getText(): Promise<string> {
+        return RN.Clipboard.getString();
     }
 }
 

--- a/src/native-common/Image.tsx
+++ b/src/native-common/Image.tsx
@@ -10,10 +10,10 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as RN from 'react-native';
-import * as SyncTasks from 'synctasks';
 
 import { DEFAULT_RESIZE_MODE } from '../common/Image';
 import { Types } from '../common/Interfaces';
+import { Defer } from '../common/utils/PromiseDefer';
 
 import * as _ from './utils/lodashMini';
 import Platform from './Platform';
@@ -43,16 +43,16 @@ export class Image extends React.Component<Types.ImageProps, ImageState> impleme
         isRxParentAText: PropTypes.bool.isRequired
     };
 
-    static prefetch(url: string): SyncTasks.Promise<boolean> {
-        return SyncTasks.fromThenable(RN.Image.prefetch(url));
+    static prefetch(url: string): Promise<boolean> {
+        return RN.Image.prefetch(url);
     }
 
-    static getMetadata(url: string): SyncTasks.Promise<Types.ImageMetadata> {
-        return SyncTasks.fromThenable(Image.prefetch(url)).then(success => {
+    static getMetadata(url: string): Promise<Types.ImageMetadata> {
+        return Image.prefetch(url).then(success => {
             if (!success) {
-                return SyncTasks.Rejected(`Prefetching url ${ url } did not succeed.`);
+                return Promise.reject(`Prefetching url ${ url } did not succeed.`);
             } else {
-                const defer = SyncTasks.Defer<Types.ImageMetadata>();
+                const defer = new Defer<Types.ImageMetadata>();
                 RN.Image.getSize(url, (width, height) => {
                     defer.resolve({ width, height });
                 }, error => {

--- a/src/native-common/Linking.ts
+++ b/src/native-common/Linking.ts
@@ -8,7 +8,6 @@
  */
 
 import * as RN from 'react-native';
-import * as SyncTasks from 'synctasks';
 
 import { Types } from '../common/Interfaces';
 import { Linking as CommonLinking } from '../common/Linking';
@@ -22,8 +21,8 @@ export class Linking extends CommonLinking {
         });
     }
 
-    protected _openUrl(url: string): SyncTasks.Promise<void> {
-        return SyncTasks.fromThenable(RN.Linking.canOpenURL(url))
+    protected _openUrl(url: string): Promise<void> {
+        return RN.Linking.canOpenURL(url)
         .then(value => {
             if (!value) {
                 const linkingError: Types.LinkingErrorInfo = {
@@ -31,9 +30,9 @@ export class Linking extends CommonLinking {
                     url: url,
                     description: 'No app found to handle url: ' + url
                 };
-                return SyncTasks.Rejected(linkingError);
+                return Promise.reject(linkingError);
             } else {
-                return SyncTasks.fromThenable(RN.Linking.openURL(url));
+                return RN.Linking.openURL(url);
             }
         }).catch(error => {
             const linkingError: Types.LinkingErrorInfo = {
@@ -41,24 +40,24 @@ export class Linking extends CommonLinking {
                 url: url,
                 description: error
             };
-            return SyncTasks.Rejected(linkingError);
+            return Promise.reject(linkingError);
         });
     }
 
-    getInitialUrl(): SyncTasks.Promise<string | undefined> {
-        return SyncTasks.fromThenable(RN.Linking.getInitialURL())
+    getInitialUrl(): Promise<string | undefined> {
+        return RN.Linking.getInitialURL()
         .then(url => !!url ? url : undefined)
         .catch(error => {
             const linkingError: Types.LinkingErrorInfo = {
                 code: Types.LinkingErrorCode.InitialUrlNotFound,
                 description: error
             };
-            return SyncTasks.Rejected(linkingError);
+            return Promise.reject(linkingError);
         });
     }
 
     // Launches Email app
-    launchEmail(emailInfo: Types.EmailInfo): SyncTasks.Promise<void> {
+    launchEmail(emailInfo: Types.EmailInfo): Promise<void> {
         // Format email info
         const emailUrl = this._createEmailUrl(emailInfo);
         return this._openUrl(emailUrl);

--- a/src/native-common/Storage.ts
+++ b/src/native-common/Storage.ts
@@ -8,13 +8,13 @@
  */
 
 import * as RN from 'react-native';
-import * as SyncTasks from 'synctasks';
 
 import * as RX from '../common/Interfaces';
+import { Defer } from '../common/utils/PromiseDefer';
 
 export class Storage extends RX.Storage {
-    getItem(key: string): SyncTasks.Promise<string | undefined> {
-        const deferred = SyncTasks.Defer<string | undefined>();
+    getItem(key: string): Promise<string | undefined> {
+        const deferred = new Defer<string | undefined>();
 
         RN.AsyncStorage.getItem(key, (error: any, result: string | undefined) => {
             if (!error) {
@@ -29,8 +29,8 @@ export class Storage extends RX.Storage {
         return deferred.promise();
     }
 
-    setItem(key: string, value: string): SyncTasks.Promise<void> {
-        const deferred = SyncTasks.Defer<void>();
+    setItem(key: string, value: string): Promise<void> {
+        const deferred = new Defer<void>();
 
         RN.AsyncStorage.setItem(key, value, (error: any) => {
             if (!error) {
@@ -45,8 +45,8 @@ export class Storage extends RX.Storage {
         return deferred.promise();
     }
 
-    removeItem(key: string): SyncTasks.Promise<void> {
-        const deferred = SyncTasks.Defer<void>();
+    removeItem(key: string): Promise<void> {
+        const deferred = new Defer<void>();
 
         RN.AsyncStorage.removeItem(key, (error: any) => {
             if (!error) {
@@ -61,8 +61,8 @@ export class Storage extends RX.Storage {
         return deferred.promise();
     }
 
-    clear(): SyncTasks.Promise<void> {
-        const deferred = SyncTasks.Defer<void>();
+    clear(): Promise<void> {
+        const deferred = new Defer<void>();
 
         RN.AsyncStorage.clear((error: any) => {
             if (!error) {

--- a/src/native-common/UserInterface.tsx
+++ b/src/native-common/UserInterface.tsx
@@ -10,11 +10,11 @@
 
 import * as React from 'react';
 import * as RN from 'react-native';
-import * as SyncTasks from 'synctasks';
 
 import AppConfig from '../common/AppConfig';
 import assert from '../common/assert';
 import * as RX from '../common/Interfaces';
+import { Defer } from '../common/utils/PromiseDefer';
 
 import MainViewStore from './MainViewStore';
 
@@ -34,9 +34,9 @@ export class UserInterface extends RX.UserInterface {
     }
 
     measureLayoutRelativeToWindow(component: React.Component<any, any>):
-        SyncTasks.Promise<RX.Types.LayoutInfo> {
+        Promise<RX.Types.LayoutInfo> {
 
-        const deferred = SyncTasks.Defer<RX.Types.LayoutInfo>();
+        const deferred = new Defer<RX.Types.LayoutInfo>();
         const nodeHandle = RN.findNodeHandle(component);
 
         assert(!!nodeHandle);
@@ -56,9 +56,9 @@ export class UserInterface extends RX.UserInterface {
     }
 
     measureLayoutRelativeToAncestor(component: React.Component<any, any>,
-        ancestor: React.Component<any, any>): SyncTasks.Promise<RX.Types.LayoutInfo> {
+        ancestor: React.Component<any, any>): Promise<RX.Types.LayoutInfo> {
 
-        const deferred = SyncTasks.Defer<RX.Types.LayoutInfo>();
+        const deferred = new Defer<RX.Types.LayoutInfo>();
         const nodeHandle = RN.findNodeHandle(component);
         const ancestorNodeHander = RN.findNodeHandle(ancestor);
 
@@ -100,8 +100,8 @@ export class UserInterface extends RX.UserInterface {
         };
     }
 
-    getContentSizeMultiplier(): SyncTasks.Promise<number> {
-        const deferred = SyncTasks.Defer<number>();
+    getContentSizeMultiplier(): Promise<number> {
+        const deferred = new Defer<number>();
 
         // TODO: #727532 Remove conditional after implementing UIManager.getContentSizeMultiplier for UWP
         // TODO:(alregner) Remove conditional after implementing UIManager.getContentSizeMultiplier for macos
@@ -114,8 +114,8 @@ export class UserInterface extends RX.UserInterface {
         return deferred.promise();
     }
 
-    getMaxContentSizeMultiplier(): SyncTasks.Promise<number> {
-        const deferred = SyncTasks.Defer<number>();
+    getMaxContentSizeMultiplier(): Promise<number> {
+        const deferred = new Defer<number>();
 
         // TODO: #727532 Remove conditional after implementing UIManager.getContentSizeMultiplier for UWP
         // TODO:(alregner) Remove conditional after implementing UIManager.getContentSizeMultiplier for macos

--- a/src/web/Clipboard.ts
+++ b/src/web/Clipboard.ts
@@ -7,8 +7,6 @@
  * Web-specific implementation of the cross-platform Clipboard abstraction.
  */
 
-import * as SyncTasks from 'synctasks';
-
 import * as RX from '../common/Interfaces';
 
 export class Clipboard extends RX.Clipboard {
@@ -21,10 +19,10 @@ export class Clipboard extends RX.Clipboard {
         document.body.removeChild(node);
     }
 
-    getText(): SyncTasks.Promise<string> {
+    getText(): Promise<string> {
         // Not supported in web platforms. This should can be only handled
         // in the paste event handlers.
-       return SyncTasks.Rejected<string>('Not supported on web');
+       return Promise.reject<string>('Not supported on web');
     }
 
     private static _createInvisibleNode(): HTMLTextAreaElement {

--- a/src/web/Image.tsx
+++ b/src/web/Image.tsx
@@ -9,11 +9,11 @@
 
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import * as SyncTasks from 'synctasks';
 
 import assert from '../common/assert';
 import { DEFAULT_RESIZE_MODE } from '../common/Image';
 import { Types } from '../common/Interfaces';
+import { Defer } from '../common/utils/PromiseDefer';
 
 import * as _ from './utils/lodashMini';
 import restyleForInlineText from './utils/restyleForInlineText';
@@ -136,8 +136,8 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         return { isRxParentAText: false };
     }
 
-    static prefetch(url: string): SyncTasks.Promise<boolean> {
-        const defer = SyncTasks.Defer<boolean>();
+    static prefetch(url: string): Promise<boolean> {
+        const defer = new Defer<boolean>();
 
         const img = new window.Image();
 
@@ -157,8 +157,8 @@ export class Image extends React.Component<Types.ImageProps, ImageState> {
         return defer.promise();
     }
 
-    static getMetadata(url: string): SyncTasks.Promise<Types.ImageMetadata> {
-        const defer = SyncTasks.Defer<Types.ImageMetadata>();
+    static getMetadata(url: string): Promise<Types.ImageMetadata> {
+        const defer = new Defer<Types.ImageMetadata>();
 
         const img = new window.Image();
 

--- a/src/web/Linking.ts
+++ b/src/web/Linking.ts
@@ -7,13 +7,11 @@
  * Web-specific implementation for deep linking
  */
 
-import * as SyncTasks from 'synctasks';
-
 import { Types } from '../common/Interfaces';
 import { Linking as CommonLinking } from '../common/Linking';
 
 export class Linking extends CommonLinking {
-    protected _openUrl(url: string): SyncTasks.Promise<void> {
+    protected _openUrl(url: string): Promise<void> {
         const otherWindow = window.open();
         if (!otherWindow) {
             // window opening was blocked by browser (probably not
@@ -24,7 +22,7 @@ export class Linking extends CommonLinking {
                 url: url,
                 description: 'Window was blocked by popup blocker'
             };
-            return SyncTasks.Rejected<void>(linkingError);
+            return Promise.reject<void>(linkingError);
         }
         // SECURITY WARNING:
         //   Destroy the back-link to this window. Otherwise the (untrusted) URL we are about to load can redirect OUR window.
@@ -36,19 +34,19 @@ export class Linking extends CommonLinking {
         }
         otherWindow.location.href = url;
 
-        return SyncTasks.Resolved<void>();
+        return Promise.resolve<void>(void 0);
     }
 
-    launchEmail(emailInfo: Types.EmailInfo): SyncTasks.Promise<void> {
+    launchEmail(emailInfo: Types.EmailInfo): Promise<void> {
         // Format email info
         const emailUrl = this._createEmailUrl(emailInfo);
         window.location.href = emailUrl;
 
-        return SyncTasks.Resolved<void>();
+        return Promise.resolve<void>(void 0);
     }
 
-    getInitialUrl(): SyncTasks.Promise<string | undefined> {
-        return SyncTasks.Resolved(undefined);
+    getInitialUrl(): Promise<string | undefined> {
+        return Promise.resolve(undefined);
     }
 }
 

--- a/src/web/ScrollView.tsx
+++ b/src/web/ScrollView.tsx
@@ -209,6 +209,8 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
                 if (this.props.scrollYAnimatedValue) {
                     this.props.scrollYAnimatedValue.setValue(container.scrollTop);
                 }
+            }).catch(e => {
+                console.warn('ScrollView onLayout exception: ' + JSON.stringify(e));
             });
         }
     }, (this.props.scrollEventThrottle || _defaultScrollThrottleValue), { leading: true, trailing: true });

--- a/src/web/Storage.ts
+++ b/src/web/Storage.ts
@@ -7,33 +7,31 @@
  * Web-specific implementation of the cross-platform database storage abstraction.
  */
 
-import * as SyncTasks from 'synctasks';
-
 import * as RX from '../common/Interfaces';
 
 export class Storage extends RX.Storage {
-    getItem(key: string): SyncTasks.Promise<string | undefined> {
+    getItem(key: string): Promise<string | undefined> {
         const value = window.localStorage.getItem(key);
-        return SyncTasks.Resolved<string | undefined>(value === null ? undefined : value);
+        return Promise.resolve<string | undefined>(value === null ? undefined : value);
     }
 
-    setItem(key: string, value: string): SyncTasks.Promise<void> {
+    setItem(key: string, value: string): Promise<void> {
         try {
             window.localStorage.setItem(key, value);
         } catch (e) {
-            return SyncTasks.Rejected(e);
+            return Promise.resolve(e);
         }
-        return SyncTasks.Resolved<void>();
+        return Promise.resolve<void>(void 0);
     }
 
-    removeItem(key: string): SyncTasks.Promise<void> {
+    removeItem(key: string): Promise<void> {
         window.localStorage.removeItem(key);
-        return SyncTasks.Resolved<void>();
+        return Promise.resolve<void>(void 0);
     }
 
-    clear(): SyncTasks.Promise<void> {
+    clear(): Promise<void> {
         window.localStorage.clear();
-        return SyncTasks.Resolved<void>();
+        return Promise.resolve<void>(void 0);
     }
 }
 

--- a/src/web/UserInterface.ts
+++ b/src/web/UserInterface.ts
@@ -10,9 +10,9 @@
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as SyncTasks from 'synctasks';
 
 import * as RX from '../common/Interfaces';
+import { Defer } from '../common/utils/PromiseDefer';
 
 import FrontLayerViewManager from './FrontLayerViewManager';
 import ScrollViewConfig from './ScrollViewConfig';
@@ -26,9 +26,9 @@ export class UserInterface extends RX.UserInterface {
     }
 
     measureLayoutRelativeToWindow(component: React.Component<any, any>) :
-            SyncTasks.Promise<RX.Types.LayoutInfo> {
+            Promise<RX.Types.LayoutInfo> {
 
-        const deferred = SyncTasks.Defer<RX.Types.LayoutInfo>();
+        const deferred = new Defer<RX.Types.LayoutInfo>();
         let componentDomNode: HTMLElement | null = null;
 
         try {
@@ -54,9 +54,9 @@ export class UserInterface extends RX.UserInterface {
     }
 
     measureLayoutRelativeToAncestor(component: React.Component<any, any>,
-        ancestor: React.Component<any, any>) : SyncTasks.Promise<RX.Types.LayoutInfo> {
+        ancestor: React.Component<any, any>) : Promise<RX.Types.LayoutInfo> {
 
-        const deferred = SyncTasks.Defer<RX.Types.LayoutInfo>();
+        const deferred = new Defer<RX.Types.LayoutInfo>();
         let componentDomNode: HTMLElement | null = null;
         let ancestorDomNode: HTMLElement | null = null;
 
@@ -94,16 +94,16 @@ export class UserInterface extends RX.UserInterface {
         };
     }
 
-    getContentSizeMultiplier(): SyncTasks.Promise<number> {
+    getContentSizeMultiplier(): Promise<number> {
         // Browsers don't support font-specific scaling. They scale all of their
         // UI elements the same.
-        return SyncTasks.Resolved(1);
+        return Promise.resolve(1);
     }
 
-    getMaxContentSizeMultiplier(): SyncTasks.Promise<number> {
+    getMaxContentSizeMultiplier(): Promise<number> {
         // Browsers don't support font-specific scaling. They scale all of their
         // UI elements the same.
-        return SyncTasks.Resolved(0);
+        return Promise.resolve(0);
     }
 
     setMaxContentSizeMultiplier(maxContentSizeMultiplier: number) {

--- a/src/windows/Button.tsx
+++ b/src/windows/Button.tsx
@@ -172,6 +172,8 @@ export class Button extends ButtonBase implements React.ChildContextProvider<But
                                     this.props.onContextMenu(mouseEvent);
                                 }
                             }
+                        }).catch(e => {
+                            console.warn('Button measureKayoutRelativeToWindow exception: ' + JSON.stringify(e));
                         });
                     }
                 }

--- a/src/windows/Link.tsx
+++ b/src/windows/Link.tsx
@@ -209,6 +209,8 @@ export class Link extends LinkBase<LinkState> implements FocusManagerFocusableCo
                                 this.props.onContextMenu(mouseEvent);
                             }
                         }
+                    }).catch(e => {
+                        console.warn('Link measureKayoutRelativeToWindow exception: ' + JSON.stringify(e));
                     });
                 }
             }

--- a/src/windows/View.tsx
+++ b/src/windows/View.tsx
@@ -183,6 +183,8 @@ export class View extends ViewCommon implements React.ChildContextProvider<ViewC
                         this.props.onContextMenu(mouseEvent);
                     }
                 }
+            }).catch(e => {
+                console.warn('View measureKayoutRelativeToWindow exception: ' + JSON.stringify(e));
             });
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "outDir": "dist/",
         "lib": [
             "es2015.promise",
+            "es2018.promise",
             "es5",
             "dom"
         ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
         "forceConsistentCasingInFileNames": true,
         "outDir": "dist/",
         "lib": [
+            "es2015.promise",
             "es5",
             "dom"
         ],


### PR DESCRIPTION
Usage of ES6 promises is more standardized, using SyncTasks by default doesn't provide many consumers a large benefit. If they need SyncTasks promises, they can wrap in SyncTasks.fromThenable at the use site