### PR TITLE
Text selectable

### DIFF
--- a/docs/docs/components/text.md
+++ b/docs/docs/components/text.md
@@ -65,6 +65,7 @@ onPress?: (e: SyntheticEvent) => void = undefined;
 onContextMenu?: (e: SyntheticEvent) => void = undefined;
 
 // Is the text selectable (affects mouse pointer and copy command)
+// iOS doesn't support partial selections.
 selectable: boolean = false;
 
 // See below for supported styles

--- a/src/android/Text.tsx
+++ b/src/android/Text.tsx
@@ -42,6 +42,7 @@ export class Text extends CommonText {
                 allowFontScaling={ this.props.allowFontScaling }
                 ellipsizeMode={ this.props.ellipsizeMode }
                 onPress={ this.props.onPress }
+                selectable={ this.props.selectable }
                 textBreakStrategy={ this.props.textBreakStrategy }
                 testID={ this.props.testId }
             >


### PR DESCRIPTION
Added missing Text selection prop for Android.

On iOS, there is no highlighting and partial text selections are not possible (same as react-native implementation)

<img src="https://user-images.githubusercontent.com/16825700/90320163-b6704980-df3e-11ea-82ab-158748415aff.jpg"  width="200">