### PR TITLE
Add onPressIn and onPressOut to View

### DIFF
--- a/docs/docs/components/view.md
+++ b/docs/docs/components/view.md
@@ -133,6 +133,8 @@ onMouseOver: (e: MouseEvent) => void = undefined;
 // Mouse & Touch Events
 onContextMenu: (e: React.SyntheticEvent) => void;
 onPress: (e: SyntheticEvent) => void = undefined;
+onPressIn: (e: SyntheticEvent) => void = undefined;
+onPressOut: (e: SyntheticEvent) => void = undefined;
 
 // Focus Events
 onFocus: (e: FocusEvent) => void = undefined;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -659,6 +659,8 @@ export interface ViewPropsShared<C = React.Component> extends CommonProps<C>, Co
     onMouseMove?: (e: MouseEvent) => void;
 
     onPress?: (e: SyntheticEvent) => void;
+    onPressIn?: (e: SyntheticEvent) => void;
+    onPressOut?: (e: SyntheticEvent) => void;
     onLongPress?: (e: SyntheticEvent) => void;
     onKeyPress?: (e: KeyboardEvent) => void;
     onFocus?: (e: FocusEvent) => void;

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -469,7 +469,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
     }
 
     protected _isButton(viewProps: RX.Types.ViewProps): boolean {
-        return !!(viewProps.onPress || viewProps.onLongPress);
+        return !!(viewProps.onPress || viewProps.onLongPress || viewProps.onPressIn || viewProps.onPressOut);
     }
 
     private _updateFocusArbitratorProvider(props: RX.Types.ViewProps) {
@@ -536,6 +536,10 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
                 this._opacityActive(_activeOpacityAnimationDuration);
             }
         }
+
+        if (this.props.onPressIn) {
+            this.props.onPressIn(e);
+        }
     }
 
     touchableHandleActivePressOut(e: RX.Types.SyntheticEvent): void {
@@ -550,6 +554,10 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
             if (!this.props.disableTouchOpacityAnimation && (this.props.activeOpacity || !this.props.underlayColor)) {
                 this._opacityInactive(_inactiveOpacityAnimationDuration);
             }
+        }
+
+        if (this.props.onPressOut) {
+            this.props.onPressOut(e);
         }
     }
 

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -359,6 +359,8 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RX.Vi
             onMouseLeave: this.props.onMouseLeave,
             onMouseOver: this.props.onMouseOver,
             onMouseMove: this.props.onMouseMove,
+            onPointerDown: this.props.onPressIn,
+            onPointerOut: this.props.onPressOut,
             // Weird things happen: ReactXP.Types.Touch is not assignable to React.Touch
             onTouchStart: this.props.onResponderStart as React.HTMLAttributes<any>['onTouchStart'],
             onTouchStartCapture: this.props.onTouchStartCapture as React.HTMLAttributes<any>['onTouchStartCapture'],


### PR DESCRIPTION
Surface the onPressIn and onPressOut props to go along with onPress. This provides consumers with a simple common pathway to update their visual styles in response to the stages of a mouse or touch press.

The implementation on native uses the existing touchable functions imported into View. On web, the Pointer Events API is used to provide native-similar behavior across both mouse and touch inputs -- this includes triggering onPressOut when a touch transitions to a scroll gesture or otherwise moves away from the initial press location.

Pointer Events are currently supported on all major browsers except Safari. An alternative could be built using Touch Events, but it would increase the tracking overhead and complexity of View, which is not ideal for a component that generally doesn't care about presses. Consumers who need support on Safari should be able to wrap View for their specific use case and leverage the onResponder* methods to add this tracking logic.