### PR TITLE
docs: add webview extension to docs sidebar

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -94,3 +94,5 @@
       title: Video
     - id: extensions/virtuallistview
       title: VirtualListView
+    - id: extensions/webview
+      title: WebView


### PR DESCRIPTION
This is a follow-on to #1101 - the WebView extension is working fine and the doc exists, it just wasn't linked int

I'm obviously unable to test this but I re-read it three times, hopefully it's correct + useful