### PR TITLE
Fix TodoList sample build in release mode

### DIFF
--- a/samples/TodoList/gulpfile.js
+++ b/samples/TodoList/gulpfile.js
@@ -420,13 +420,6 @@ gulp.task('compile-rn', function () {
         .pipe(enableSrcMaps ? sourcemaps.init() : gutil.noop())
         .pipe(tsProject());
 
-    var shouldAssert = isDevEnv || (!isCandidateBuild && !isPublicRelease && !isInsidersRelease);
-    if (!shouldAssert) {
-        stream = stream
-            .pipe(unassert());
-    }
-
-    // must run after unassert
     if (enableSrcMaps) {
         stream = stream.pipe(sourcemaps.write('.',
             { sourceRoot: path.join(process.cwd(), config.ts.srcRoot) }));


### PR DESCRIPTION
If a build using this file was attempted in release mode, it attempted to reference variables that did not exist, and unassert() method which similarly did not exist

Yes, it is just a sample, but I finally got around to extending my app to web and as I integrated the gulp part of the build infrastructure to get the module aliasing, I noticed that release builds would fail in this area