### PR TITLE
Updated setup and build for TodoList Sample

### DIFF
--- a/samples/TodoList/docs/setup-and-build.md
+++ b/samples/TodoList/docs/setup-and-build.md
@@ -5,7 +5,7 @@
 To test the web build, you can run a local web server in node.
 
 ### Node.JS
-From a command line, go to the web directory and simply type:
+From a command line, go to the TodoList directory and simply type:
 ```
 node nodeserver.js
 ```


### PR DESCRIPTION
web folder inside TodoList does not contain the nodeserver.js which throws the following error:
```
internal/modules/cjs/loader.js:651
    throw err;
    ^

Error: Cannot find module '/reactxp/samples/TodoList/web/nodeserver.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:649:15)
    at Function.Module._load (internal/modules/cjs/loader.js:575:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:862:12)
    at internal/main/run_main_module.js:21:11
```
Executing the command from the sample base folder (reactxp/samples/TodoList) works fine.