### PR TITLE
Support for touch gestures on web/GestureView by creating a common base component

### DIFF
--- a/src/android/GestureView.tsx
+++ b/src/android/GestureView.tsx
@@ -22,7 +22,7 @@ export class GestureView extends BaseGestureView {
         return _preferredPanRatio;
     }
 
-    protected _getEventTimestamp(e: Types.TouchEvent): number {
+    protected _getEventTimestamp(e: Types.TouchEvent | Types.MouseEvent): number {
         let timestamp = e.timeStamp;
 
         // Work around a bug in some versions of RN where "timestamp" is

--- a/src/common/GestureView.tsx
+++ b/src/common/GestureView.tsx
@@ -1,0 +1,653 @@
+/**
+ * GestureView.tsx
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ *
+ * Cross-platform parts of the implementation of the GestureView component.
+ * It provides much of the standard work necessary to support combinations of
+ * pinch-and-zoom, panning, single tap and double tap gestures.
+ */
+
+import * as React from 'react';
+
+import assert from '../common/assert';
+import { Types } from '../common/Interfaces';
+import Timers from '../common/utils/Timers';
+
+export enum GestureType {
+    None,
+    MultiTouch,
+    Pan,
+    PanVertical,
+    PanHorizontal
+}
+
+// These threshold values were chosen empirically.
+const _pinchZoomPixelThreshold = 3;
+const _panPixelThreshold = 10;
+const _tapDurationThreshold = 500;
+const _longPressDurationThreshold = 750;
+const _tapPixelThreshold = 4;
+const _doubleTapDurationThreshold = 250;
+const _doubleTapPixelThreshold = 20;
+
+export interface GestureStatePoint {
+    /**
+     * accumulated distance of the gesture since the touch started
+     */
+    dx: number;
+
+    /**
+     * accumulated distance of the gesture since the touch started
+     */
+    dy: number;
+}
+
+export interface GestureStatePointVelocity extends GestureStatePoint {
+    /**
+     * current velocity of the gesture
+     */
+    vx: number;
+
+    /**
+     * current velocity of the gesture
+     */
+    vy: number;
+}
+
+// We need a method-less really-basic touch event basic type for allowing cross-platform adapting of
+// web(React)-based touch events into RX touch events, since they're based on the RN type to allow
+// for zero-work casting and manipulating.
+export interface TouchListBasic {
+    [index: number]: Types.Touch;
+    length: number;
+}
+
+export interface TouchEventBasic extends Types.SyntheticEvent {
+    // We override this definition because the public
+    // type excludes location and page fields.
+    altKey: boolean;
+    changedTouches: TouchListBasic;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+    targetTouches: TouchListBasic;
+    locationX?: number;
+    locationY?: number;
+    pageX?: number;
+    pageY?: number;
+    touches: TouchListBasic;
+}
+
+export abstract class GestureView extends React.Component<Types.GestureViewProps, Types.Stateless> {
+    private _doubleTapTimer: number | undefined;
+
+    private _pendingLongPressEvent: Types.TapGestureState | undefined;
+    private _longPressTimer: number | undefined;
+
+    // State for tracking move gestures (pinch/zoom or pan)
+    private _pendingGestureType: GestureType = GestureType.None;
+    private _pendingGestureState: Types.MultiTouchGestureState | Types.PanGestureState | Types.TapGestureState | undefined;
+
+    // State for tracking double taps
+    private _lastTapEvent: Types.TapGestureState | undefined;
+
+    // Skip ability for next tap to work around some event issues
+    private _shouldSkipNextTap = false;
+
+    // State for tracking single taps
+    private _lastGestureStartEvent: TouchEventBasic | undefined;
+
+    componentWillUnmount() {
+        // Dispose of timer before the component goes away.
+        this._cancelDoubleTapTimer();
+    }
+
+    // Returns true if we care about trapping/tracking the event
+    protected _onTouchSeriesStart(event: TouchEventBasic): boolean {
+        this._lastGestureStartEvent = event;
+
+        // If we're trying to detect a tap, set this as the responder immediately.
+        if (this.props.onTap || this.props.onDoubleTap || this.props.onLongPress || this.props.onContextMenu) {
+            if (this.props.onLongPress) {
+                const gsState = this._touchEventToSinglePointGestureState(event);
+                this._startLongPressTimer(gsState);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    // Returns true if we care about trapping/tracking the event
+    protected _onTouchChange(event: TouchEventBasic, gestureState: GestureStatePointVelocity): boolean {
+        this._lastGestureStartEvent = event;
+        let initializeFromEvent = false;
+
+        // If this is the first movement we've seen, try to match it against
+        // the various move gestures that we're looking for.
+        if (this._pendingGestureType === GestureType.None) {
+            this._pendingGestureType = this._detectMoveGesture(event, gestureState);
+            initializeFromEvent = true;
+        }
+
+        if (this._pendingGestureType === GestureType.MultiTouch) {
+            this._setPendingGestureState(this._sendMultiTouchEvents(event, gestureState,
+                initializeFromEvent, false));
+        } else if (this._pendingGestureType === GestureType.Pan ||
+                this._pendingGestureType === GestureType.PanVertical ||
+                this._pendingGestureType === GestureType.PanHorizontal) {
+            const spEvent = this._touchEventToSinglePointGestureState(event);
+            this._setPendingGestureState(this._sendPanEvent(spEvent, gestureState,
+                this._pendingGestureType, initializeFromEvent, false));
+        }
+
+        return false;
+    }
+
+    protected _onTouchSeriesFinished(touchEvent: TouchEventBasic, gestureState: GestureStatePointVelocity) {
+        // Can't possibly be a long press if the touch ended.
+        this._cancelLongPressTimer();
+
+        // Close out any of the pending move gestures.
+        if (this._pendingGestureType === GestureType.MultiTouch) {
+            this._sendMultiTouchEvents(touchEvent, gestureState, false, true);
+            this._pendingGestureState = undefined;
+            this._pendingGestureType = GestureType.None;
+        } else if (this._pendingGestureType === GestureType.Pan ||
+            this._pendingGestureType === GestureType.PanVertical ||
+            this._pendingGestureType === GestureType.PanHorizontal) {
+            const spEvent = this._touchEventToSinglePointGestureState(touchEvent);
+            this._sendPanEvent(spEvent, gestureState, this._pendingGestureType, false, true);
+            this._pendingGestureState = undefined;
+            this._pendingGestureType = GestureType.None;
+        } else if (this._isTap(touchEvent)) {
+            const tapGestureState = this._touchEventToSinglePointGestureState(touchEvent);
+            if (!this.props.onDoubleTap) {
+                // If there is no double-tap handler, we can invoke the tap handler immediately.
+                this._sendTapEvent(tapGestureState);
+            } else if (this._isDoubleTap(tapGestureState)) {
+                // This is a double-tap, so swallow the previous single tap.
+                this._cancelDoubleTapTimer();
+                this._sendDoubleTapEvent(tapGestureState);
+            } else {
+                // This wasn't a double-tap. Report any previous single tap and start the double-tap
+                // timer so we can determine whether the current tap is a single or double.
+                this._reportDelayedTap();
+                this._startDoubleTapTimer(tapGestureState);
+            }
+        } else {
+            this._reportDelayedTap();
+            this._cancelDoubleTapTimer();
+        }
+    }
+
+    // Get preferred pan ratio for platform.
+    protected abstract _getPreferredPanRatio(): number;
+
+    // Returns the timestamp for the touch event in milliseconds.
+    protected abstract _getEventTimestamp(e: TouchEventBasic | Types.MouseEvent): number;
+
+    protected _skipNextTap() {
+        this._shouldSkipNextTap = true;
+    }
+
+    private _setPendingGestureState(gestureState: Types.MultiTouchGestureState | Types.PanGestureState | Types.TapGestureState) {
+        this._reportDelayedTap();
+        this._cancelDoubleTapTimer();
+        this._cancelLongPressTimer();
+        this._pendingGestureState = gestureState;
+    }
+
+    private _detectMoveGesture(e: TouchEventBasic, gestureState: GestureStatePoint): GestureType {
+        if (this._shouldRespondToPinchZoom(e) || this._shouldRespondToRotate(e)) {
+            return GestureType.MultiTouch;
+        } else if (this._shouldRespondToPan(gestureState)) {
+            return GestureType.Pan;
+        } else if (this._shouldRespondToPanVertical(gestureState)) {
+            return GestureType.PanVertical;
+        } else if (this._shouldRespondToPanHorizontal(gestureState)) {
+            return GestureType.PanHorizontal;
+        }
+
+        return GestureType.None;
+    }
+
+    // Determines whether a touch event constitutes a tap. The "finger up"
+    // event must be within a certain distance and within a certain time
+    // from where the "finger down" event occurred.
+    private _isTap(e: TouchEventBasic): boolean {
+        if (!this._lastGestureStartEvent) {
+            return false;
+        }
+
+        const initialTimeStamp = this._getEventTimestamp(this._lastGestureStartEvent);
+        const initialPageX = this._lastGestureStartEvent.pageX!;
+        const initialPageY = this._lastGestureStartEvent.pageY!;
+
+        const timeStamp = this._getEventTimestamp(e);
+
+        return (timeStamp - initialTimeStamp <= _tapDurationThreshold &&
+            this._calcDistance(initialPageX - e.pageX!, initialPageY - e.pageY!) <= _tapPixelThreshold);
+    }
+
+    // This method assumes that the caller has already determined that two
+    // taps have been detected in a row with no intervening gestures. It
+    // is responsible for determining if they occurred within close proximity
+    // and within a certain threshold of time.
+    protected _isDoubleTap(e: Types.TapGestureState) {
+        if (!this._lastTapEvent) {
+            return false;
+        }
+
+        return (e.timeStamp - this._lastTapEvent.timeStamp <= _doubleTapDurationThreshold &&
+            this._calcDistance(this._lastTapEvent.pageX - e.pageX, this._lastTapEvent.pageY - e.pageY) <= _doubleTapPixelThreshold);
+    }
+
+    // Starts a timer that reports a previous tap if it's not canceled by a subsequent gesture.
+    protected _startDoubleTapTimer(e: Types.TapGestureState) {
+        this._lastTapEvent = e;
+
+        this._doubleTapTimer = Timers.setTimeout(() => {
+            this._reportDelayedTap();
+            this._doubleTapTimer = undefined;
+        }, _doubleTapDurationThreshold);
+    }
+
+    // Cancels any pending double-tap timer.
+    protected _cancelDoubleTapTimer() {
+        if (this._doubleTapTimer) {
+            Timers.clearTimeout(this._doubleTapTimer);
+            this._doubleTapTimer = undefined;
+        }
+    }
+
+    protected _startLongPressTimer(gsState: Types.TapGestureState, isDefinitelyMouse = false) {
+        if (this._pendingLongPressEvent) {
+            return;
+        }
+
+        this._pendingLongPressEvent = gsState;
+
+        this._longPressTimer = Timers.setTimeout(() => {
+            this._reportLongPress();
+            this._longPressTimer = undefined;
+        }, _longPressDurationThreshold);
+    }
+
+    private _reportLongPress() {
+        if (!this._pendingLongPressEvent) {
+            return;
+        }
+
+        if (this.props.onLongPress) {
+            this.props.onLongPress(this._pendingLongPressEvent);
+        }
+
+        this._pendingLongPressEvent = undefined;
+    }
+
+    protected _cancelLongPressTimer() {
+        if (this._longPressTimer) {
+            Timers.clearTimeout(this._longPressTimer);
+            this._longPressTimer = undefined;
+        }
+
+        this._pendingLongPressEvent = undefined;
+    }
+
+    // If there was a previous tap recorded but we haven't yet reported it because we were
+    // waiting for a potential second tap, report it now.
+    protected _reportDelayedTap() {
+        if (this._lastTapEvent && this.props.onTap) {
+            this._sendTapEvent(this._lastTapEvent);
+            this._lastTapEvent = undefined;
+        }
+    }
+
+    protected _clearLastTap() {
+        this._lastTapEvent = undefined;
+    }
+
+    private static _isActuallyMouseEvent(e: TouchEventBasic | undefined): boolean {
+        if (!e) {
+            return false;
+        }
+
+        const nativeEvent = e as any;
+        if (nativeEvent.button !== undefined) {
+            return true;
+        } else if (nativeEvent.isRightButton || nativeEvent.IsRightButton) {
+            return true;
+        } else if (nativeEvent.isMiddleButton || nativeEvent.IsMiddleButton) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private _shouldRespondToPinchZoom(e: TouchEventBasic) {
+        if (!this.props.onPinchZoom) {
+            return false;
+        }
+
+        // Do we see two touches?
+        if (!e.touches || e.touches.length !== 2) {
+            return false;
+        }
+
+        // Has the user started to pinch or zoom?
+        if (this._calcDistance(e.touches[0].pageX - e.touches[1].pageX,
+                e.touches[0].pageY - e.touches[1].pageY) >=
+                    _pinchZoomPixelThreshold) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private _shouldRespondToRotate(e: TouchEventBasic) {
+        if (!this.props.onRotate) {
+            return false;
+        }
+
+        // Do we see two touches?
+        if (!e.touches || e.touches.length !== 2) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected _shouldRespondToPan(gestureState: GestureStatePoint) {
+        if (!this.props.onPan) {
+            return false;
+        }
+
+        // Has the user started to pan?
+        const panThreshold = (this.props.panPixelThreshold !== undefined && this.props.panPixelThreshold > 0) ?
+            this.props.panPixelThreshold : _panPixelThreshold;
+        return (this._calcDistance(gestureState.dx, gestureState.dy) >= panThreshold);
+    }
+
+    protected _shouldRespondToPanVertical(gestureState: GestureStatePoint) {
+        if (!this.props.onPanVertical) {
+            return false;
+        }
+
+        // Has the user started to pan?
+        const panThreshold = (this.props.panPixelThreshold !== undefined && this.props.panPixelThreshold > 0) ?
+            this.props.panPixelThreshold : _panPixelThreshold;
+        const isPan = Math.abs(gestureState.dy) >= panThreshold;
+
+        if (isPan && this.props.preferredPan === Types.PreferredPanGesture.Horizontal) {
+            return Math.abs(gestureState.dy) > Math.abs(gestureState.dx * this._getPreferredPanRatio());
+        }
+        return isPan;
+    }
+
+    protected _shouldRespondToPanHorizontal(gestureState: GestureStatePoint) {
+        if (!this.props.onPanHorizontal) {
+            return false;
+        }
+
+        // Has the user started to pan?
+        const panThreshold = (this.props.panPixelThreshold !== undefined && this.props.panPixelThreshold > 0) ?
+            this.props.panPixelThreshold : _panPixelThreshold;
+        const isPan = Math.abs(gestureState.dx) >= panThreshold;
+
+        if (isPan && this.props.preferredPan === Types.PreferredPanGesture.Vertical) {
+            return Math.abs(gestureState.dx) > Math.abs(gestureState.dy * this._getPreferredPanRatio());
+        }
+        return isPan;
+    }
+
+    private _calcDistance(dx: number, dy: number) {
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    private _calcAngle(touches: TouchListBasic): number {
+        const a = touches[0];
+        const b = touches[1];
+
+        let degrees = this._radiansToDegrees(Math.atan2(b.pageY - a.pageY, b.pageX - a.pageX));
+        if (degrees < 0) {
+            degrees += 360;
+        }
+
+        return degrees;
+    }
+
+    private _radiansToDegrees(rad: number): number {
+        return rad * 180 / Math.PI;
+    }
+
+    private _sendMultiTouchEvents(e: TouchEventBasic, gestureState: GestureStatePointVelocity,
+            initializeFromEvent: boolean, isComplete: boolean) {
+        const p = this._pendingGestureState as Types.MultiTouchGestureState;
+        let multiTouchEvent: Types.MultiTouchGestureState;
+
+        // If the user lifted up one or both fingers, the multitouch gesture
+        // is halted. Just return the existing gesture state.
+        if (!e.touches || e.touches.length !== 2) {
+            multiTouchEvent = p;
+            p.isComplete = isComplete;
+        } else {
+            const centerPageX = (e.touches[0].pageX + e.touches[1].pageX) / 2;
+            const centerPageY = (e.touches[0].pageY + e.touches[1].pageY) / 2;
+            const centerClientX = (e.touches[0].locationX + e.touches[1].locationX) / 2;
+            const centerClientY = (e.touches[0].locationY + e.touches[1].locationY) / 2;
+            const width = Math.abs(e.touches[0].pageX - e.touches[1].pageX);
+            const height = Math.abs(e.touches[0].pageY - e.touches[1].pageY);
+            const distance = this._calcDistance(width, height);
+            const angle = this._calcAngle(e.touches);
+
+            const initialCenterPageX = initializeFromEvent ? centerPageX : p.initialCenterPageX;
+            const initialCenterPageY = initializeFromEvent ? centerPageY : p.initialCenterPageY;
+            const initialCenterClientX = initializeFromEvent ? centerClientX : p.initialCenterClientX;
+            const initialCenterClientY = initializeFromEvent ? centerClientY : p.initialCenterClientY;
+            const initialWidth = initializeFromEvent ? width : p.initialWidth;
+            const initialHeight = initializeFromEvent ? height : p.initialHeight;
+            const initialDistance = initializeFromEvent ? distance : p.initialDistance;
+            const initialAngle = initializeFromEvent ? angle : p.initialAngle;
+
+            const velocityX = initializeFromEvent ? 0 : gestureState.vx;
+            const velocityY = initializeFromEvent ? 0 : gestureState.vy;
+
+            multiTouchEvent = {
+                initialCenterPageX: initialCenterPageX,
+                initialCenterPageY: initialCenterPageY,
+                initialCenterClientX: initialCenterClientX,
+                initialCenterClientY: initialCenterClientY,
+                initialWidth: initialWidth,
+                initialHeight: initialHeight,
+                initialDistance: initialDistance,
+                initialAngle: initialAngle,
+
+                centerPageX: centerPageX,
+                centerPageY: centerPageY,
+                centerClientX: centerClientX,
+                centerClientY: centerClientY,
+                velocityX: velocityX,
+                velocityY: velocityY,
+                width: width,
+                height: height,
+                distance: distance,
+                angle: angle,
+
+                isComplete: isComplete,
+                timeStamp: e.timeStamp,
+                isTouch: !GestureView._isActuallyMouseEvent(e)
+            };
+        }
+
+        if (this.props.onPinchZoom) {
+            this.props.onPinchZoom(multiTouchEvent);
+        }
+
+        if (this.props.onRotate) {
+            this.props.onRotate(multiTouchEvent);
+        }
+
+        return multiTouchEvent;
+    }
+
+    protected _touchEventToSinglePointGestureState(e: TouchEventBasic): Types.SinglePointGestureState {
+        let pageX = e.pageX!;
+        let pageY = e.pageY!;
+        let clientX = e.locationX!;
+        let clientY = e.locationY!;
+
+        // Grab the first touch. If the user adds additional touch events,
+        // we will ignore them. If we use e.pageX/Y, we will be using the average
+        // of the touches, so we'll see a discontinuity.
+        if (e.touches && e.touches.length > 0) {
+            pageX = e.touches[0].pageX;
+            pageY = e.touches[0].pageY;
+            clientX = e.touches[0].locationX;
+            clientY = e.touches[0].locationY;
+        }
+
+        return {
+            timeStamp: this._getEventTimestamp(e),
+            clientX,
+            clientY,
+            pageX,
+            pageY,
+            isTouch: !GestureView._isActuallyMouseEvent(e)
+        };
+    }
+
+    protected _mouseEventToSinglePointGestureState(e: Types.MouseEvent): Types.SinglePointGestureState {
+        const xyOffset = this._getClientXYOffset();
+        return {
+            timeStamp: this._getEventTimestamp(e),
+            clientX: e.clientX - xyOffset.x,
+            clientY: e.clientY - xyOffset.y,
+            pageX: e.pageX || 0,
+            pageY: e.pageY || 0,
+            isTouch: false
+        };
+    }
+
+    protected _getClientXYOffset(): { x: number; y: number } {
+        return { x: 0, y: 0 };
+    }
+
+    private _sendPanEvent(e: Types.SinglePointGestureState, gestureState: GestureStatePointVelocity,
+            gestureType: GestureType, initializeFromEvent: boolean, isComplete: boolean) {
+        const state = this._pendingGestureState as Types.PanGestureState;
+
+        assert(this._lastGestureStartEvent, 'Gesture start event must not be null.');
+
+        const initialPageX = this._lastGestureStartEvent
+            ? this._lastGestureStartEvent.pageX!
+            : initializeFromEvent ? e.pageX : state.initialPageX;
+        const initialPageY = this._lastGestureStartEvent
+            ? this._lastGestureStartEvent.pageY!
+            : initializeFromEvent ? e.pageY : state.initialPageY;
+        const initialClientX = this._lastGestureStartEvent
+            ? this._lastGestureStartEvent.locationX!
+            : initializeFromEvent ? e.clientX : state.initialClientX;
+        const initialClientY = this._lastGestureStartEvent
+            ? this._lastGestureStartEvent.locationY!
+            : initializeFromEvent ? e.clientY : state.initialClientY;
+
+        const velocityX = initializeFromEvent ? 0 : gestureState.vx;
+        const velocityY = initializeFromEvent ? 0 : gestureState.vy;
+
+        const panEvent: Types.PanGestureState = {
+            initialPageX: initialPageX,
+            initialPageY: initialPageY,
+            initialClientX: initialClientX,
+            initialClientY: initialClientY,
+
+            pageX: e.pageX,
+            pageY: e.pageY,
+            clientX: e.clientX,
+            clientY: e.clientY,
+            velocityX: velocityX,
+            velocityY: velocityY,
+
+            isComplete: isComplete,
+            timeStamp: e.timeStamp,
+            isTouch: !GestureView._isActuallyMouseEvent(this._lastGestureStartEvent)
+        };
+
+        switch (gestureType) {
+            case GestureType.Pan:
+                if (this.props.onPan) {
+                    this.props.onPan(panEvent);
+                }
+                break;
+            case GestureType.PanVertical:
+                if (this.props.onPanVertical) {
+                    this.props.onPanVertical(panEvent);
+                }
+                break;
+            case GestureType.PanHorizontal:
+                if (this.props.onPanHorizontal) {
+                    this.props.onPanHorizontal(panEvent);
+                }
+                break;
+
+            default:
+                // do nothing;
+        }
+
+        return panEvent;
+    }
+
+    private static _toMouseButton(nativeEvent: any): number {
+        if (nativeEvent.button !== undefined) {
+            return nativeEvent.button;
+        } else if (nativeEvent.isRightButton || nativeEvent.IsRightButton) {
+            return 2;
+        } else if (nativeEvent.isMiddleButton || nativeEvent.IsMiddleButton) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    // Protected only as a hack for supporting keyboard nav clicking from native-common/GestureView
+    protected _sendTapEvent = (tapEvent: Types.TapGestureState) => {
+        // we need to skip tap after succesfull pan event
+        // mouse up would otherwise trigger both pan & tap
+        if (this._shouldSkipNextTap) {
+            this._shouldSkipNextTap = false;
+            return;
+        }
+
+        const button = GestureView._toMouseButton(tapEvent);
+        if (button === 2) {
+            // Always handle secondary button, even if context menu is not set - it shouldn't trigger onTap.
+            if (this.props.onContextMenu) {
+                this.props.onContextMenu(tapEvent);
+            }
+        } else if (this.props.onTap) {
+            this.props.onTap(tapEvent);
+        }
+    }
+
+    protected _sendDoubleTapEvent(e: Types.TapGestureState) {
+        // If user did a double click with different mouse buttons, eg. left (50ms) right
+        // both clicks need to be registered as separate events.
+        const lastButton = GestureView._toMouseButton(this._lastTapEvent!);
+        const button = GestureView._toMouseButton(e);
+        if (lastButton !== button || button === 2) {
+            this._sendTapEvent(this._lastTapEvent!);
+            return;
+        }
+
+        if (this.props.onDoubleTap) {
+            this.props.onDoubleTap(e);
+        }
+
+        this._lastTapEvent = undefined;
+    }
+}
+
+export default GestureView;

--- a/src/common/GestureView.tsx
+++ b/src/common/GestureView.tsx
@@ -111,7 +111,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         // If we're trying to detect a tap, set this as the responder immediately.
         if (this.props.onTap || this.props.onDoubleTap || this.props.onLongPress || this.props.onContextMenu) {
             if (this.props.onLongPress) {
-                const gsState = this._touchEventToSinglePointGestureState(event);
+                const gsState = this._touchEventToTapGestureState(event);
                 this._startLongPressTimer(gsState);
             }
 
@@ -142,7 +142,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         } else if (this._pendingGestureType === GestureType.Pan ||
                 this._pendingGestureType === GestureType.PanVertical ||
                 this._pendingGestureType === GestureType.PanHorizontal) {
-            const spEvent = this._touchEventToSinglePointGestureState(event);
+            const spEvent = this._touchEventToTapGestureState(event);
             this._setPendingGestureState(this._sendPanEvent(spEvent, gestureState,
                 this._pendingGestureType, initializeFromEvent, false));
             return true;
@@ -163,12 +163,12 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         } else if (this._pendingGestureType === GestureType.Pan ||
             this._pendingGestureType === GestureType.PanVertical ||
             this._pendingGestureType === GestureType.PanHorizontal) {
-            const spEvent = this._touchEventToSinglePointGestureState(touchEvent);
+            const spEvent = this._touchEventToTapGestureState(touchEvent);
             this._sendPanEvent(spEvent, gestureState, this._pendingGestureType, false, true);
             this._pendingGestureState = undefined;
             this._pendingGestureType = GestureType.None;
         } else if (this._isTap(touchEvent)) {
-            const tapGestureState = this._touchEventToSinglePointGestureState(touchEvent);
+            const tapGestureState = this._touchEventToTapGestureState(touchEvent);
             if (!this.props.onDoubleTap) {
                 // If there is no double-tap handler, we can invoke the tap handler immediately.
                 this._sendTapEvent(tapGestureState);
@@ -498,7 +498,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         return multiTouchEvent;
     }
 
-    protected _touchEventToSinglePointGestureState(e: TouchEventBasic): Types.SinglePointGestureState {
+    protected _touchEventToTapGestureState(e: TouchEventBasic): Types.TapGestureState {
         let pageX = e.pageX!;
         let pageY = e.pageY!;
         let clientX = e.locationX!;
@@ -524,7 +524,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         };
     }
 
-    protected _mouseEventToSinglePointGestureState(e: Types.MouseEvent): Types.SinglePointGestureState {
+    protected _mouseEventToTapGestureState(e: Types.MouseEvent): Types.TapGestureState {
         const xyOffset = this._getClientXYOffset();
         return {
             timeStamp: this._getEventTimestamp(e),
@@ -540,7 +540,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         return { x: 0, y: 0 };
     }
 
-    private _sendPanEvent(e: Types.SinglePointGestureState, gestureState: GestureStatePointVelocity,
+    private _sendPanEvent(e: Types.TapGestureState, gestureState: GestureStatePointVelocity,
             gestureType: GestureType, initializeFromEvent: boolean, isComplete: boolean) {
         const state = this._pendingGestureState as Types.PanGestureState;
 

--- a/src/common/GestureView.tsx
+++ b/src/common/GestureView.tsx
@@ -123,11 +123,13 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
 
     // Returns true if we care about trapping/tracking the event
     protected _onTouchChange(event: TouchEventBasic, gestureState: GestureStatePointVelocity): boolean {
-        this._lastGestureStartEvent = event;
-        let initializeFromEvent = false;
+        if (!this._lastGestureStartEvent) {
+            this._lastGestureStartEvent = event;
+        }
 
         // If this is the first movement we've seen, try to match it against
         // the various move gestures that we're looking for.
+        let initializeFromEvent = false;
         if (this._pendingGestureType === GestureType.None) {
             this._pendingGestureType = this._detectMoveGesture(event, gestureState);
             initializeFromEvent = true;
@@ -136,12 +138,14 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         if (this._pendingGestureType === GestureType.MultiTouch) {
             this._setPendingGestureState(this._sendMultiTouchEvents(event, gestureState,
                 initializeFromEvent, false));
+            return true;
         } else if (this._pendingGestureType === GestureType.Pan ||
                 this._pendingGestureType === GestureType.PanVertical ||
                 this._pendingGestureType === GestureType.PanHorizontal) {
             const spEvent = this._touchEventToSinglePointGestureState(event);
             this._setPendingGestureState(this._sendPanEvent(spEvent, gestureState,
                 this._pendingGestureType, initializeFromEvent, false));
+            return true;
         }
 
         return false;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -698,7 +698,7 @@ export interface GestureState {
     timeStamp: number;
 }
 
-export interface SinglePointGestureState extends GestureState {
+export interface TapGestureState extends GestureState {
     clientX: number;
     clientY: number;
     pageX: number;
@@ -729,11 +729,11 @@ export interface MultiTouchGestureState extends GestureState {
     isComplete: boolean;
 }
 
-export interface ScrollWheelGestureState extends SinglePointGestureState {
+export interface ScrollWheelGestureState extends TapGestureState {
     scrollAmount: number;
 }
 
-export interface PanGestureState extends SinglePointGestureState {
+export interface PanGestureState extends TapGestureState {
     initialClientX: number;
     initialClientY: number;
     initialPageX: number;
@@ -743,8 +743,6 @@ export interface PanGestureState extends SinglePointGestureState {
 
     isComplete: boolean;
 }
-
-export type TapGestureState = SinglePointGestureState;
 
 export enum GestureMouseCursor {
     Default,

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -698,6 +698,13 @@ export interface GestureState {
     timeStamp: number;
 }
 
+export interface SinglePointGestureState extends GestureState {
+    clientX: number;
+    clientY: number;
+    pageX: number;
+    pageY: number;
+}
+
 export interface MultiTouchGestureState extends GestureState {
     initialCenterClientX: number;
     initialCenterClientY: number;
@@ -722,35 +729,22 @@ export interface MultiTouchGestureState extends GestureState {
     isComplete: boolean;
 }
 
-export interface ScrollWheelGestureState extends GestureState {
-    clientX: number;
-    clientY: number;
-    pageX: number;
-    pageY: number;
+export interface ScrollWheelGestureState extends SinglePointGestureState {
     scrollAmount: number;
 }
 
-export interface PanGestureState extends GestureState {
+export interface PanGestureState extends SinglePointGestureState {
     initialClientX: number;
     initialClientY: number;
     initialPageX: number;
     initialPageY: number;
-    clientX: number;
-    clientY: number;
-    pageX: number;
-    pageY: number;
     velocityX: number;
     velocityY: number;
 
     isComplete: boolean;
 }
 
-export interface TapGestureState extends GestureState {
-    clientX: number;
-    clientY: number;
-    pageX: number;
-    pageY: number;
-}
+export type TapGestureState = SinglePointGestureState;
 
 export enum GestureMouseCursor {
     Default,

--- a/src/common/utils/EventHelpers.ts
+++ b/src/common/utils/EventHelpers.ts
@@ -1,0 +1,18 @@
+/**
+ * EventHelpers.ts
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ */
+
+export function toMouseButton(nativeEvent: any): number {
+    if (nativeEvent.button !== undefined) {
+        return nativeEvent.button;
+    } else if (nativeEvent.isRightButton || nativeEvent.IsRightButton) {
+        return 2;
+    } else if (nativeEvent.isMiddleButton || nativeEvent.IsMiddleButton) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/ios/GestureView.tsx
+++ b/src/ios/GestureView.tsx
@@ -22,7 +22,7 @@ export class GestureView extends BaseGestureView {
         return _preferredPanRatio;
     }
 
-    protected _getEventTimestamp(e: Types.TouchEvent): number {
+    protected _getEventTimestamp(e: Types.TouchEvent | Types.MouseEvent): number {
         let timestamp = e.timeStamp;
 
         // Work around a bug in some versions of RN where "timestamp" is

--- a/src/macos/GestureView.tsx
+++ b/src/macos/GestureView.tsx
@@ -22,7 +22,7 @@ export class GestureView extends BaseGestureView {
         return _preferredPanRatio;
     }
 
-    protected _getEventTimestamp(e: Types.TouchEvent): number {
+    protected _getEventTimestamp(e: Types.TouchEvent | Types.MouseEvent): number {
         let timestamp = e.timeStamp;
 
         // Work around a bug in some versions of RN where "timestamp" is

--- a/src/native-common/GestureView.tsx
+++ b/src/native-common/GestureView.tsx
@@ -13,54 +13,21 @@ import * as React from 'react';
 import * as RN from 'react-native';
 
 import App from '../native-common/App';
-import assert from '../common/assert';
+import GestureViewCommon from '../common/GestureView';
 import { Types } from '../common/Interfaces';
-import Timers from '../common/utils/Timers';
 
 import { MacComponentAccessibilityProps } from './Accessibility';
 import AccessibilityUtil from './AccessibilityUtil';
 import EventHelpers from './utils/EventHelpers';
-import { isUndefined } from './utils/lodashMini';
 import Platform from './Platform';
 import UserInterface from './UserInterface';
 import ViewBase from './ViewBase';
 
-enum GestureType {
-    None,
-    MultiTouch,
-    Pan,
-    PanVertical,
-    PanHorizontal
-}
-
-// These threshold values were chosen empirically.
-const _pinchZoomPixelThreshold = 3;
-const _panPixelThreshold = 10;
-const _tapDurationThreshold = 500;
-const _longPressDurationThreshold = 750;
-const _tapPixelThreshold = 4;
-const _doubleTapDurationThreshold = 250;
-const _doubleTapPixelThreshold = 20;
-
 const _defaultImportantForAccessibility = Types.ImportantForAccessibility.Yes;
 const _isNativeMacOs = Platform.getType() === 'macos';
 
-export abstract class GestureView extends React.Component<Types.GestureViewProps, Types.Stateless> {
+export abstract class GestureView extends GestureViewCommon {
     private _panResponder: RN.PanResponderInstance;
-    private _doubleTapTimer: number | undefined;
-
-    private _pendingLongPressEvent: Types.TouchEvent | undefined;
-    private _longPressTimer: number | undefined;
-
-    // State for tracking move gestures (pinch/zoom or pan)
-    private _pendingGestureType: GestureType = GestureType.None;
-    private _pendingGestureState: Types.MultiTouchGestureState | Types.PanGestureState | Types.TapGestureState | undefined;
-
-    // State for tracking double taps
-    private _lastTapEvent: Types.TouchEvent | undefined;
-
-    // State for tracking single taps
-    private _lastGestureStartEvent: Types.TouchEvent | undefined;
 
     private _view: RN.View | undefined;
 
@@ -72,72 +39,29 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
             onStartShouldSetPanResponder: (e: RN.GestureResponderEvent, gestureState: RN.PanResponderGestureState) => {
                 const event = (e as any).nativeEvent as Types.TouchEvent;
                 UserInterface.evaluateTouchLatency(e as any);
-
-                this._lastGestureStartEvent = event;
-                // If we're trying to detect a tap, set this as the responder immediately.
-                if (this.props.onTap || this.props.onDoubleTap || this.props.onLongPress || this.props.onContextMenu) {
-                    if (this.props.onLongPress) {
-                        this._startLongPressTimer(event);
-                    }
-
-                    return true;
-                }
-                return false;
+                return this._onTouchSeriesStart(event);
             },
 
             onMoveShouldSetPanResponder: (e: RN.GestureResponderEvent, gestureState: RN.PanResponderGestureState) => {
                 const event = (e as any).nativeEvent as Types.TouchEvent;
                 UserInterface.evaluateTouchLatency(e as any);
-
-                this._lastGestureStartEvent = event;
-                this._pendingGestureType = this._detectMoveGesture(event, gestureState);
-
-                if (this._pendingGestureType === GestureType.MultiTouch) {
-                    // Handle multi-touch gestures.
-                    this._setPendingGestureState(this._sendMultiTouchEvents(event, gestureState, true, false));
-                    return true;
-                } else if (this._pendingGestureType === GestureType.Pan ||
-                    this._pendingGestureType === GestureType.PanVertical ||
-                    this._pendingGestureType === GestureType.PanHorizontal) {
-                    // Handle a pan gesture.
-                    this._setPendingGestureState(this._sendPanEvent(event, gestureState,
-                        this._pendingGestureType, true, false));
-                    return true;
-                }
-
-                return false;
+                return this._onTouchChange(event, gestureState);
             },
 
             onPanResponderRelease: (e: RN.GestureResponderEvent, gestureState: RN.PanResponderGestureState) => {
-                this._onPanResponderEnd(e, gestureState);
+                const event = (e as any).nativeEvent as Types.TouchEvent;
+                this._onTouchSeriesFinished(event, gestureState);
             },
 
             onPanResponderTerminate: (e: RN.GestureResponderEvent, gestureState: RN.PanResponderGestureState) => {
-                this._onPanResponderEnd(e, gestureState);
+                const event = (e as any).nativeEvent as Types.TouchEvent;
+                this._onTouchSeriesFinished(event, gestureState);
             },
 
             onPanResponderMove: (e: RN.GestureResponderEvent, gestureState: RN.PanResponderGestureState) => {
                 const event = (e as any).nativeEvent as Types.TouchEvent;
                 UserInterface.evaluateTouchLatency(e as any);
-
-                let initializeFromEvent = false;
-
-                // If this is the first movement we've seen, try to match it against
-                // the various move gestures that we're looking for.
-                if (this._pendingGestureType === GestureType.None) {
-                    this._pendingGestureType = this._detectMoveGesture(event, gestureState);
-                    initializeFromEvent = true;
-                }
-
-                if (this._pendingGestureType === GestureType.MultiTouch) {
-                    this._setPendingGestureState(this._sendMultiTouchEvents(event, gestureState,
-                        initializeFromEvent, false));
-                } else if (this._pendingGestureType === GestureType.Pan ||
-                        this._pendingGestureType === GestureType.PanVertical ||
-                        this._pendingGestureType === GestureType.PanHorizontal) {
-                    this._setPendingGestureState(this._sendPanEvent(event, gestureState,
-                        this._pendingGestureType, initializeFromEvent, false));
-                }
+                this._onTouchChange(event, gestureState);
             },
 
             // Something else wants to become responder. Should this view release the responder?
@@ -145,471 +69,6 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
             onPanResponderTerminationRequest: (e: RN.GestureResponderEvent, gestureState:
                 RN.PanResponderGestureState) => !!this.props.releaseOnRequest
         });
-    }
-
-    componentWillUnmount() {
-        // Dispose of timer before the component goes away.
-        this._cancelDoubleTapTimer();
-    }
-
-    // Get preferred pan ratio for platform.
-    protected abstract _getPreferredPanRatio(): number;
-
-    // Returns the timestamp for the touch event in milliseconds.
-    protected abstract _getEventTimestamp(e: Types.TouchEvent): number;
-
-    private _onPanResponderEnd(e: RN.GestureResponderEvent, gestureState: RN.PanResponderGestureState) {
-        const event = (e as any).nativeEvent as Types.TouchEvent;
-
-        // Can't possibly be a long press if the touch ended.
-        this._cancelLongPressTimer();
-
-        // Close out any of the pending move gestures.
-        if (this._pendingGestureType === GestureType.MultiTouch) {
-            this._sendMultiTouchEvents(event, gestureState, false, true);
-            this._pendingGestureState = undefined;
-            this._pendingGestureType = GestureType.None;
-        } else if (this._pendingGestureType === GestureType.Pan ||
-            this._pendingGestureType === GestureType.PanVertical ||
-            this._pendingGestureType === GestureType.PanHorizontal) {
-            this._sendPanEvent(event, gestureState, this._pendingGestureType, false, true);
-            this._pendingGestureState = undefined;
-            this._pendingGestureType = GestureType.None;
-        } else if (this._isTap(event)) {
-            if (!this.props.onDoubleTap) {
-                // If there is no double-tap handler, we can invoke the tap handler immediately.
-                this._sendTapEvent(event);
-            } else if (this._isDoubleTap(event)) {
-                // This is a double-tap, so swallow the previous single tap.
-                this._cancelDoubleTapTimer();
-                this._sendDoubleTapEvent(event);
-                this._lastTapEvent = undefined;
-            } else {
-                // This wasn't a double-tap. Report any previous single tap and start the double-tap
-                // timer so we can determine whether the current tap is a single or double.
-                this._reportDelayedTap();
-                this._startDoubleTapTimer(event);
-            }
-        } else {
-            this._reportDelayedTap();
-            this._cancelDoubleTapTimer();
-        }
-    }
-
-    private _setPendingGestureState(gestureState: Types.MultiTouchGestureState | Types.PanGestureState | Types.TapGestureState) {
-        this._reportDelayedTap();
-        this._cancelDoubleTapTimer();
-        this._cancelLongPressTimer();
-        this._pendingGestureState = gestureState;
-    }
-
-    private _detectMoveGesture(e: Types.TouchEvent, gestureState: RN.PanResponderGestureState): GestureType {
-        if (this._shouldRespondToPinchZoom(e, gestureState) || this._shouldRespondToRotate(e, gestureState)) {
-            return GestureType.MultiTouch;
-        } else if (this._shouldRespondToPan(gestureState)) {
-            return GestureType.Pan;
-        } else if (this._shouldRespondToPanVertical(gestureState)) {
-            return GestureType.PanVertical;
-        } else if (this._shouldRespondToPanHorizontal(gestureState)) {
-            return GestureType.PanHorizontal;
-        }
-
-        return GestureType.None;
-    }
-
-    // Determines whether a touch event constitutes a tap. The "finger up"
-    // event must be within a certain distance and within a certain time
-    // from where the "finger down" event occurred.
-    private _isTap(e: Types.TouchEvent): boolean {
-        if (!this._lastGestureStartEvent) {
-            return false;
-        }
-
-        const initialTimeStamp = this._getEventTimestamp(this._lastGestureStartEvent);
-        const initialPageX = this._lastGestureStartEvent.pageX!;
-        const initialPageY = this._lastGestureStartEvent.pageY!;
-
-        const timeStamp = this._getEventTimestamp(e);
-
-        return (timeStamp - initialTimeStamp <= _tapDurationThreshold &&
-            this._calcDistance(initialPageX - e.pageX!, initialPageY - e.pageY!) <= _tapPixelThreshold);
-    }
-
-    // This method assumes that the caller has already determined that two
-    // taps have been detected in a row with no intervening gestures. It
-    // is responsible for determining if they occurred within close proximity
-    // and within a certain threshold of time.
-    private _isDoubleTap(e: Types.TouchEvent) {
-        const timeStamp = this._getEventTimestamp(e);
-
-        if (!this._lastTapEvent) {
-            return false;
-        }
-
-        return (timeStamp - this._getEventTimestamp(this._lastTapEvent) <= _doubleTapDurationThreshold &&
-            this._calcDistance((this._lastTapEvent.pageX || 0) - (e.pageX || 0), (this._lastTapEvent.pageY || 0) - (e.pageY || 0)) <=
-                _doubleTapPixelThreshold);
-    }
-
-    // Starts a timer that reports a previous tap if it's not canceled by a subsequent gesture.
-    private _startDoubleTapTimer(e: Types.TouchEvent) {
-        this._lastTapEvent = e;
-
-        this._doubleTapTimer = Timers.setTimeout(() => {
-            this._reportDelayedTap();
-            this._doubleTapTimer = undefined;
-        }, _doubleTapDurationThreshold);
-    }
-
-    // Cancels any pending double-tap timer.
-    private _cancelDoubleTapTimer() {
-        if (this._doubleTapTimer) {
-            Timers.clearTimeout(this._doubleTapTimer);
-            this._doubleTapTimer = undefined;
-        }
-    }
-
-    private _startLongPressTimer(event: Types.TouchEvent) {
-        this._pendingLongPressEvent = event;
-
-        this._longPressTimer = Timers.setTimeout(() => {
-            this._reportLongPress();
-            this._longPressTimer = undefined;
-        }, _longPressDurationThreshold);
-    }
-
-    private _cancelLongPressTimer() {
-        if (this._longPressTimer) {
-            Timers.clearTimeout(this._longPressTimer);
-            this._longPressTimer = undefined;
-        }
-        this._pendingLongPressEvent = undefined;
-    }
-
-    // If there was a previous tap recorded but we haven't yet reported it because we were
-    // waiting for a potential second tap, report it now.
-    private _reportDelayedTap() {
-        if (this._lastTapEvent && this.props.onTap) {
-            this._sendTapEvent(this._lastTapEvent);
-            this._lastTapEvent = undefined;
-        }
-    }
-
-    private _reportLongPress() {
-        if (this.props.onLongPress) {
-            const tapEvent: Types.TapGestureState = {
-                isTouch: !EventHelpers.isActuallyMouseEvent(this._pendingLongPressEvent!),
-                pageX: this._pendingLongPressEvent!.pageX!,
-                pageY: this._pendingLongPressEvent!.pageY!,
-                clientX: this._pendingLongPressEvent!.locationX!,
-                clientY: this._pendingLongPressEvent!.locationY!,
-                timeStamp: this._pendingLongPressEvent!.timeStamp
-            };
-
-            this.props.onLongPress(tapEvent);
-        }
-
-        this._pendingLongPressEvent = undefined;
-    }
-
-    private _shouldRespondToPinchZoom(e: Types.TouchEvent, gestureState: RN.PanResponderGestureState) {
-        if (!this.props.onPinchZoom) {
-            return false;
-        }
-
-        // Do we see two touches?
-        if (!e.touches || e.touches.length !== 2) {
-            return false;
-        }
-
-        // Has the user started to pinch or zoom?
-        if (this._calcDistance(e.touches[0].pageX - e.touches[1].pageX,
-                e.touches[0].pageY - e.touches[1].pageY) >=
-                    _pinchZoomPixelThreshold) {
-            return true;
-        }
-
-        return false;
-    }
-
-    private _shouldRespondToRotate(e: Types.TouchEvent, gestureState: RN.PanResponderGestureState) {
-        if (!this.props.onRotate) {
-            return false;
-        }
-
-        // Do we see two touches?
-        if (!e.touches || e.touches.length !== 2) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private _shouldRespondToPan(gestureState: RN.PanResponderGestureState) {
-        if (!this.props.onPan) {
-            return false;
-        }
-
-        // Has the user started to pan?
-        const panThreshold = (!isUndefined(this.props.panPixelThreshold) && this.props.panPixelThreshold > 0) ?
-            this.props.panPixelThreshold : _panPixelThreshold;
-        return (this._calcDistance(gestureState.dx, gestureState.dy) >= panThreshold);
-    }
-
-    private _shouldRespondToPanVertical(gestureState: RN.PanResponderGestureState) {
-        if (!this.props.onPanVertical) {
-            return false;
-        }
-
-        // Has the user started to pan?
-        const panThreshold = (!isUndefined(this.props.panPixelThreshold) && this.props.panPixelThreshold > 0) ?
-            this.props.panPixelThreshold : _panPixelThreshold;
-        const isPan = Math.abs(gestureState.dy) >= panThreshold;
-
-        if (isPan && this.props.preferredPan === Types.PreferredPanGesture.Horizontal) {
-            return Math.abs(gestureState.dy) > Math.abs(gestureState.dx * this._getPreferredPanRatio());
-        }
-        return isPan;
-    }
-
-    private _shouldRespondToPanHorizontal(gestureState: RN.PanResponderGestureState) {
-        if (!this.props.onPanHorizontal) {
-            return false;
-        }
-
-        // Has the user started to pan?
-        const panThreshold = (!isUndefined(this.props.panPixelThreshold) && this.props.panPixelThreshold > 0) ?
-            this.props.panPixelThreshold : _panPixelThreshold;
-        const isPan = Math.abs(gestureState.dx) >= panThreshold;
-
-        if (isPan && this.props.preferredPan === Types.PreferredPanGesture.Vertical) {
-            return Math.abs(gestureState.dx) > Math.abs(gestureState.dy * this._getPreferredPanRatio());
-        }
-        return isPan;
-    }
-
-    private _calcDistance(dx: number, dy: number) {
-        return Math.sqrt(dx * dx + dy * dy);
-    }
-
-    private _calcAngle(touches: Types.TouchList): number {
-        const a = touches[0];
-        const b = touches[1];
-
-        let degrees = this._radiansToDegrees(Math.atan2(b.pageY - a.pageY, b.pageX - a.pageX));
-        if (degrees < 0) {
-            degrees += 360;
-        }
-
-        return degrees;
-    }
-
-    private _radiansToDegrees(rad: number): number {
-        return rad * 180 / Math.PI;
-    }
-
-    private _sendMultiTouchEvents(e: Types.TouchEvent, gestureState: RN.PanResponderGestureState,
-            initializeFromEvent: boolean, isComplete: boolean) {
-        const p = this._pendingGestureState as Types.MultiTouchGestureState;
-        let multiTouchEvent: Types.MultiTouchGestureState;
-
-        // If the user lifted up one or both fingers, the multitouch gesture
-        // is halted. Just return the existing gesture state.
-        if (!e.touches || e.touches.length !== 2) {
-            multiTouchEvent = p;
-            p.isComplete = isComplete;
-        } else {
-            const centerPageX = (e.touches[0].pageX + e.touches[1].pageX) / 2;
-            const centerPageY = (e.touches[0].pageY + e.touches[1].pageY) / 2;
-            const centerClientX = (e.touches[0].locationX + e.touches[1].locationX) / 2;
-            const centerClientY = (e.touches[0].locationY + e.touches[1].locationY) / 2;
-            const width = Math.abs(e.touches[0].pageX - e.touches[1].pageX);
-            const height = Math.abs(e.touches[0].pageY - e.touches[1].pageY);
-            const distance = this._calcDistance(width, height);
-            const angle = this._calcAngle(e.touches);
-
-            const initialCenterPageX = initializeFromEvent ? centerPageX : p.initialCenterPageX;
-            const initialCenterPageY = initializeFromEvent ? centerPageY : p.initialCenterPageY;
-            const initialCenterClientX = initializeFromEvent ? centerClientX : p.initialCenterClientX;
-            const initialCenterClientY = initializeFromEvent ? centerClientY : p.initialCenterClientY;
-            const initialWidth = initializeFromEvent ? width : p.initialWidth;
-            const initialHeight = initializeFromEvent ? height : p.initialHeight;
-            const initialDistance = initializeFromEvent ? distance : p.initialDistance;
-            const initialAngle = initializeFromEvent ? angle : p.initialAngle;
-
-            const velocityX = initializeFromEvent ? 0 : gestureState.vx;
-            const velocityY = initializeFromEvent ? 0 : gestureState.vy;
-
-            multiTouchEvent = {
-                initialCenterPageX: initialCenterPageX,
-                initialCenterPageY: initialCenterPageY,
-                initialCenterClientX: initialCenterClientX,
-                initialCenterClientY: initialCenterClientY,
-                initialWidth: initialWidth,
-                initialHeight: initialHeight,
-                initialDistance: initialDistance,
-                initialAngle: initialAngle,
-
-                centerPageX: centerPageX,
-                centerPageY: centerPageY,
-                centerClientX: centerClientX,
-                centerClientY: centerClientY,
-                velocityX: velocityX,
-                velocityY: velocityY,
-                width: width,
-                height: height,
-                distance: distance,
-                angle: angle,
-
-                isComplete: isComplete,
-                timeStamp: e.timeStamp,
-                isTouch: !EventHelpers.isActuallyMouseEvent(e)
-            };
-        }
-
-        if (this.props.onPinchZoom) {
-            this.props.onPinchZoom(multiTouchEvent);
-        }
-
-        if (this.props.onRotate) {
-            this.props.onRotate(multiTouchEvent);
-        }
-
-        return multiTouchEvent;
-    }
-
-    private _sendPanEvent(e: Types.TouchEvent, gestureState: RN.PanResponderGestureState,
-            gestureType: GestureType, initializeFromEvent: boolean, isComplete: boolean) {
-        const state = this._pendingGestureState as Types.PanGestureState;
-
-        let pageX = e.pageX!;
-        let pageY = e.pageY!;
-        let clientX = e.locationX!;
-        let clientY = e.locationY!;
-
-        // Grab the first touch. If the user adds additional touch events,
-        // we will ignore them. If we use e.pageX/Y, we will be using the average
-        // of the touches, so we'll see a discontinuity.
-        if (e.touches && e.touches.length > 0) {
-            pageX = e.touches[0].pageX;
-            pageY = e.touches[0].pageY;
-            clientX = e.touches[0].locationX;
-            clientY = e.touches[0].locationY;
-        }
-
-        assert(this._lastGestureStartEvent, 'Gesture start event must not be null.');
-
-        const initialPageX = this._lastGestureStartEvent
-            ? this._lastGestureStartEvent.pageX!
-            : initializeFromEvent ? pageX : state.initialPageX;
-        const initialPageY = this._lastGestureStartEvent
-            ? this._lastGestureStartEvent.pageY!
-            : initializeFromEvent ? pageY : state.initialPageY;
-        const initialClientX = this._lastGestureStartEvent
-            ? this._lastGestureStartEvent.locationX!
-            : initializeFromEvent ? clientX : state.initialClientX;
-        const initialClientY = this._lastGestureStartEvent
-            ? this._lastGestureStartEvent.locationY!
-            : initializeFromEvent ? clientY : state.initialClientY;
-
-        const velocityX = initializeFromEvent ? 0 : gestureState.vx;
-        const velocityY = initializeFromEvent ? 0 : gestureState.vy;
-
-        const panEvent: Types.PanGestureState = {
-            initialPageX: initialPageX,
-            initialPageY: initialPageY,
-            initialClientX: initialClientX,
-            initialClientY: initialClientY,
-
-            pageX: pageX,
-            pageY: pageY,
-            clientX: clientX,
-            clientY: clientY,
-            velocityX: velocityX,
-            velocityY: velocityY,
-
-            isComplete: isComplete,
-            timeStamp: e.timeStamp,
-            isTouch: !EventHelpers.isActuallyMouseEvent(this._lastGestureStartEvent)
-        };
-
-        switch (gestureType) {
-            case GestureType.Pan:
-                if (this.props.onPan) {
-                    this.props.onPan(panEvent);
-                }
-                break;
-            case GestureType.PanVertical:
-                if (this.props.onPanVertical) {
-                    this.props.onPanVertical(panEvent);
-                }
-                break;
-            case GestureType.PanHorizontal:
-                if (this.props.onPanHorizontal) {
-                    this.props.onPanHorizontal(panEvent);
-                }
-                break;
-
-            default:
-                // do nothing;
-        }
-
-        return panEvent;
-    }
-
-    private _sendTapEvent = (e: Types.TouchEvent) => {
-        const button = EventHelpers.toMouseButton(e);
-        if (button === 2) {
-            // Always handle secondary button, even if context menu is not set - it shouldn't trigger onTap.
-            if (this.props.onContextMenu) {
-                const tapEvent: Types.TapGestureState = {
-                    pageX: e.pageX!,
-                    pageY: e.pageY!,
-                    clientX: e.locationX!,
-                    clientY: e.locationY!,
-                    timeStamp: e.timeStamp,
-                    isTouch: !EventHelpers.isActuallyMouseEvent(e)
-                };
-
-                this.props.onContextMenu(tapEvent);
-            }
-        } else if (this.props.onTap) {
-            const tapEvent: Types.TapGestureState = {
-                pageX: e.pageX!,
-                pageY: e.pageY!,
-                clientX: e.locationX!,
-                clientY: e.locationY!,
-                timeStamp: e.timeStamp,
-                isTouch: !EventHelpers.isActuallyMouseEvent(e)
-            };
-
-            this.props.onTap(tapEvent);
-        }
-    }
-
-    private _sendDoubleTapEvent(e: Types.TouchEvent) {
-        // If user did a double click with different mouse buttons, eg. left (50ms) right
-        // both clicks need to be registered as separate events.
-        const lastButton = EventHelpers.toMouseButton(this._lastTapEvent!);
-        const button = EventHelpers.toMouseButton(e);
-        if (lastButton !== button || button === 2) {
-            this._sendTapEvent(this._lastTapEvent!);
-            this._sendTapEvent(e);
-            return;
-        }
-
-        if (this.props.onDoubleTap) {
-            const tapEvent: Types.TapGestureState = {
-                pageX: e.pageX!,
-                pageY: e.pageY!,
-                clientX: e.locationX!,
-                clientY: e.locationY!,
-                timeStamp: e.timeStamp,
-                isTouch: !EventHelpers.isActuallyMouseEvent(e)
-            };
-
-            this.props.onDoubleTap(tapEvent);
-        }
     }
 
     render() {
@@ -625,7 +84,7 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
         };
 
         if (_isNativeMacOs && App.supportsExperimentalKeyboardNavigation && this.props.onTap) {
-            extendedProps.onClick = this._sendTapEvent;
+            extendedProps.onClick = this._macos_sendTapEvent;
             if (this.props.tabIndex === undefined || this.props.tabIndex >= 0) {
                 extendedProps.acceptsKeyboardFocus = true;
                 extendedProps.enableFocusRing = true;
@@ -647,6 +106,11 @@ export abstract class GestureView extends React.Component<Types.GestureViewProps
                 { this.props.children }
             </RN.View>
         );
+    }
+
+    protected _macos_sendTapEvent = (e: Types.MouseEvent) => {
+        const gsState = this._mouseEventToSinglePointGestureState(e);
+        this._sendTapEvent(gsState);
     }
 
     private _onRef = (ref: RN.View | null) => {

--- a/src/native-common/GestureView.tsx
+++ b/src/native-common/GestureView.tsx
@@ -109,7 +109,7 @@ export abstract class GestureView extends GestureViewCommon {
     }
 
     protected _macos_sendTapEvent = (e: Types.MouseEvent) => {
-        const gsState = this._mouseEventToSinglePointGestureState(e);
+        const gsState = this._mouseEventToTapGestureState(e);
         this._sendTapEvent(gsState);
     }
 

--- a/src/native-common/utils/EventHelpers.ts
+++ b/src/native-common/utils/EventHelpers.ts
@@ -6,6 +6,7 @@
  */
 import { Platform } from 'react-native';
 
+import * as EventHelpersCommon from '../../common/utils/EventHelpers';
 import { Types } from '../../common/Interfaces';
 
 import { clone } from './lodashMini';
@@ -297,7 +298,7 @@ export class EventHelpers {
             mouseEvent.clientY = mouseEvent.pageY = nativeEvent.pageY;
         }
 
-        mouseEvent.button = this.toMouseButton(e.nativeEvent);
+        mouseEvent.button = EventHelpersCommon.toMouseButton(e.nativeEvent);
 
         if (nativeEvent.shiftKey) {
             mouseEvent.shiftKey = nativeEvent.shiftKey;
@@ -333,37 +334,8 @@ export class EventHelpers {
         return dndEvent;
     }
 
-    toMouseButton(nativeEvent: any): number {
-        if (nativeEvent.button !== undefined) {
-            return nativeEvent.button;
-        } else if (nativeEvent.isRightButton || nativeEvent.IsRightButton) {
-            return 2;
-        } else if (nativeEvent.isMiddleButton || nativeEvent.IsMiddleButton) {
-            return 1;
-        }
-
-        return 0;
-    }
-
-    isActuallyMouseEvent(e: Types.TouchEvent | undefined): boolean {
-        if (!e) {
-            return false;
-        }
-
-        const nativeEvent = e as any;
-        if (nativeEvent.button !== undefined) {
-            return true;
-        } else if (nativeEvent.isRightButton || nativeEvent.IsRightButton) {
-            return true;
-        } else if (nativeEvent.isMiddleButton || nativeEvent.IsMiddleButton) {
-            return true;
-        }
-
-        return false;
-    }
-
     isRightMouseButton(e: Types.SyntheticEvent): boolean {
-        return (this.toMouseButton(e.nativeEvent) === 2);
+        return (EventHelpersCommon.toMouseButton(e.nativeEvent) === 2);
     }
 
     // Keyboard events do not inherently hold a position that can be used to show flyouts on keyboard input.

--- a/src/windows/GestureView.tsx
+++ b/src/windows/GestureView.tsx
@@ -22,7 +22,7 @@ export class GestureView extends BaseGestureView {
         return _preferredPanRatio;
     }
 
-    protected _getEventTimestamp(e: Types.TouchEvent): number {
+    protected _getEventTimestamp(e: Types.TouchEvent | Types.MouseEvent): number {
         let timestamp = e.timeStamp;
 
         // Work around a bug in some versions of RN where "timestamp" is


### PR DESCRIPTION
…to a straight common/GestureView abstract base component, and changed much of the logic away from using raw events as inputs and into the processed RX GestureState types.  Pulled a bunch of the duplicate logic out of web/GestureView and used the new base class.  Added touchstart/move/end support to web/GestureView to now reuse the touch code out of the common GestureView to get web touch support in GestureView!