### PR TITLE
include es2015.iterable type for RXPTest

### DIFF
--- a/samples/RXPTest/tsconfig.json
+++ b/samples/RXPTest/tsconfig.json
@@ -18,6 +18,7 @@
     "strict": true,
     "lib": [
         "es2015.promise",
+        "es2015.iterable",
         "es2018.promise",
         "es5",
         "dom"


### PR DESCRIPTION
without this `npm run rn-watch` fails:

`node_modules/typescript/lib/lib.es2015.promise.d.ts:129:21 - error TS2304: Cannot find name 'Iterable'.`

1) this may not be the correct fix but in my limited research it seemed to be, and it certainly allows tsc to run so I can check RXPTest

2) this may be necessary in other reactxp samples, I did not survey (sorry!)