### PR TITLE
fix: upgrade react-native-webview dependency, remove obsolete props

### DIFF
--- a/extensions/webview/package.json
+++ b/extensions/webview/package.json
@@ -9,7 +9,7 @@
     "tslint": "tslint -p tsconfig.json -r tslint.json --fix || true"
   },
   "dependencies": {
-    "react-native-webview": "^5.6.3"
+    "react-native-webview": "^7.0.5"
   },
   "peerDependencies": {
     "reactxp": "^2.0.0-rc.1",

--- a/extensions/webview/src/native-common/WebView.tsx
+++ b/extensions/webview/src/native-common/WebView.tsx
@@ -40,11 +40,6 @@ export class WebView extends React.Component<Types.WebViewProps, RX.Types.Statel
         const source = this._buildSource();
         const injectedJavascript = this._buildInjectedJavascript();
 
-        // Force use of webkit on iOS (applies to RN 0.57 and newer only).
-        const extendedProps: RNWebViewProps = {
-            useWebKit: true
-        };
-
         return (
             <RNWebView
                 ref={ this._onMount }
@@ -65,7 +60,6 @@ export class WebView extends React.Component<Types.WebViewProps, RX.Types.Statel
                 onMessage={ this.props.onMessage ? this._onMessage : undefined }
                 testID={ this.props.testId }
                 mixedContentMode={ this._sandboxToMixedContentMode(this.props.sandbox) }
-                { ...extendedProps }
             />
         );
     }


### PR DESCRIPTION
react-native-webview issued a breaking change release to shed the
UIWebView references on iOS, as Apple indicated they would soon stop
accepting app submissions that used that deprecated API.

react-native-webview is now fully WebKit and without this the webview
extension here references obsolete symbols because the JS layer still has
RNCWKWebView symbols from react-native-webview <7 while the auto-linked
iOS Pod is from react-native-webview >=7

Perhaps react-native-webview should be a peerDependency?

More info: https://github.com/react-native-community/react-native-webview/releases/tag/v7.0.1