### PR TITLE
Update TodoList sample android sqlite-storage path

### DIFF
--- a/samples/TodoList/android/settings.gradle
+++ b/samples/TodoList/android/settings.gradle
@@ -3,4 +3,4 @@ rootProject.name = 'RXPTodoList'
 include ':app'
 
 include ':react-native-sqlite-storage'
-project(':react-native-sqlite-storage').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-sqlite-storage/src/android')
+project(':react-native-sqlite-storage').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-sqlite-storage/platforms/android')


### PR DESCRIPTION
Android won't compile without this, but with an update to match
current module documentation it works:
https://github.com/andpor/react-native-sqlite-storage/#step-1---update-gradle-settings-located-under-gradle-settings-in-project-panel