### PR TITLE
feat: enable 'handled' mode of ScrollView['keyboardShouldPersistTaps']

### DIFF
--- a/docs/docs/components/scrollview.md
+++ b/docs/docs/components/scrollview.md
@@ -25,7 +25,7 @@ keyboardDismissMode: 'none' | 'interactive' | 'on-drag'; // Native only
 
 // Should the on-screen keyboard remain visible when the user taps
 // the scroll view?
-keyboardShouldPersistTaps: boolean = false; // Native only
+keyboardShouldPersistTaps: boolean | 'always' | 'never' | 'handled' = 'never'; // Native only
 
 // Invoked when the contents of the scroll view change
 onContentSizeChange: (width: number, height: number) => void = undefined;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -838,7 +838,7 @@ export interface ScrollViewProps extends CommonStyledProps<ScrollViewStyleRuleSe
     // The following props are valid only on native platforms and
     // have no meaning on the web implementation.
     keyboardDismissMode?: 'none' | 'interactive' | 'on-drag';
-    keyboardShouldPersistTaps?: boolean;
+    keyboardShouldPersistTaps?: boolean | 'always' | 'never' | 'handled';
 
     // This controls how often the scroll event will be fired while scrolling
     // (in milliseconds between events). A lower number yields better accuracy for code

--- a/src/native-common/ScrollView.tsx
+++ b/src/native-common/ScrollView.tsx
@@ -11,6 +11,7 @@ import * as React from 'react';
 import * as RN from 'react-native';
 
 import * as RX from '../common/Interfaces';
+import { ScrollViewProps } from '../common/Types';
 
 import ViewBase from './ViewBase';
 
@@ -82,7 +83,18 @@ export class ScrollView extends ViewBase<RX.Types.ScrollViewProps, RX.Types.Stat
             scrollHandler = undefined;
         }
 
-        const keyboardShouldPersistTaps = (overrideKeyboardShouldPersistTaps || this.props.keyboardShouldPersistTaps ? 'always' : 'never');
+        // 1) keyboardShouldPersistTaps may be overridden, superceding all other settings
+        // 2) in the absence of any other setting, 'never' is the default
+        // 3) if a boolean is seen, translate to 'always' or 'never' as the boolean is deprecated
+        // 4) it is also possible to see a string value of 'handled'
+        let keyboardShouldPersistTaps: ScrollViewProps['keyboardShouldPersistTaps'] = 'never';
+        if (overrideKeyboardShouldPersistTaps || this.props.keyboardShouldPersistTaps === true) {
+            // If there is an override or a boolean true, translate it to 'always'
+            keyboardShouldPersistTaps = 'always';
+        } else if (typeof this.props.keyboardShouldPersistTaps === 'string') {
+            // If there is no override, and a string && non-boolean was provided, use it without translation
+            keyboardShouldPersistTaps = this.props.keyboardShouldPersistTaps;
+        }
 
         // NOTE: We are setting `automaticallyAdjustContentInsets` to false
         // (http://facebook.github.io/react-native/docs/scrollview.html#automaticallyadjustcontentinsets). The


### PR DESCRIPTION
This enables tap events to go through the ScrollView and trigger onPress
on Touchable things inside the ScrollView. 

So while the keyboard is showing in a TextInput inside a ScrollView and you tap a button, the button will actually tap instead of needing one tap to dismiss keyboard, and one tap on the button

You guys have a pretty concise style and my Typescript Typing skills are not very strong yet, so if there is anything stylistic about this you don't like, just let me know.

Side note: if you disregard the package-lock.json right now (e.g. by using yarn instead of npm) current master fails to compile with tsc. I'm assuming some underlying type package moved and Button and View no longer have compatible Animated Style types. Using `npm install` does work though and after that install a `yarn build` is successful, and I can transplant the src+dist directories to my project's node_modules for patch-package consumption where I can deploy my work.